### PR TITLE
Faster FOV calculations.

### DIFF
--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -382,7 +382,7 @@ void BattlescapeGenerator::nextStage()
 			if (!(*j)->isOut())
 			{
 				(*j)->setTurnsSinceSpotted(255);
-				(*j)->getVisibleTiles()->clear();
+				(*j)->clearVisibleTiles();
 				if (!selectedFirstSoldier && (*j)->getGeoscapeSoldier())
 				{
 					_save->setSelectedUnit(*j);

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -302,7 +302,7 @@ bool TileEngine::calculateUnitsInFOV(BattleUnit* unit, const Position eventPos, 
 		return false;
 
 	Position posSelf = unit->getPosition();
-	if (eventRadius == 0 || eventPos == Position(-1, -1, -1) || distanceSq(posSelf, eventPos) <= eventRadius * eventRadius)
+	if (eventRadius == 0 || eventPos == Position(-1, -1, -1) || distanceSq(posSelf, eventPos, false) <= eventRadius * eventRadius)
 	{
 		//Asked to do a full check. Or the event is overlapping our tile. Better check everything.
 		selfWithinEventRadius = true;
@@ -410,7 +410,7 @@ void TileEngine::calculateTilesInFOV(BattleUnit *unit, const Position eventPos, 
 		return;
 	}
 	Position posSelf = unit->getPosition();
-	if (eventPos == Position(-1,-1,-1) || eventPos == unit->getPosition() || distanceSq(posSelf, eventPos) <= eventRadius * eventRadius)
+	if (eventPos == Position(-1,-1,-1) || eventPos == unit->getPosition() || distanceSq(posSelf, eventPos, false) <= eventRadius * eventRadius)
 	{
 		//Asked to do a full check. Or unit within event. Should update all.
 		unit->clearVisibleTiles();
@@ -424,7 +424,7 @@ void TileEngine::calculateTilesInFOV(BattleUnit *unit, const Position eventPos, 
 	}
 	
 	//Only recalculate bresenham lines to tiles that are at the event or further away.
-	const int distanceSqrMin = skipNarrowArcTest ? 0 : std::max(distanceSq(posSelf, eventPos) - eventRadius*eventRadius, 0); 
+	const int distanceSqrMin = skipNarrowArcTest ? 0 : std::max(distanceSq(posSelf, eventPos, false) - eventRadius * eventRadius, 0); 
 	
 	//Variables for finding the tiles to test based on the view direction.
 	Position posTest;
@@ -971,9 +971,11 @@ void TileEngine::calculateFOV(const Position &position, int eventRadius, const b
 		eventRadius = getMaxViewDistance();
 		updateRadius = getMaxViewDistanceSq();
 	} 
-	else {
+	else 
+	{
 		//Need to grab units which are out of range of the centre of the event, but can still see the edge of the effect.
-		updateRadius = getMaxViewDistanceSq() + (eventRadius > 0 ? eventRadius*eventRadius : 0);
+		updateRadius = getMaxViewDistance() + (eventRadius > 0 ? eventRadius : 0);
+		updateRadius *= updateRadius;
 	}
 	for (std::vector<BattleUnit*>::iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
 	{

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -969,15 +969,15 @@ void TileEngine::calculateFOV(const Position &position, int eventRadius, const b
 	if (eventRadius == -1)
 	{
 		eventRadius = getMaxViewDistance();
-		updateRadius = getMaxViewDistance();
+		updateRadius = getMaxViewDistanceSq();
 	} 
 	else {
 		//Need to grab units which are out of range of the centre of the event, but can still see the edge of the effect.
-		updateRadius = getMaxViewDistance() + (eventRadius > 0 ? eventRadius : 0);
+		updateRadius = getMaxViewDistanceSq() + (eventRadius > 0 ? eventRadius*eventRadius : 0);
 	}
 	for (std::vector<BattleUnit*>::iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
 	{
-		if (distanceSq(position, (*i)->getPosition(), false) < updateRadius) //could this unit have observed the event?
+		if (distanceSq(position, (*i)->getPosition(), false) <= updateRadius) //could this unit have observed the event?
 		{
 			if (updateTiles)
 			{

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -149,6 +149,7 @@ void UnitDieBState::think()
 	{
 		_parent->getMap()->setUnitDying(false);
 		_parent->getTileEngine()->calculateUnitLighting();
+		_parent->getTileEngine()->calculateFOV(_unit->getPosition(), _unit->getArmor()->getSize(), false); //Update FOV for anyone that can see me
 		_parent->popState();
 		if (_unit->getOriginalFaction() == FACTION_PLAYER)
 		{

--- a/src/Battlescape/UnitFallBState.cpp
+++ b/src/Battlescape/UnitFallBState.cpp
@@ -268,7 +268,8 @@ void UnitFallBState::think()
 				}
 				// move our personal lighting with us
 				_terrain->calculateUnitLighting();
-				_terrain->calculateFOV(*unit);
+				_terrain->calculateFOV((*unit)->getPosition(), 1, false); //update everyone else to see this unit, as well as all this unit's visible units.
+				_terrain->calculateFOV((*unit), true, false); //update tiles
 				_parent->checkForProximityGrenades(*unit);
 				if (_parent->getTileEngine()->checkReactionFire(*unit))
 					_parent->getPathfinding()->abortPath();

--- a/src/Battlescape/UnitWalkBState.cpp
+++ b/src/Battlescape/UnitWalkBState.cpp
@@ -86,7 +86,6 @@ void UnitWalkBState::think()
 	{
 		if (_parent->kneel(_unit))
 		{
-			_terrain->calculateFOV(_unit);
 			return;
 		}
 		else
@@ -197,7 +196,8 @@ void UnitWalkBState::think()
 			{
 				_unit->setVisible(false);
 			}
-			_terrain->calculateFOV(_unit->getPosition());
+			_terrain->calculateFOV(_unit->getPosition(), 2, false); //update unit visibility for all units which can see last and current position.
+			//tile visibility for this unit is handled later.
 			unitSpotted = (!_action.ignoreSpottedEnemies && !_falling && !_action.desperate && _parent->getPanicHandled() && _numUnitsSpotted != _unit->getUnitsSpottedThisTurn().size());
 
 			if (_parent->checkForProximityGrenades(_unit))

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <string>
+#include <unordered_set>
 #include "../Battlescape/Position.h"
 #include "../Battlescape/BattlescapeGame.h"
 #include "../Mod/RuleItem.h"
@@ -79,6 +80,7 @@ private:
 	int _walkPhase, _fallPhase;
 	std::vector<BattleUnit *> _visibleUnits, _unitsSpottedThisTurn;
 	std::vector<Tile *> _visibleTiles;
+	std::unordered_set<Tile *> _visibleTilesLookup;
 	int _tu, _energy, _health, _morale, _stunlevel;
 	bool _kneeled, _floating, _dontReselect;
 	int _currentArmor[SIDE_MAX];
@@ -260,14 +262,20 @@ public:
 	void setTimeUnits(int tu);
 	/// Add unit to visible units.
 	bool addToVisibleUnits(BattleUnit *unit);
+	/// Remove a unit from the list of visible units.
+	bool removeFromVisibleUnits(BattleUnit *unit);
+	/// Is the given unit among this unit's visible units?
+	bool hasVisibleUnit(BattleUnit *unit);
 	/// Get the list of visible units.
 	std::vector<BattleUnit*> *getVisibleUnits();
 	/// Clear visible units.
 	void clearVisibleUnits();
 	/// Add unit to visible tiles.
 	bool addToVisibleTiles(Tile *tile);
+	/// Has this unit marked this tile as within its view?
+	bool hasVisibleTile(Tile *tile) const;
 	/// Get the list of visible tiles.
-	std::vector<Tile*> *getVisibleTiles();
+	const std::vector<Tile*> *getVisibleTiles();
 	/// Clear visible tiles.
 	void clearVisibleTiles();
 	/// Calculate psi attack accuracy.
@@ -460,7 +468,7 @@ public:
 	/// derive a rank integer based on rank string (for xcom soldiers ONLY)
 	void deriveRank();
 	/// this function checks if a tile is visible, using maths.
-	bool checkViewSector(Position pos) const;
+	bool checkViewSector(Position pos, bool useTurretDirection = false) const;
 	/// adjust this unit's stats according to difficulty.
 	void adjustStats(const int diff);
 	/// did this unit already take fire damage this turn? (used to avoid damaging large units multiple times.)

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -1804,7 +1804,8 @@ void SavedBattleGame::reviveUnconsciousUnits(bool noTU)
 					(*i)->turn(false); // makes the unit stand up again
 					(*i)->kneel(false);
 					if (noTU) (*i)->setTimeUnits(0);
-					getTileEngine()->calculateFOV((*i));
+					getTileEngine()->calculateFOV((*i)->getPosition(), 1, false); //Let everyone see this unit and update potentially blocked visibility caused by its revival.
+					getTileEngine()->calculateFOV((*i), true, false); //Update tile visibility for this unit. A full unit check should've been triggered by the above call.
 					getTileEngine()->calculateUnitLighting();
 					removeUnconsciousBodyItem((*i));
 				}


### PR DESCRIPTION
Greatly reduces the delay caused by FOV-related updates in the game.
Reduces stuttering while moving, after each shot, and explosion.

Done by allowing partial visibility updates of tiles and units for cases
when we know an event has occurred and the exact tiles affected. This
creates a small circle sector originating at the observing unit with its
arc width set by the radius of the event. Any tiles and/or units in this
area may then be updated, which is faster than updating everything
within that unit's full vision sector.

Also changed the way the unit visibility algorithm scales, from an
area-based algorithm to be based on the number of units in range. This
scales better with view distance.