### PR TITLE
All soldier lists can now be reordered with the mouse wheel.

### DIFF
--- a/src/Basescape/CraftArmorState.cpp
+++ b/src/Basescape/CraftArmorState.cpp
@@ -286,6 +286,7 @@ void CraftArmorState::initList(size_t scrl)
 void CraftArmorState::lstItemsLeftArrowClick(Action *action)
 {
 	unsigned int row = _lstSoldiers->getSelectedRow();
+    size_t numSoldiers = _base->getSoldiers()->size();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -296,7 +297,18 @@ void CraftArmorState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
 	}
+    if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
+    {
+        if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
 }
@@ -348,6 +360,17 @@ void CraftArmorState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+        else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+	}
+    if (row > 0)
+    {
+		if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -297,6 +297,7 @@ void CraftSoldiersState::init()
 void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
 {
 	unsigned int row = _lstSoldiers->getSelectedRow();
+    size_t numSoldiers = _base->getSoldiers()->size();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -307,7 +308,18 @@ void CraftSoldiersState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
 	}
+    if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
+    {
+        if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
 }
@@ -359,6 +371,17 @@ void CraftSoldiersState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+        else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+	}
+    if (row > 0)
+    {
+		if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -395,6 +395,7 @@ void SoldiersState::initList(size_t scrl)
 void SoldiersState::lstItemsLeftArrowClick(Action *action)
 {
 	unsigned int row = _lstSoldiers->getSelectedRow();
+    size_t numSoldiers = _base->getSoldiers()->size();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -405,7 +406,18 @@ void SoldiersState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
 	}
+    if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
+    {
+        if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
 }
@@ -457,6 +469,17 @@ void SoldiersState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+        else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
+    if (row > 0)
+    {
+		if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Geoscape/AllocatePsiTrainingState.cpp
+++ b/src/Geoscape/AllocatePsiTrainingState.cpp
@@ -274,6 +274,7 @@ void AllocatePsiTrainingState::initList(size_t scrl)
 void AllocatePsiTrainingState::lstItemsLeftArrowClick(Action *action)
 {
 	unsigned int row = _lstSoldiers->getSelectedRow();
+    size_t numSoldiers = _base->getSoldiers()->size();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -284,7 +285,18 @@ void AllocatePsiTrainingState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
 	}
+    if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
+    {
+        if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
 }
@@ -336,6 +348,17 @@ void AllocatePsiTrainingState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+        else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+	}
+    if (row > 0)
+    {
+		if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));

--- a/src/Geoscape/AllocateTrainingState.cpp
+++ b/src/Geoscape/AllocateTrainingState.cpp
@@ -293,6 +293,7 @@ void AllocateTrainingState::initList(size_t scrl)
 void AllocateTrainingState::lstItemsLeftArrowClick(Action *action)
 {
 	unsigned int row = _lstSoldiers->getSelectedRow();
+    size_t numSoldiers = _base->getSoldiers()->size();
 	if (row > 0)
 	{
 		if (action->getDetails()->button.button == SDL_BUTTON_LEFT)
@@ -303,7 +304,18 @@ void AllocateTrainingState::lstItemsLeftArrowClick(Action *action)
 		{
 			moveSoldierUp(action, row, true);
 		}
+		else if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
+		}
 	}
+    if (0 < numSoldiers && INT_MAX >= numSoldiers && row < numSoldiers - 1)
+    {
+        if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+    }
 	_cbxSortBy->setText(tr("STR_SORT_BY"));
 	_cbxSortBy->setSelected(-1);
 }
@@ -355,6 +367,17 @@ void AllocateTrainingState::lstItemsRightArrowClick(Action *action)
 		else if (action->getDetails()->button.button == SDL_BUTTON_RIGHT)
 		{
 			moveSoldierDown(action, row, true);
+		}
+        else if (action->getDetails()->button.button == SDL_BUTTON_WHEELDOWN)
+		{
+			moveSoldierDown(action, row);
+		}
+	}
+    if (row > 0)
+    {
+		if (action->getDetails()->button.button == SDL_BUTTON_WHEELUP)
+		{
+			moveSoldierUp(action, row);
 		}
 	}
 	_cbxSortBy->setText(tr("STR_SORT_BY"));


### PR DESCRIPTION
The same PR as before, only now it's not broken. All soldier lists in OXCE+ can be reordered using the mouse wheel the same way the craft soldier list can in OXC.