### PR TITLE
new faster FOV calculation

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -296,7 +296,7 @@ void BattlescapeGame::handleAI(BattleUnit *unit)
 
 	unit->setVisible(false);
 
-	_save->getTileEngine()->calculateFOV(unit->getPosition()); // might need this populate _visibleUnit for a newly-created alien
+	_save->getTileEngine()->calculateFOV(unit->getPosition(), true); // might need this populate _visibleUnit for a newly-created alien
         // it might also help chryssalids realize they've zombified someone and need to move on
 		// it should also hide units when they've killed the guy spotting them
         // it's also for good luck
@@ -1673,7 +1673,7 @@ void BattlescapeGame::dropItem(const Position &position, BattleItem *item, bool 
 	if (item->getGlow())
 	{
 		getTileEngine()->calculateTerrainLighting();
-		getTileEngine()->calculateFOV(position);
+		getTileEngine()->calculateFOV(position, true); //lighting only affects unit visibility, hence no need to recalculate tiles
 	}
 
 }

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -1673,7 +1673,7 @@ void BattlescapeGame::dropItem(const Position &position, BattleItem *item, bool 
 	if (item->getGlow())
 	{
 		getTileEngine()->calculateTerrainLighting();
-		getTileEngine()->calculateFOV(position, true); //lighting only affects unit visibility, hence no need to recalculate tiles
+		getTileEngine()->calculateFOV(position);
 	}
 
 }

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -44,7 +44,6 @@
 #include "../Engine/Options.h"
 #include "ProjectileFlyBState.h"
 #include "MeleeAttackBState.h"
-#include "../Engine/Logger.h"
 #include "../fmath.h"
 
 namespace OpenXcom
@@ -85,21 +84,6 @@ void TileEngine::calculateSunShading()
 	{
 		_save->getTile(i)->resetLight(layer);
 		calculateSunShading(_save->getTile(i));
-	}
-}
-
-/**
-* Calculates sun shading for all tiles in the column at the given X-Y-coordinates.
-* @param pos The position to calculate sun shading for. Z-coordinate is ignored.
-*/
-void TileEngine::calculateSunShading(const Position &pos)
-{
-	Position toUpdate = pos;
-	for (int z = _save->getMapSizeZ() - 1; z >= 0; z--)
-	{
-		toUpdate.z = z;
-		_save->getTile(toUpdate)->resetLight(0); //reset ambient lighting
-		calculateSunShading(_save->getTile(toUpdate));
 	}
 }
 
@@ -251,6 +235,7 @@ void TileEngine::addLight(const Position &center, int power, int layer)
 */
 bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= false*/)
 {
+	int count = 0;
 	size_t oldNumVisibleUnits = unit->getUnitsSpottedThisTurn().size();
 	bool useTurretDirection = false;
 	int direction;
@@ -262,7 +247,7 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 	{
 		direction = unit->getDirection();
 	}
-
+	
 	unit->clearVisibleUnits();
 	unit->clearVisibleTiles();
 
@@ -308,7 +293,7 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 			}
 		}
 	}
-
+	
 	//Clearing the fog is only needed for the player. It's recommended to skip this step if doing a global FOV calculation without terrain changes.
 	if (!updateVisibleUnitsOnly && unit->getFaction() == FACTION_PLAYER)
 	{
@@ -328,10 +313,10 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 				++posSelf.z;
 			}
 		}
