### PR TITLE
Oxce3.5 plus proto

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -1490,12 +1490,15 @@ std::vector<TileEngine::ReactionScore> TileEngine::getSpottingUnits(BattleUnit* 
 {
 	std::vector<TileEngine::ReactionScore> spotters;
 	Tile *tile = unit->getTile();
-	int threshold = unit->getReactionScore();
+    // Active unit reaction score adjusted for default 25% of TUs.
+	int threshold = unit->getReactionScore(int(floor(0.25 * unit->getBaseStats()->tu)));
 	// no reaction on civilian turn.
 	if (_save->getSide() != FACTION_NEUTRAL)
 	{
 		for (std::vector<BattleUnit*>::const_iterator i = _save->getUnits()->begin(); i != _save->getUnits()->end(); ++i)
 		{
+            ReactionScore rs = determineReactionType(*i, unit);
+
 				// not dead/unconscious
 			if (!(*i)->isOut() &&
 				// not dying
@@ -1503,7 +1506,8 @@ std::vector<TileEngine::ReactionScore> TileEngine::getSpottingUnits(BattleUnit* 
 				// not about to pass out
 				(*i)->getStunlevel() < (*i)->getHealth() &&
 				// have any chances for reacting
-				(*i)->getReactionScore() >= threshold &&
+                rs.reactionScore >= threshold &&
+				//(*i)->getReactionScore((*i)->getActionTUs(BA_SNAPSHOT, (*i)->getMainHandWeapon(true)).Time) >= threshold &&
 				// not a friend
 				(*i)->getFaction() != _save->getSide() &&
 				// not a civilian
@@ -1531,15 +1535,15 @@ std::vector<TileEngine::ReactionScore> TileEngine::getSpottingUnits(BattleUnit* 
 						unit->setVisible(true);
 					}
 					(*i)->addToVisibleUnits(unit);
-					ReactionScore rs = determineReactionType(*i, unit);
+					//ReactionScore rs = determineReactionType(*i, unit);
 					if (rs.attackType != BA_NONE)
 					{
-						if (rs.attackType == BA_SNAPSHOT && Options::battleUFOExtenderAccuracy)
+						if ((rs.attackType == BA_SNAPSHOT || rs.attackType == BA_AUTOSHOT) && Options::battleUFOExtenderAccuracy)
 						{
 							BattleItem *weapon = (*i)->getMainHandWeapon((*i)->getFaction() != FACTION_PLAYER);
 							int accuracy = (*i)->getFiringAccuracy(rs.attackType, weapon, _save->getBattleGame()->getMod());
 							int distance = _save->getTileEngine()->distance((*i)->getPosition(), unit->getPosition());
-							int upperLimit = weapon->getRules()->getSnapRange();
+                            int upperLimit = rs.attackType == BA_SNAPSHOT ? weapon->getRules()->getSnapRange() : weapon->getRules()->getAutoRange();
 							int lowerLimit = weapon->getRules()->getMinRange();
 							if (distance > upperLimit)
 							{
@@ -1585,7 +1589,8 @@ TileEngine::ReactionScore *TileEngine::getReactor(std::vector<TileEngine::Reacti
 			best = &(*i);
 		}
 	}
-	if (best &&(unit->getReactionScore() <= best->reactionScore))
+    if (best &&(unit->getReactionScore((int)floor(0.25 * unit->getBaseStats()->tu)) <= best->reactionScore))
+	//if (best &&(unit->getReactionScore(unit->getActionTUs(BA_SNAPSHOT, unit->getMainHandWeapon(true)).Time) <= best->reactionScore))
 	{
 		if (best->unit->getOriginalFaction() == FACTION_PLAYER)
 		{
@@ -1600,7 +1605,7 @@ TileEngine::ReactionScore *TileEngine::getReactor(std::vector<TileEngine::Reacti
 }
 
 /**
- * Checks the validity of a snap shot performed here.
+ * Checks the validity of a auto, snap or aimed shot performed here.
  * @param unit The unit to check sight from.
  * @param target The unit to check sight TO.
  * @return True if the target is valid.
@@ -1611,7 +1616,7 @@ TileEngine::ReactionScore TileEngine::determineReactionType(BattleUnit *unit, Ba
 	{
 		unit,
 		BA_NONE,
-		unit->getReactionScore(),
+		unit->getReactionScore(unit->getActionTUs(BA_SNAPSHOT, unit->getMainHandWeapon(true)).Time),
 		0,
 	};
 	// prioritize melee
@@ -1621,34 +1626,82 @@ TileEngine::ReactionScore TileEngine::determineReactionType(BattleUnit *unit, Ba
 		validMeleeRange(unit, target, unit->getDirection()) &&
 		BattleActionCost(BA_HIT, unit, meleeWeapon).haveTU())
 	{
+        reaction.reactionScore = unit->getReactionScore(BattleActionCost(BA_HIT, unit, meleeWeapon).Time);
 		reaction.attackType = BA_HIT;
 		reaction.reactionReduction = 1.0 * BattleActionCost(BA_HIT, unit, meleeWeapon).Time * unit->getBaseStats()->reactions / unit->getBaseStats()->tu;
 		return reaction;
 	}
 
 	// has a weapon
-	BattleItem *weapon = unit->getMainHandWeapon(unit->getFaction() != FACTION_PLAYER);
-	if (_save->canUseWeapon(weapon, unit, false) &&
-		distance(unit->getPosition(), target->getPosition()) < weapon->getRules()->getMaxRange() &&
-		(	// has a melee weapon and is in melee range
-			(weapon->getRules()->getBattleType() == BT_MELEE &&
-				validMeleeRange(unit, target, unit->getDirection()) &&
-				BattleActionCost(BA_HIT, unit, weapon).haveTU()) ||
-			// has a gun capable of snap shot with ammo
-			(weapon->getRules()->getBattleType() != BT_MELEE &&
-				weapon->getAmmoItem() &&
-				BattleActionCost(BA_SNAPSHOT, unit, weapon).haveTU())))
-	{
-		reaction.attackType = BA_SNAPSHOT;
-		reaction.reactionReduction = 1.0 * BattleActionCost(BA_SNAPSHOT, unit, weapon).Time * unit->getBaseStats()->reactions / unit->getBaseStats()->tu;
-		return reaction;
-	}
+    BattleItem *weapon = unit->getMainHandWeapon(unit->getFaction() != FACTION_PLAYER);
+
+    // prioritize auto shot if in close range
+    if (_save->canUseWeapon(weapon, unit, false) &&
+        distance(unit->getPosition(), target->getPosition()) <= weapon->getRules()->getMaxRange() &&
+        (   // has a melee weapon and is in melee range
+         (weapon->getRules()->getBattleType() == BT_MELEE &&
+          validMeleeRange(unit, target, unit->getDirection()) &&
+          BattleActionCost(BA_HIT, unit, weapon).haveTU()) ||
+         // has a gun capable of auto shot with ammo
+         (weapon->getRules()->getBattleType() != BT_MELEE &&
+          weapon->getAmmoItem() &&
+          BattleActionCost(BA_AUTOSHOT, unit, weapon).haveTU() &&
+          // and is within accurate auto shot range or is only capable of auto shot
+          (distance(unit->getPosition(), target->getPosition()) <= weapon->getRules()->getAutoRange() ||
+           (weapon->getRules()->getCostSnap().Time == 0 && weapon->getRules()->getCostAimed().Time == 0)))))
+    {
+        reaction.reactionScore = unit->getReactionScore(unit->getActionTUs(BA_AUTOSHOT, weapon).Time);
+        reaction.attackType = BA_AUTOSHOT;
+        reaction.reactionReduction = 1.0 * BattleActionCost(BA_AUTOSHOT, unit, weapon).Time * unit->getBaseStats
+        ()->reactions / unit->getBaseStats()->tu;
+        return reaction;
+    }
+    
+    // next try snap shot if in snap shot range
+    if (_save->canUseWeapon(weapon, unit, false) &&
+        distance(unit->getPosition(), target->getPosition()) < weapon->getRules()->getMaxRange() &&
+        (	// has a melee weapon and is in melee range
+         (weapon->getRules()->getBattleType() == BT_MELEE &&
+          validMeleeRange(unit, target, unit->getDirection()) &&
+          BattleActionCost(BA_HIT, unit, weapon).haveTU()) ||
+         // has a gun capable of snap shot with ammo
+         (weapon->getRules()->getBattleType() != BT_MELEE &&
+          weapon->getAmmoItem() &&
+          BattleActionCost(BA_SNAPSHOT, unit, weapon).haveTU() &&
+          // and is in effective snap shot range or is not capable of aimed shot (at all or out of TUs)
+          (distance(unit->getPosition(), target->getPosition()) <= weapon->getRules()->getSnapRange() ||
+          (weapon->getRules()->getCostAimed().Time == 0 || !BattleActionCost(BA_AIMEDSHOT, unit, weapon).haveTU())))))
+    {
+        reaction.reactionScore = unit->getReactionScore(unit->getActionTUs(BA_SNAPSHOT, weapon).Time);
+        reaction.attackType = BA_SNAPSHOT;
+        reaction.reactionReduction = 1.0 * BattleActionCost(BA_SNAPSHOT, unit, weapon).Time * unit->getBaseStats()->reactions / unit->getBaseStats()->tu;
+        return reaction;
+    }
+    
+    // finally attempt an aimed shot if in effective aimed shot range
+    if (_save->canUseWeapon(weapon, unit, false) &&
+        distance(unit->getPosition(), target->getPosition()) < weapon->getRules()->getMaxRange() &&
+        (   // has a melee weapon and is in melee range
+            (weapon->getRules()->getBattleType() == BT_MELEE &&
+                validMeleeRange(unit, target, unit->getDirection()) &&
+                BattleActionCost(BA_HIT, unit, weapon).haveTU()) ||
+            // has a gun capable of aimed shot with ammo
+            (weapon->getRules()->getBattleType() != BT_MELEE &&
+                weapon->getAmmoItem() &&
+                BattleActionCost(BA_AIMEDSHOT, unit, weapon).haveTU())))
+    {
+        reaction.reactionScore = unit->getReactionScore(unit->getActionTUs(BA_AIMEDSHOT, weapon).Time);
+        reaction.attackType = BA_AIMEDSHOT;
+        reaction.reactionReduction = 1.0 * BattleActionCost(BA_AIMEDSHOT, unit, weapon).Time * unit->getBaseStats
+            ()->reactions / unit->getBaseStats()->tu;
+        return reaction;
+    }
 
 	return reaction;
 }
 
 /**
- * Attempts to perform a reaction snap shot.
+ * Attempts to perform a reaction snap/aimed shot.
  * @param unit The unit to check sight from.
  * @param target The unit to check sight TO.
  * @return True if the action should (theoretically) succeed.

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -173,7 +173,6 @@ void create()
 	_info.push_back(OptionInfo("storageLimitsEnforced", &storageLimitsEnforced, false, "STR_STORAGELIMITSENFORCED", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("canSellLiveAliens", &canSellLiveAliens, false, "STR_CANSELLLIVEALIENS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("anytimePsiTraining", &anytimePsiTraining, false, "STR_ANYTIMEPSITRAINING", "STR_GEOSCAPE"));
-	_info.push_back(OptionInfo("anytimeMartialTraining", &anytimeMartialTraining, true, "STR_ANYTIMEMARTIALTRAINING", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("globeSeasons", &globeSeasons, false, "STR_GLOBESEASONS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("psiStrengthEval", &psiStrengthEval, false, "STR_PSISTRENGTHEVAL", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("canTransferCraftsWhileAirborne", &canTransferCraftsWhileAirborne, false, "STR_CANTRANSFERCRAFTSWHILEAIRBORNE", "STR_GEOSCAPE")); // When the craft can reach the destination base with its fuel
@@ -217,10 +216,10 @@ void create()
 	_info.push_back(OptionInfo("removeWoundedFromTraining", &removeWoundedFromTraining, false, "STR_REMOVE_WOUNDED_FROM_TRAINING", "STR_OXCE"));
 	_info.push_back(OptionInfo("autoAssignPilots", &autoAssignPilots, false, "STR_AUTO_ASSIGN_PILOTS", "STR_OXCE"));
 	_info.push_back(OptionInfo("fullNightVision", &fullNightVision, false, "STR_FULL_NIGHT_VISION", "STR_OXCE"));
-	_info.push_back(OptionInfo("nightVisionColor", &nightVisionColor, 8, "STR_NIGHT_VISION_COLOR", "STR_OXCE"));
-	_info.push_back(OptionInfo("autoNightVision", &autoNightVision, false, "STR_AUTO_NIGHT_VISION", "STR_OXCE"));
+	_info.push_back(OptionInfo("nightVisionColor", &nightVisionColor, 5, "STR_NIGHT_VISION_COLOR", "STR_OXCE"));
 	_info.push_back(OptionInfo("autoSell", &autoSell, false, "STR_AUTO_SELL", "STR_OXCE"));
 	_info.push_back(OptionInfo("techTreeViewerSpoilerProtection", &techTreeViewerSpoilerProtection, false, "STR_TECH_SPOILER_PROTECTION", "STR_OXCE"));
+    _info.push_back(OptionInfo("extendedReactionFire", &extendedReactionFire, false, "STR_EXTENDED_REACTION_FIRE", "STR_OXCE"));
 
 	// controls
 	_info.push_back(OptionInfo("keyOk", &keyOk, SDLK_RETURN, "STR_OK", "STR_GENERAL"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -20,7 +20,7 @@ OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave;
 
 // Geoscape options
 OPT int geoClockSpeed, dogfightSpeed, geoScrollSpeed, geoDragScrollButton, geoscapeScale;
-OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, anytimeMartialTraining, weaponSelfDestruction, retainCorpses, craftLaunchAlways, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
+OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, weaponSelfDestruction, retainCorpses, craftLaunchAlways, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
 	storageLimitsEnforced, canSellLiveAliens, canTransferCraftsWhileAirborne, customInitialBase, aggressiveRetaliation, geoDragScrollInvert,
 	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, allowPsiStrengthImprovement, fieldPromotions, meetingPoint;
 OPT SDLKey keyGeoLeft, keyGeoRight, keyGeoUp, keyGeoDown, keyGeoZoomIn, keyGeoZoomOut, keyGeoSpeed1, keyGeoSpeed2, keyGeoSpeed3, keyGeoSpeed4, keyGeoSpeed5, keyGeoSpeed6,
@@ -53,9 +53,9 @@ OPT bool removeWoundedFromTraining;
 OPT bool autoAssignPilots;
 OPT bool fullNightVision;
 OPT int nightVisionColor;
-OPT bool autoNightVision;
 OPT bool autoSell;
 OPT bool techTreeViewerSpoilerProtection;
+OPT bool extendedReactionFire;
 
 // Flags and other stuff that don't need OptionInfo's.
 OPT bool mute, reload, newOpenGL, newScaleFilter, newHQXFilter, newXBRZFilter, newRootWindowedMode, newFullscreen, newAllowResize, newBorderless;

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -50,7 +50,7 @@ RuleItem::RuleItem(const std::string &type) :
 	_costAimed(0), _costAuto(0, -1), _costSnap(0, -1), _costMelee(0), _costUse(25), _costMind(-1, -1), _costPanic(-1, -1), _costThrow(25), _costPrime(50), _costUnprime(25),
 	_clipSize(0), _specialChance(100), _tuLoad(15), _tuUnload(8),
 	_battleType(BT_NONE), _fuseType(BFT_NONE), _psiAttackName(), _primeActionName("STR_PRIME_GRENADE"), _unprimeActionName(), _primeActionMessage("STR_GRENADE_IS_ACTIVATED"), _unprimeActionMessage("STR_GRENADE_IS_DEACTIVATED"),
-	_twoHanded(false), _blockBothHands(false), _fixedWeapon(false), _fixedWeaponShow(false), _allowSelfHeal(false), _isConsumable(false), _isFireExtinguisher(false), _isExplodingInHands(false), _waypoints(0), _invWidth(1), _invHeight(1),
+    _twoHanded(false), _blockBothHands(false), _fixedWeapon(false), _fixedWeaponShow(false), _allowSelfHeal(false), _isConsumable(false), _isFireExtinguisher(false), _isExplodingInHands(false), _canReact(true), _waypoints(0), _invWidth(1), _invHeight(1),
 	_painKiller(0), _heal(0), _stimulant(0), _medikitType(BMT_NORMAL), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _moraleRecovery(0), _painKillerRecovery(1.0f), _recoveryPoints(0), _armor(20), _turretType(-1),
 	_aiUseDelay(-1), _aiMeleeHitCount(25),
 	_recover(true), _ignoreInBaseDefense(false), _liveAlien(false), _liveAlienPrisonType(0), _attraction(0), _flatUse(0, 1), _flatMelee(-1, -1), _flatThrow(0, 1), _flatPrime(0, 1), _flatUnprime(0, 1), _arcingShot(false), _experienceTrainingMode(ETM_DEFAULT), _listOrder(0),
@@ -411,6 +411,7 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 	_isConsumable = node["isConsumable"].as<bool>(_isConsumable);
 	_isFireExtinguisher = node["isFireExtinguisher"].as<bool>(_isFireExtinguisher);
 	_isExplodingInHands = node["isExplodingInHands"].as<bool>(_isExplodingInHands);
+    _canReact = node["canReact"].as<bool>(_canReact);
 	_invWidth = node["invWidth"].as<int>(_invWidth);
 	_invHeight = node["invHeight"].as<int>(_invHeight);
 
@@ -1356,7 +1357,7 @@ bool RuleItem::isFireExtinguisher() const
 {
 	return _isFireExtinguisher;
 }
-
+ 
 /**
  * Is this item explode in hands?
  * @return True if the item can explode in hand.
@@ -1364,6 +1365,15 @@ bool RuleItem::isFireExtinguisher() const
 bool RuleItem::isExplodingInHands() const
 {
 	return _isExplodingInHands;
+}
+    
+/**
+ * Can this item be used in reactions?
+ * @return True if can be used in reactions.
+ */
+bool RuleItem::canReact() const
+{
+    return _canReact;
 }
 
 /**

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -50,7 +50,7 @@ RuleItem::RuleItem(const std::string &type) :
 	_costAimed(0), _costAuto(0, -1), _costSnap(0, -1), _costMelee(0), _costUse(25), _costMind(-1, -1), _costPanic(-1, -1), _costThrow(25), _costPrime(50), _costUnprime(25),
 	_clipSize(0), _specialChance(100), _tuLoad(15), _tuUnload(8),
 	_battleType(BT_NONE), _fuseType(BFT_NONE), _psiAttackName(), _primeActionName("STR_PRIME_GRENADE"), _unprimeActionName(), _primeActionMessage("STR_GRENADE_IS_ACTIVATED"), _unprimeActionMessage("STR_GRENADE_IS_DEACTIVATED"),
-    _twoHanded(false), _blockBothHands(false), _fixedWeapon(false), _fixedWeaponShow(false), _allowSelfHeal(false), _isConsumable(false), _isFireExtinguisher(false), _isExplodingInHands(false), _canReact(true), _waypoints(0), _invWidth(1), _invHeight(1),
+    _twoHanded(false), _blockBothHands(false), _fixedWeapon(false), _fixedWeaponShow(false), _allowSelfHeal(false), _isConsumable(false), _isFireExtinguisher(false), _isExplodingInHands(false), _canReactAimed(true), _canReactAuto(true), _canReactSnap(true), _canReactMelee(true), _waypoints(0), _invWidth(1), _invHeight(1),
 	_painKiller(0), _heal(0), _stimulant(0), _medikitType(BMT_NORMAL), _woundRecovery(0), _healthRecovery(0), _stunRecovery(0), _energyRecovery(0), _moraleRecovery(0), _painKillerRecovery(1.0f), _recoveryPoints(0), _armor(20), _turretType(-1),
 	_aiUseDelay(-1), _aiMeleeHitCount(25),
 	_recover(true), _ignoreInBaseDefense(false), _liveAlien(false), _liveAlienPrisonType(0), _attraction(0), _flatUse(0, 1), _flatMelee(-1, -1), _flatThrow(0, 1), _flatPrime(0, 1), _flatUnprime(0, 1), _arcingShot(false), _experienceTrainingMode(ETM_DEFAULT), _listOrder(0),
@@ -411,7 +411,9 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 	_isConsumable = node["isConsumable"].as<bool>(_isConsumable);
 	_isFireExtinguisher = node["isFireExtinguisher"].as<bool>(_isFireExtinguisher);
 	_isExplodingInHands = node["isExplodingInHands"].as<bool>(_isExplodingInHands);
-    _canReact = node["canReact"].as<bool>(_canReact);
+    _canReactAimed = node["canReactAimed"].as<bool>(_canReactAimed);
+    _canReactAuto = node["canReactAuto"].as<bool>(_canReactAuto);
+    _canReactSnap = node["canReactSnap"].as<bool>(_canReactSnap);
 	_invWidth = node["invWidth"].as<int>(_invWidth);
 	_invHeight = node["invHeight"].as<int>(_invHeight);
 
@@ -1368,12 +1370,39 @@ bool RuleItem::isExplodingInHands() const
 }
     
 /**
- * Can this item be used in reactions?
- * @return True if can be used in reactions.
+ * Can this item be used for reactions with aimed shot?
+ * @return True if the item can be used for reactions with aimed shot.
  */
-bool RuleItem::canReact() const
+bool RuleItem::canReactAimed() const
 {
-    return _canReact;
+    return _canReactAimed;
+}
+    
+/**
+* Can this item be used for reactions with auto shot?
+* @return True if the item can be used for reactions with aimed shot.
+*/
+bool RuleItem::canReactAuto() const
+{
+    return _canReactAuto;
+}
+
+/**
+* Can this item be used for reactions with snap shot?
+* @return True if the item can be used for reactions with snap shot.
+*/
+bool RuleItem::canReactSnap() const
+{
+    return _canReactSnap;
+}
+    
+/**
+* Can this item be used for melee reactions?
+* @return True if the item can be used for melee reactions.
+*/
+bool RuleItem::canReactMelee() const
+{
+    return _canReactMelee;
 }
 
 /**

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -128,7 +128,7 @@ private:
 	BattleType _battleType;
 	BattleFuseType _fuseType;
 	std::string _psiAttackName, _primeActionName, _unprimeActionName, _primeActionMessage, _unprimeActionMessage;
-	bool _twoHanded, _blockBothHands, _fixedWeapon, _fixedWeaponShow, _allowSelfHeal, _isConsumable, _isFireExtinguisher, _isExplodingInHands, _canReact;
+	bool _twoHanded, _blockBothHands, _fixedWeapon, _fixedWeaponShow, _allowSelfHeal, _isConsumable, _isFireExtinguisher, _isExplodingInHands, _canReactAimed, _canReactAuto, _canReactSnap, _canReactMelee;
 	std::string _defaultInventorySlot;
 	std::vector<std::string> _supportedInventorySections;
 	int _waypoints, _invWidth, _invHeight;
@@ -388,8 +388,14 @@ public:
 	bool isFireExtinguisher() const;
 	/// Is this item explode in hands?
 	bool isExplodingInHands() const;
-    /// Can the item be used in reactions?
-    bool canReact() const;
+    /// Can the item be used for reactions with aimed shot?
+    bool canReactAimed() const;
+    /// Can the item be used for reactions with auto shot?
+    bool canReactAuto() const;
+    /// Can the item be used for reactions with snap shot?
+    bool canReactSnap() const;
+    /// Can the item be used for melee reactions?
+    bool canReactMelee() const;
 	/// Gets the medikit use type.
 	BattleMediKitType getMediKitType() const;
 	/// Gets the max explosion radius.

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -128,7 +128,7 @@ private:
 	BattleType _battleType;
 	BattleFuseType _fuseType;
 	std::string _psiAttackName, _primeActionName, _unprimeActionName, _primeActionMessage, _unprimeActionMessage;
-	bool _twoHanded, _blockBothHands, _fixedWeapon, _fixedWeaponShow, _allowSelfHeal, _isConsumable, _isFireExtinguisher, _isExplodingInHands;
+	bool _twoHanded, _blockBothHands, _fixedWeapon, _fixedWeaponShow, _allowSelfHeal, _isConsumable, _isFireExtinguisher, _isExplodingInHands, _canReact;
 	std::string _defaultInventorySlot;
 	std::vector<std::string> _supportedInventorySections;
 	int _waypoints, _invWidth, _invHeight;
@@ -388,6 +388,8 @@ public:
 	bool isFireExtinguisher() const;
 	/// Is this item explode in hands?
 	bool isExplodingInHands() const;
+    /// Can the item be used in reactions?
+    bool canReact() const;
 	/// Gets the medikit use type.
 	BattleMediKitType getMediKitType() const;
 	/// Gets the max explosion radius.

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1842,11 +1842,13 @@ int BattleUnit::getFatalWounds() const
  * Little formula to calculate reaction score.
  * @return Reaction score.
  */
-double BattleUnit::getReactionScore() const
+double BattleUnit::getReactionScore(int tuCost) const
 {
-	//(Reactions Stat) x (Current Time Units / Max TUs)
-	double score = ((double)getBaseStats()->reactions * (double)getTimeUnits()) / (double)getBaseStats()->tu;
-	return score;
+    // This has been modified to include half of weapon TU cost
+    // Default is set to assault rifle, 25% snap shot. Anything above that slows unit down, below speeds it up.
+    //(Reactions Stat) x (Current Time Units - (Weapon TU cost - 0.25*Max TUs) / 2) / Max TUs
+    double score = (double)getBaseStats()->reactions * (double)(getTimeUnits() - int((tuCost - int(0.25 * getBaseStats()->tu))/2)) / (double)getBaseStats()->tu;
+    return score;
 }
 
 /**
@@ -3983,7 +3985,7 @@ void geReactionScoreScript(const BattleUnit *bu, int &ret)
 {
 	if (bu)
 	{
-		ret = (int)bu->getReactionScore();
+		ret = (int)bu->getReactionScore(bu->getActionTUs(BA_SNAPSHOT, bu->getMainHandWeapon(true)).Time);
 	}
 	ret = 0;
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1844,10 +1844,18 @@ int BattleUnit::getFatalWounds() const
  */
 double BattleUnit::getReactionScore(int tuCost) const
 {
-    // This has been modified to include half of weapon TU cost
-    // Default is set to assault rifle, 25% snap shot. Anything above that slows unit down, below speeds it up.
-    //(Reactions Stat) x (Current Time Units - (Weapon TU cost - 0.25*Max TUs) / 2) / Max TUs
-    double score = (double)getBaseStats()->reactions * (double)(getTimeUnits() - int((tuCost - int(0.25 * getBaseStats()->tu))/2)) / (double)getBaseStats()->tu;
+    // If extended reaction fire option is chosen, the reaction score depends on the TUs required to operate the weapon.
+    // Default is set to assault rifle snap shot, 25% of all TUs.
+    int tuAction;
+    if (Options::extendedReactionFire) {
+        // Anything above default slows the unit down, and below it speeds it up, by half of the difference.
+        tuAction = int((tuCost - int(0.25 * getBaseStats()->tu))/2);
+    } else {
+        // Otherwise revert to standard calculation.
+        tuAction = 0;
+    }
+    //(Reactions Stat) x (Current Time Units - Possible Modification for ERF) / Max TUs
+    double score = (double)getBaseStats()->reactions * (double)(getTimeUnits() - tuAction) / (double)getBaseStats()->tu;
     return score;
 }
 

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -314,7 +314,7 @@ public:
 	/// Get total number of fatal wounds.
 	int getFatalWounds() const;
 	/// Get the current reaction score.
-	double getReactionScore() const;
+	double getReactionScore(int tuCost) const;
 	/// Prepare for a new turn.
 	void prepareNewTurn(bool fullProcess = true);
 	/// Calculate change in unit stats.


### PR DESCRIPTION
Extended Reaction Fire: enabling the setting opens reaction actions to aimed and auto shots. 
Added flags for excluding melee or aimed, auto, or snap shots from reactions for a given weapon. Enabling ERF tweaks Reaction Score calculations in the name of balance.
See https://openxcom.org/forum/index.php/topic,5475.0.html for more information.