### PR TITLE
Add restriction levels to inventory slots

### DIFF
--- a/src/Battlescape/Inventory.cpp
+++ b/src/Battlescape/Inventory.cpp
@@ -771,7 +771,7 @@ void Inventory::mouseClick(Action *action, State *state)
 				bool canStack = slot->getType() == INV_GROUND && canBeStacked(item, _selItem);
 
 				// Check if this inventory section supports the item
-				if (!_selItem->getRules()->canBePlacedIntoInventorySection(slot->getId()))
+				if (!_selItem->getRules()->canBePlacedIntoInventorySection(slot->getId(), slot->getResLevel()))
 				{
 					_warning->showMessage(_game->getLanguage()->getString("STR_CANNOT_PLACE_ITEM_INTO_THIS_SECTION"));
 				}

--- a/src/Mod/RuleInventory.cpp
+++ b/src/Mod/RuleInventory.cpp
@@ -52,8 +52,9 @@ namespace OpenXcom
  * Creates a blank ruleset for a certain
  * type of inventory section.
  * @param id String defining the id.
+ * @param _resLevel int restriction level for item placement.
  */
-RuleInventory::RuleInventory(const std::string &id): _id(id), _x(0), _y(0), _type(INV_SLOT), _listOrder(0), _hand(0)
+RuleInventory::RuleInventory(const std::string &id): _id(id), _x(0), _y(0), _type(INV_SLOT), _resLevel(1), _listOrder(0), _hand(0)
 {
 }
 
@@ -76,6 +77,7 @@ void RuleInventory::load(const YAML::Node &node, int listOrder)
 	_x = node["x"].as<int>(_x);
 	_y = node["y"].as<int>(_y);
 	_type = (InventoryType)node["type"].as<int>(_type);
+	_resLevel = node["PlacementRestrictionLevel"].as<int>(_resLevel);
 	_slots = node["slots"].as< std::vector<RuleSlot> >(_slots);
 	_costs = node["costs"].as< std::map<std::string, int> >(_costs);
 	_listOrder = node["listOrder"].as<int>(listOrder);
@@ -131,6 +133,15 @@ int RuleInventory::getY() const
 InventoryType RuleInventory::getType() const
 {
 	return _type;
+}
+
+/**
+ * Gets the restriction level. 0 never restricted, 1 restricted for items with slot lists (default), 2 always restricted.
+ * @return restriction level.
+ */
+bool RuleInventory::getResLevel() const
+{
+	return _resLevel;
 }
 
 /**

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -924,12 +924,12 @@ const std::vector<std::string> &RuleItem::getSupportedInventorySections() const
  */
 bool RuleItem::canBePlacedIntoInventorySection(const std::string &inventorySection) const
 {
-	// backwards-compatibility
-	if (_supportedInventorySections.empty())
+	// allow default items in unrestricted inventory sections.
+	if (resLevel == 1 && _supportedInventorySections.empty())
 		return true;
 
-	// always possible to put an item on the ground
-	if (inventorySection == "STR_GROUND")
+	// always possible to put an item on the ground or in fully unrestricted slots
+	if (inventorySection == "STR_GROUND" or resLevel == 0)
 		return true;
 
 	// otherwise check allowed inventory sections


### PR DESCRIPTION
Adds a property to the ruleset invs: PlacementRestrictionLevel that sets whether or not items can be placed into a slot by default, or if the Items: supportedInventorySections property must include the slot in question.

See: https://openxcom.org/forum/index.php/topic,6543.0.html 