-		//Test all tiles within view cone for visibility
+		//Test tiles within view cone for visibility
 		for (int x = 0; x <= getMaxViewDistance(); ++x)
 		{
-			if (direction & 1)
+			if (direction % 2)
 			{
 				y1 = 0;
 				y2 = getMaxViewDistance();
@@ -372,15 +357,22 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 									//Reveal all tiles along line of vision. Note: needed due to width of bresenham stroke
 									for (std::vector<Position>::iterator i = _trajectory.begin(); i != _trajectory.end(); ++i)
 									{
+										//TODO: consider pruning by checking whether anything has been changed for X tiles. Where X is dependent on bresenham period
 										Position posVisited = (*i);
 										_save->getTile(posVisited)->setVisible(+1);
 										_save->getTile(posVisited)->setDiscovered(true, 2);
 
 										// walls to the east or south of a visible tile, we see that too
 										Tile* t = _save->getTile(Position(posVisited.x + 1, posVisited.y, posVisited.z));
-										if (t) t->setDiscovered(true, 0);
+										if (t)
+										{
+											t->setDiscovered(true, 0);
+										}
 										t = _save->getTile(Position(posVisited.x, posVisited.y + 1, posVisited.z));
-										if (t) t->setDiscovered(true, 1);
+										if (t)
+										{
+											t->setDiscovered(true, 1);
+										}
 									}
 								}
 							}
@@ -390,7 +382,7 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 			}
 		}
 	}
-
+	
 	// we only react when there are at least the same amount of visible units as before AND the checksum is different
 	// this way we stop if there are the same amount of visible units, but a different unit is seen
 	// or we stop if there are more visible units seen
