### PR TITLE
All soldier lists can now be reordered with the mouse wheel.

### DIFF
--- a/src/Basescape/CraftArmorState.cpp
+++ b/src/Basescape/CraftArmorState.cpp
@@ -296,6 +296,14 @@ void CraftArmorState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
@@ -348,6 +356,14 @@ void CraftArmorState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -307,6 +307,14 @@ void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
@@ -359,6 +367,14 @@ void CraftSoldiersState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -405,6 +405,14 @@ void SoldiersState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
@@ -457,6 +465,14 @@ void SoldiersState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Geoscape/AllocatePsiTrainingState.cpp
+++ b/src/Geoscape/AllocatePsiTrainingState.cpp
@@ -284,6 +284,14 @@ void AllocatePsiTrainingState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
@@ -336,6 +344,14 @@ void AllocatePsiTrainingState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Geoscape/AllocateTrainingState.cpp
+++ b/src/Geoscape/AllocateTrainingState.cpp
@@ -303,6 +303,14 @@ void AllocateTrainingState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
@@ -355,6 +363,14 @@ void AllocateTrainingState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));


### PR DESCRIPTION
This is something I asked to be added a few years ago. OXC allows the craft soldier list to be reordered by turning the mouse wheel over the up/down buttons, but although OXCE+ has the same buttons on other soldier lists they do not have the mouse wheel functionality. This patch adds it for all soldier lists.