@@ -400,6 +392,7 @@ bool TileEngine::calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly /*= 
 	}
 	return false;
 }
+
 
 /**
  * Gets the origin voxel of a unit's eyesight (from just one eye or something? Why is it x+7??
@@ -828,11 +821,11 @@ bool TileEngine::canTargetTile(Position *originVoxel, Tile *tile, int part, Posi
 }
 
 /**
-* Calculates line of sight of a soldiers within range of the Position
-* (used when terrain has changed, which can reveal new parts of terrain or units).
-* @param position Position of the changed terrain.
-* @param updateVisibleUnitsOnly Update only unit visibility (true) or unit and tile visibility (false)
-*/
+ * Calculates line of sight of a soldiers within range of the Position
+ * (used when terrain has changed, which can reveal new parts of terrain or units).
+ * @param position Position of the changed terrain.
+ * @param updateVisibleUnitsOnly Update only unit visibility (true) or unit and tile visibility (false)
+ */
 void TileEngine::calculateFOV(const Position &position, bool updateVisibleUnitsOnly /* =false */)
 {
 	for (std::vector<BattleUnit*>::iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
@@ -1108,9 +1101,8 @@ bool TileEngine::tryReaction(BattleUnit *unit, BattleUnit *target, int attackTyp
  * @param tile targeted tile.
  * @param damage power of hit.
  * @param type damage type of hit.
- * @return whether a smoke (1) or fire (2) effect was produced
  */
-int TileEngine::hitTile(Tile* tile, int damage, const RuleDamageType* type)
+void TileEngine::hitTile(Tile* tile, int damage, const RuleDamageType* type)
 {
 	if (damage >= type->SmokeThreshold)
 	{
@@ -1122,10 +1114,11 @@ int TileEngine::hitTile(Tile* tile, int damage, const RuleDamageType* type)
 				tile->setSmoke(RNG::generate(7, 15)); // for SmokeThreshold == 0
 			else
 				tile->setSmoke(RNG::generate(7, 15) * (damage - type->SmokeThreshold) / type->SmokeThreshold);
-			return 1;
 		}
+		return;
 	}
-	else if (damage >= type->FireThreshold)
+
+	if (damage >= type->FireThreshold)
 	{
 		if (!tile->isVoid())
 		{
@@ -1136,11 +1129,10 @@ int TileEngine::hitTile(Tile* tile, int damage, const RuleDamageType* type)
 				else
 					tile->setFire(tile->getFuel() * (damage - type->FireThreshold) / type->FireThreshold + 1);
 				tile->setSmoke(std::max(1, std::min(15 - (tile->getFlammability() / 10), 12)));
-				return 2;
 			}
 		}
+		return;
 	}
-	return 0;
 }
 
 /**
@@ -1395,8 +1387,6 @@ bool TileEngine::hitUnit(BattleUnit *unit, BattleItem *clipOrWeapon, BattleUnit 
  */
 BattleUnit *TileEngine::hit(const Position &center, int power, const RuleDamageType *type, BattleUnit *unit, BattleItem *clipOrWeapon, bool rangeAtack)
 {
-	bool terrainChanged = false; //did the hit destroy a tile thereby changing line of sight?
-	int effectGenerated = 0; //did the hit produce smoke (1), fire/light (2) or disabled a unit (3) ?
 	Tile *tile = _save->getTile(center.toTile());
 	if (!tile || power <= 0)
 	{
@@ -1415,7 +1405,6 @@ BattleUnit *TileEngine::hit(const Position &center, int power, const RuleDamageT
 			{
 				if (hitUnit(unit, clipOrWeapon, (*i)->getUnit(), Position(0,0,0), damage, type, rangeAtack))
 				{
-					if ((*i)->getGlow()) effectGenerated = 2; //Any glowing corpses?
 					nothing = false;
 					break;
 				}
@@ -1424,12 +1413,7 @@ BattleUnit *TileEngine::hit(const Position &center, int power, const RuleDamageT
 		if (nothing)
 		{
 			const int tileDmg = damage * type->ToTile;
-			
-			//Do we need to update the visibility of units due to smoke/fire?
-			effectGenerated = hitTile(tile, damage, type);
-			//If a tile was destroyed we may have revealed new areas for one or more observers
-			if (tileDmg >= tile->getMapData(part)->getArmor()) terrainChanged = true;
-
+			hitTile(tile, damage, type);
 			if (part == V_OBJECT && _save->getMissionType() == "STR_BASE_DEFENSE")
 			{
 				if (tileDmg >= tile->getMapData(O_OBJECT)->getArmor() && tile->getMapData(V_OBJECT)->isBaseModule())
@@ -1466,40 +1450,13 @@ BattleUnit *TileEngine::hit(const Position &center, int power, const RuleDamageT
 			const Position target = bu->getPosition().toVexel() + Position(sz,sz, bu->getFloatHeight() - tile->getTerrainLevel());
 			const Position relative = (center - target) - Position(0,0,verticaloffset);
 
-			if (hitUnit(unit, clipOrWeapon, bu, relative, damage, type, rangeAtack) && (bu->getHealth() == 0 || bu->getStunlevel() >= bu->getHealth()))
-			{
-				//Unit hit and disabled
-				effectGenerated = 3; //a unit standing at some point behind this unit may have been revealed
-				if (bu->getFire())
-				{
-					//Note: overriding the 3 is not a problem
-					effectGenerated = 2;
-				}
-			}
+			hitUnit(unit, clipOrWeapon, bu, relative, damage, type, rangeAtack);
 		}
 	}
-
-	//Recalculate relevant item/unit locations and visibility depending on what happened during the hit
-	if (terrainChanged || effectGenerated)
-	{
-		applyGravity(tile);
-	}
-	if (effectGenerated == 2) //fire, or lighting otherwise changed
-	{
-		calculateTerrainLighting(); // fires could have been started
-	}
-	if (terrainChanged) //part of tile destroyed
-	{
-		if (part == V_FLOOR && _save->getTile(center.toTile() - Position(0, 0, 1))) {
-			calculateSunShading(center.toTile()); // roof destroyed, update sunlight in this tile column
-		}
-		calculateFOV(center.toTile(), false); //full calculation due to changed terrain
-	}
-	else if (effectGenerated)
-	{
-		//Unchanged terrain, but something happened which may have changed unit visibility
-		calculateFOV(center.toTile(), true);
-	}
+	applyGravity(tile);
+	calculateSunShading(); // roofs could have been destroyed
+	calculateTerrainLighting(); // fires could have been started
+	calculateFOV(center.toTile()); //TODO: only do a full FOV calc if a tile has been removed. Likewise partial is only needed for destroyed units and smoke changes
 	return bu;
 }
 
@@ -1668,7 +1625,7 @@ void TileEngine::explode(const Position &center, int power, const RuleDamageType
 
 	calculateSunShading(); // roofs could have been destroyed
 	calculateTerrainLighting(); // fires could have been started
-	calculateFOV(center / Position(16,16,24));
+	calculateFOV(center / Position(16,16,24));  //TODO: only do a full FOV calc if a tile has been removed. Likewise partial is only needed for destroyed units and smoke changes
 }
 
 /**

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -93,9 +93,9 @@ public:
 	/// Calculates sun shading of a single tile.
 	void calculateSunShading(Tile *tile);
 	/// Calculates the field of view from a units view point.
-	bool calculateFOV(BattleUnit *unit);
+	bool calculateFOV(BattleUnit *unit, bool updateVisibleUnitsOnly = false);
 	/// Calculates the field of view within range of a certain position.
-	void calculateFOV(const Position &position);
+	void calculateFOV(const Position &position, bool updateVisibleUnitsOnly = false);
 	/// Checks reaction fire.
 	bool checkReactionFire(BattleUnit *unit);
 	/// Recalculates lighting of the battlescape for terrain.

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -90,7 +90,6 @@ public:
 	~TileEngine();
 	/// Calculates sun shading of the whole map.
 	void calculateSunShading();
-	void calculateSunShading(const Position &pos);
 	/// Calculates sun shading of a single tile.
 	void calculateSunShading(Tile *tile);
 	/// Calculates the field of view from a units view point.
@@ -104,7 +103,7 @@ public:
 	/// Recalculates lighting of the battlescape for units.
 	void calculateUnitLighting();
 	/// Handles tile hit.
-	int hitTile(Tile *tile, int damage, const RuleDamageType* type);
+	void hitTile(Tile *tile, int damage, const RuleDamageType* type);
 	/// Handles experience training.
 	bool awardExperience(BattleUnit *unit, BattleItem *weapon, BattleUnit *target, bool rangeAtack);
 	/// Handles unit hit.

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -90,6 +90,7 @@ public:
 	~TileEngine();
 	/// Calculates sun shading of the whole map.
 	void calculateSunShading();
+	void calculateSunShading(const Position &pos);
 	/// Calculates sun shading of a single tile.
 	void calculateSunShading(Tile *tile);
 	/// Calculates the field of view from a units view point.
@@ -103,7 +104,7 @@ public:
 	/// Recalculates lighting of the battlescape for units.
 	void calculateUnitLighting();
 	/// Handles tile hit.
-	void hitTile(Tile *tile, int damage, const RuleDamageType* type);
+	int hitTile(Tile *tile, int damage, const RuleDamageType* type);
 	/// Handles experience training.
 	bool awardExperience(BattleUnit *unit, BattleItem *weapon, BattleUnit *target, bool rangeAtack);
 	/// Handles unit hit.

--- a/src/Battlescape/UnitWalkBState.cpp
+++ b/src/Battlescape/UnitWalkBState.cpp
@@ -197,7 +197,7 @@ void UnitWalkBState::think()
 			{
 				_unit->setVisible(false);
 			}
-			_terrain->calculateFOV(_unit->getPosition());
+			_terrain->calculateFOV(_unit->getPosition(), true);
 			unitSpotted = (!_action.ignoreSpottedEnemies && !_falling && !_action.desperate && _parent->getPanicHandled() && _numUnitsSpotted != _unit->getUnitsSpottedThisTurn().size());
 
 			if (_parent->checkForProximityGrenades(_unit))

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -2963,51 +2963,59 @@ void BattleUnit::deriveRank()
 }
 
 /**
- * this function checks if a tile is visible, using maths.
+ * this function checks if a tile is visible from either of the unit's tiles, using maths.
  * @param pos the position to check against
+ * @param useTurretDirection use turret facing (true) or body facing (false) for sector calculation
  * @return what the maths decide
  */
-bool BattleUnit::checkViewSector (Position pos) const
+bool BattleUnit::checkViewSector (Position pos, bool useTurretDirection /* = false */) const
 {
-	int deltaX = pos.x - _pos.x;
-	int deltaY = _pos.y - pos.y;
-
-	switch (_direction)
+	int unitSize = getArmor()->getSize();
+	//Check view cone from each of the unit's tiles
+	for (int x = 0; x < unitSize; ++x)
 	{
-		case 0:
-			if ( (deltaX + deltaY >= 0) && (deltaY - deltaX >= 0) )
-				return true;
-			break;
-		case 1:
-			if ( (deltaX >= 0) && (deltaY >= 0) )
-				return true;
-			break;
-		case 2:
-			if ( (deltaX + deltaY >= 0) && (deltaY - deltaX <= 0) )
-				return true;
-			break;
-		case 3:
-			if ( (deltaY <= 0) && (deltaX >= 0) )
-				return true;
-			break;
-		case 4:
-			if ( (deltaX + deltaY <= 0) && (deltaY - deltaX <= 0) )
-				return true;
-			break;
-		case 5:
-			if ( (deltaX <= 0) && (deltaY <= 0) )
-				return true;
-			break;
-		case 6:
-			if ( (deltaX + deltaY <= 0) && (deltaY - deltaX >= 0) )
-				return true;
-			break;
-		case 7:
-			if ( (deltaY >= 0) && (deltaX <= 0) )
-				return true;
-			break;
-		default:
-			return false;
+		for (int y = 0; y < unitSize; ++y)
+		{
+			int deltaX = pos.x + x - _pos.x;
+			int deltaY = _pos.y - pos.y - y;
+			switch (useTurretDirection ? _directionTurret : _direction)
+			{
+				case 0:
+					if ( (deltaX + deltaY >= 0) && (deltaY - deltaX >= 0) )
+						return true;
+					break;
+				case 1:
+					if ( (deltaX >= 0) && (deltaY >= 0) )
+						return true;
+					break;
+				case 2:
+					if ( (deltaX + deltaY >= 0) && (deltaY - deltaX <= 0) )
+						return true;
+					break;
+				case 3:
+					if ( (deltaY <= 0) && (deltaX >= 0) )
+						return true;
+					break;
+				case 4:
+					if ( (deltaX + deltaY <= 0) && (deltaY - deltaX <= 0) )
+						return true;
+					break;
+				case 5:
+					if ( (deltaX <= 0) && (deltaY <= 0) )
+						return true;
+					break;
+				case 6:
+					if ( (deltaX + deltaY <= 0) && (deltaY - deltaX >= 0) )
+						return true;
+					break;
+				case 7:
+					if ( (deltaY >= 0) && (deltaX <= 0) )
+						return true;
+					break;
+				default:
+					break;
+			}
+		}
 	}
 	return false;
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -460,7 +460,7 @@ public:
 	/// derive a rank integer based on rank string (for xcom soldiers ONLY)
 	void deriveRank();
 	/// this function checks if a tile is visible, using maths.
-	bool checkViewSector(Position pos) const;
+	bool checkViewSector(Position pos, bool useTurretDirection = false) const;
 	/// adjust this unit's stats according to difficulty.
 	void adjustStats(const int diff);
 	/// did this unit already take fire damage this turn? (used to avoid damaging large units multiple times.)


### PR DESCRIPTION
New significantly faster FOV calculation

Unit detection:

- Changes the current scan every tile in vision range for finding units to instead searching the unit list for potentially visible units.

Tile detection (fog removal):
- Added ability to skip this step of the calculation.
- Very useful when a unit moves as it is rather unnecessary for every observing unit to recalculate its tiles when all we care about is whether they can see new units.
