### PR TITLE
Feature: define inventory rulesets per armor

### DIFF
--- a/src/Battlescape/AlienInventory.cpp
+++ b/src/Battlescape/AlienInventory.cpp
@@ -112,20 +112,21 @@ void AlienInventory::drawGrid()
 	RuleInterface *rule = _game->getMod()->getInterface("inventory");
 	Uint8 color = rule->getElement("grid")->color;
 
-	for (std::map<std::string, RuleInventory*>::iterator i = _game->getMod()->getInventories()->begin(); i != _game->getMod()->getInventories()->end(); ++i)
+	if (_selUnit != 0) for (std::vector<std::string>::const_iterator i = _selUnit->getArmor()->getInventorySlots().cbegin(); i != _selUnit->getArmor()->getInventorySlots().cend(); i++)
 	{
-		if (i->second->getType() == INV_HAND)
+		RuleInventory *ruleI = (*_game->getMod()->getInventories())[*i];
+		if (ruleI->getType() == INV_HAND)
 		{
 			SDL_Rect r;
-			r.x = i->second->getX();
+			r.x = ruleI->getX();
 			r.x += ALIEN_INVENTORY_STATIC_OFFSET;
 
-			if (i->second->getId() == "STR_RIGHT_HAND")
+			if (ruleI->getId() == _selUnit->getArmor()->getDefaultInventoryMap("STR_RIGHT_HAND"))
 				r.x -= _dynamicOffset;
-			else if (i->second->getId() == "STR_LEFT_HAND")
+			else if (ruleI->getId() == _selUnit->getArmor()->getDefaultInventoryMap("STR_LEFT_HAND"))
 				r.x += _dynamicOffset;
 
-			r.y = i->second->getY();
+			r.y = ruleI->getY();
 			r.w = RuleInventory::HAND_W * RuleInventory::SLOT_W;
 			r.h = RuleInventory::HAND_H * RuleInventory::SLOT_H;
 			_grid->drawRect(&r, color);
@@ -159,9 +160,9 @@ void AlienInventory::drawItems()
 				int x = (*i)->getSlot()->getX() + (*i)->getRules()->getHandSpriteOffX();
 				x += ALIEN_INVENTORY_STATIC_OFFSET;
 
-				if ((*i)->getSlot()->getId() == "STR_RIGHT_HAND")
+				if ((*i)->getSlot()->getId() == _selUnit->getArmor()->getDefaultInventoryMap("STR_RIGHT_HAND"))
 					x -= _dynamicOffset;
-				else if ((*i)->getSlot()->getId() == "STR_LEFT_HAND")
+				else if ((*i)->getSlot()->getId() == _selUnit->getArmor()->getDefaultInventoryMap("STR_LEFT_HAND"))
 					x += _dynamicOffset;
 
 				frame->blitNShade(_items, x, (*i)->getSlot()->getY() + (*i)->getRules()->getHandSpriteOffY());
@@ -182,11 +183,12 @@ void AlienInventory::drawItems()
  */
 RuleInventory *AlienInventory::getSlotInPosition(int *x, int *y) const
 {
-	for (std::map<std::string, RuleInventory*>::iterator i = _game->getMod()->getInventories()->begin(); i != _game->getMod()->getInventories()->end(); ++i)
+	if (_selUnit != 0) for (std::vector<std::string>::const_iterator i = _selUnit->getArmor()->getInventorySlots().cbegin(); i != _selUnit->getArmor()->getInventorySlots().cend(); i++)
 	{
-		if (i->second->checkSlotInPosition(x, y))
+		RuleInventory *ruleI = (*_game->getMod()->getInventories())[*i];
+		if (ruleI->checkSlotInPosition(x, y))
 		{
-			return i->second;
+			return ruleI;
 		}
 	}
 	return 0;

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -2480,6 +2480,7 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 	auto rightWeapon = action->actor->getRightHandWeapon();
 	auto leftWeapon = action->actor->getLeftHandWeapon();
 	auto unit = action->actor;
+	auto armor = unit->getArmor();
 
 	auto reloadWeapon = [&unit](BattleItem* weapon, BattleItem* i)
 	{
@@ -2528,28 +2529,28 @@ bool BattlescapeGame::takeItem(BattleItem* item, BattleAction *action)
 		}
 		else
 		{
-			placed = equipItem(mod->getInventory("STR_BELT", true), item);
+			placed = equipItem(mod->getInventory(armor->getDefaultInventoryMap("STR_BELT"), true), item);
 		}
 		break;
 	case BT_GRENADE:
 	case BT_PROXIMITYGRENADE:
-		placed = equipItem(mod->getInventory("STR_BELT", true), item);
+		placed = equipItem(mod->getInventory(armor->getDefaultInventoryMap("STR_BELT"), true), item);
 		break;
 	case BT_FIREARM:
 	case BT_MELEE:
 		if (!rightWeapon)
 		{
-			placed = equipItem(mod->getInventory("STR_RIGHT_HAND", true), item);
+			placed = equipItem(mod->getInventory(armor->getDefaultInventoryMap("STR_RIGHT_HAND"), true), item);
 		}
 		break;
 	case BT_MEDIKIT:
 	case BT_SCANNER:
-		placed = equipItem(mod->getInventory("STR_BACK_PACK", true), item);
+		placed = equipItem(mod->getInventory(armor->getDefaultInventoryMap("STR_BACK_PACK"), true), item);
 		break;
 	case BT_MINDPROBE:
 		if (!leftWeapon)
 		{
-			placed = equipItem(mod->getInventory("STR_LEFT_HAND", true), item);
+			placed = equipItem(mod->getInventory(armor->getDefaultInventoryMap("STR_LEFT_HAND"), true), item);
 		}
 		break;
 	default: break;

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -490,14 +490,13 @@ void BattlescapeGenerator::nextStage()
 	{
 		_save->selectNextPlayerUnit();
 	}
-	RuleInventory *ground = _game->getMod()->getInventory("STR_GROUND", true);
 
 	for (std::vector<BattleItem*>::iterator i = takeToNextStage.begin(); i != takeToNextStage.end(); ++i)
 	{
 		_save->getItems()->push_back(*i);
-		if ((*i)->getSlot() == ground)
+		if ((*i)->getSlot() == _inventorySlotGround)
 		{
-			_craftInventoryTile->addItem(*i, ground);
+			_craftInventoryTile->addItem(*i, _inventorySlotGround);
 			if ((*i)->getUnit())
 			{
 				_craftInventoryTile->setUnit((*i)->getUnit());
@@ -672,8 +671,6 @@ void BattlescapeGenerator::run()
 void BattlescapeGenerator::deployXCOM(const RuleStartingCondition *startingCondition)
 {
 	_save->setStartingConditionType(startingCondition != 0 ? startingCondition->getType() : "");
-
-	RuleInventory *ground = _game->getMod()->getInventory("STR_GROUND", true);
 
 	if (_craft != 0)
 		_base = _craft->getBase();
@@ -899,7 +896,7 @@ void BattlescapeGenerator::deployXCOM(const RuleStartingCondition *startingCondi
 	tempItemList = *_craftInventoryTile->getInventory();
 
 	// auto-equip soldiers (only soldiers without layout) and clean up moved items
-	autoEquip(*_save->getUnits(), _game->getMod(), &tempItemList, ground, _worldShade, _allowAutoLoadout, false);
+	autoEquip(*_save->getUnits(), _game->getMod(), &tempItemList, _inventorySlotGround, _worldShade, _allowAutoLoadout, false);
 }
 
 void BattlescapeGenerator::autoEquip(std::vector<BattleUnit*> units, Mod *mod, std::vector<BattleItem*> *craftInv,
@@ -1339,7 +1336,7 @@ bool BattlescapeGenerator::placeItemByLayout(BattleItem *item, const std::vector
 			{
 				if (itemType != layoutItem->getItemType()) continue;
 
-				auto inventorySlot = _game->getMod()->getInventory(layoutItem->getSlot(), true);
+				auto inventorySlot = _game->getMod()->getInventory(unit->getArmor()->getDefaultInventoryMap(layoutItem->getSlot()), true);
 
 				if (unit->getItem(inventorySlot, layoutItem->getSlotX(), layoutItem->getSlotY())) continue;
 
@@ -1564,7 +1561,7 @@ int BattlescapeGenerator::loadMAP(MapBlock *mapblock, int xoff, int yoff, int zo
 
 				BattleItem *item = new BattleItem(rule, _save->getCurrentItemId());
 				_save->getItems()->push_back(item);
-				_save->getTile(i->position + Position(xoff, yoff, zoff))->addItem(item, _game->getMod()->getInventory("STR_GROUND"));
+				_save->getTile(i->position + Position(xoff, yoff, zoff))->addItem(item, _inventorySlotGround);
 			}
 		}
 	}

--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -218,14 +218,11 @@ InventoryState::InventoryState(bool tu, BattlescapeState *parent, Base *base, bo
 	_btnRank->onMouseIn((ActionHandler)&InventoryState::txtTooltipIn);
 	_btnRank->onMouseOut((ActionHandler)&InventoryState::txtTooltipOut);
 
-	if (!_game->getMod()->getInventoryOverlapsPaperdoll())
-	{
-		_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClick);
-		_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClickRight, SDL_BUTTON_RIGHT);
-		_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClickMiddle, SDL_BUTTON_MIDDLE);
-		_btnArmor->onMouseIn((ActionHandler)&InventoryState::txtArmorTooltipIn);
-		_btnArmor->onMouseOut((ActionHandler)&InventoryState::txtArmorTooltipOut);
-	}
+	_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClick);
+	_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClickRight, SDL_BUTTON_RIGHT);
+	_btnArmor->onMouseClick((ActionHandler)&InventoryState::btnArmorClickMiddle, SDL_BUTTON_MIDDLE);
+	_btnArmor->onMouseIn((ActionHandler)&InventoryState::txtArmorTooltipIn);
+	_btnArmor->onMouseOut((ActionHandler)&InventoryState::txtArmorTooltipOut);
 
 	_btnCreateTemplate->onMouseClick((ActionHandler)&InventoryState::btnCreateTemplateClick);
 	_btnCreateTemplate->onKeyboardPress((ActionHandler)&InventoryState::btnCreateTemplateClick, Options::keyInvCreateTemplate);
@@ -259,9 +256,9 @@ InventoryState::InventoryState(bool tu, BattlescapeState *parent, Base *base, bo
 		updateTemplateButtons(true);
 	}
 
-	_inv->draw();
 	_inv->setTuMode(_tu);
 	_inv->setSelectedUnit(_game->getSavedGame()->getSavedBattle()->getSelectedUnit());
+	_inv->draw();
 	_inv->onMouseClick((ActionHandler)&InventoryState::invClick, 0);
 	_inv->onMouseOver((ActionHandler)&InventoryState::invMouseOver);
 	_inv->onMouseOut((ActionHandler)&InventoryState::invMouseOut);
@@ -458,6 +455,7 @@ void InventoryState::init()
 		_inv->arrangeGround();
 	}
 
+	_inv->draw();
 	updateStats();
 	refreshMouse();
 }
@@ -596,6 +594,11 @@ void InventoryState::btnArmorClick(Action *action)
 
 	// equipment in the base
 	BattleUnit *unit = _battleGame->getSelectedUnit();
+	if (!unit || unit->getArmor()->inventoryOverlapsPaperdoll())
+	{
+		//no unit or armor inventory overlaps paperdoll
+		return;
+	}
 	Soldier *s = unit->getGeoscapeSoldier();
 
 	if (!(s->getCraft() && s->getCraft()->getStatus() == "STR_OUT"))
@@ -628,6 +631,11 @@ void InventoryState::btnArmorClickRight(Action *action)
 
 	// equipment in the base
 	BattleUnit *unit = _battleGame->getSelectedUnit();
+	if (!unit || unit->getArmor()->inventoryOverlapsPaperdoll())
+	{
+		//armor inventory overlaps paperdoll
+		return;
+	}
 	Soldier *s = unit->getGeoscapeSoldier();
 
 	if (!(s->getCraft() && s->getCraft()->getStatus() == "STR_OUT"))
@@ -654,6 +662,11 @@ void InventoryState::btnArmorClickMiddle(Action *action)
 	BattleUnit *unit = _inv->getSelectedUnit();
 	if (unit != 0)
 	{
+		if (unit->getArmor()->inventoryOverlapsPaperdoll())
+		{
+			//armor inventory overlaps paperdoll
+			return;
+		}
 		std::string articleId = unit->getArmor()->getType();
 		Ufopaedia::openArticle(_game, articleId);
 	}
@@ -1652,6 +1665,11 @@ void InventoryState::txtArmorTooltipIn(Action *action)
 		BattleUnit *unit = _inv->getSelectedUnit();
 		if (unit != 0)
 		{
+			if (unit->getArmor()->inventoryOverlapsPaperdoll())
+			{
+				//armor inventory overlaps paperdoll
+				return;
+			}
 			action->getSender()->setTooltip(unit->getArmor()->getType());
 			_currentTooltip = action->getSender()->getTooltip();
 			if (Options::showItemNameAndWeightInInventory)
@@ -1677,6 +1695,12 @@ void InventoryState::txtArmorTooltipIn(Action *action)
 */
 void InventoryState::txtArmorTooltipOut(Action *action)
 {
+	BattleUnit *unit = _battleGame->getSelectedUnit();
+	if (!unit || unit->getArmor()->inventoryOverlapsPaperdoll())
+	{
+		//no unit or armor inventory overlaps paperdoll
+		return;
+	}
 	if (_inv->getSelectedItem() == 0)
 	{
 		if (_currentTooltip == action->getSender()->getTooltip())

--- a/src/Mod/Armor.h
+++ b/src/Mod/Armor.h
@@ -76,17 +76,21 @@ private:
 	RuleStatBonus _timeRecovery, _energyRecovery, _moraleRecovery, _healthRecovery, _stunRecovery;
 	ModScript::BattleUnitScripts::Container _battleUnitScripts;
 
-	std::vector<std::string> _units;
 	ScriptValues<Armor> _scriptValues;
 	std::vector<int> _customArmorPreviewIndex;
 	bool _allowsRunning, _allowsStrafing, _allowsKneeling, _allowsMoving;
 	bool _instantWoundRecovery;
 	int _standHeight, _kneelHeight, _floatHeight;
+	std::vector<std::string> _units, _inventorySlots;
+	std::map<std::string, std::string> _defaultInventoriesMap;
+	bool _inventoryOverlapsPaperdoll;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type);
 	/// Cleans up the armor ruleset.
 	~Armor();
+	/// Cross link with other rules.
+	void afterLoad(const Mod* mod);
 	/// Loads the armor data from YAML.
 	void load(const YAML::Node& node, const ModScript& parsers, Mod *mod);
 	/// Gets the armor's type.
@@ -255,6 +259,12 @@ public:
 	int getKneelHeight() const;
 	/// Gets a unit's float elevation while wearing this armor.
 	int getFloatHeight() const;
+	/// Gets the armor's inventory slots.
+	const std::vector<std::string> &getInventorySlots() const;
+	/// Gets the default inventory rules mapping
+	std::string getDefaultInventoryMap(std::string s) const;
+	/// Inventory overlaps paperdoll
+	bool inventoryOverlapsPaperdoll() const;
 };
 
 }

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -278,7 +278,6 @@ public:
  * Creates an empty mod.
  */
 Mod::Mod() :
-	_inventoryOverlapsPaperdoll(false),
 	_maxViewDistance(20), _maxDarknessToSeeUnits(9), _maxStaticLightDistance(16), _maxDynamicLightDistance(24), _enhancedLighting(0),
 	_costHireEngineer(0), _costHireScientist(0),
 	_costEngineer(0), _costScientist(0), _timePersonnel(0), _initialFunding(0),
@@ -1060,35 +1059,12 @@ void Mod::loadAll(const std::vector< std::pair< std::string, std::vector<std::st
 		j->second->updateCategories(&replacementRules);
 	}
 
-	// find out if paperdoll overlaps with inventory slots
-	int x1 = RuleInventory::PAPERDOLL_X;
-	int y1 = RuleInventory::PAPERDOLL_Y;
-	int w1 = RuleInventory::PAPERDOLL_W;
-	int h1 = RuleInventory::PAPERDOLL_H;
-	for (auto invCategory : _invs)
-	{
-		for (auto invSlot : *invCategory.second->getSlots())
-		{
-			int x2 = invCategory.second->getX() + (invSlot.x * RuleInventory::SLOT_W);
-			int y2 = invCategory.second->getY() + (invSlot.y * RuleInventory::SLOT_H);
-			int w2 = RuleInventory::SLOT_W;
-			int h2 = RuleInventory::SLOT_H;
-			if (x1 + w1 < x2 || x2 + w2 < x1 || y1 + h1 < y2 || y2 + h2 < y1)
-			{
-				// intersection is empty
-			}
-			else
-			{
-				_inventoryOverlapsPaperdoll = true;
-			}
-		}
-	}
-
 	afterLoadHelper("research", this, _research, &RuleResearch::afterLoad);
 	afterLoadHelper("items", this, _items, &RuleItem::afterLoad);
 	afterLoadHelper("manufacture", this, _manufacture, &RuleManufacture::afterLoad);
 	afterLoadHelper("units", this, _units, &Unit::afterLoad);
 	afterLoadHelper("facilities", this, _facilities, &RuleBaseFacility::afterLoad);
+	afterLoadHelper("armors", this, _armors, &Armor::afterLoad);
 
 	// fixed user options
 	if (!_fixedUserOptions.empty())

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -128,7 +128,6 @@ private:
 	std::map<std::string, Armor*> _armors;
 	std::map<std::string, ArticleDefinition*> _ufopaediaArticles;
 	std::map<std::string, RuleInventory*> _invs;
-	bool _inventoryOverlapsPaperdoll;
 	std::map<std::string, RuleResearch *> _research;
 	std::map<std::string, RuleManufacture *> _manufacture;
 	std::map<std::string, RuleSoldierTransformation *> _soldierTransformation;
@@ -413,8 +412,6 @@ public:
 	std::map<std::string, RuleInventory*> *getInventories();
 	/// Gets the ruleset for a specific inventory.
 	RuleInventory *getInventory(const std::string &id, bool error = false) const;
-	/// Gets whether or not the inventory slots overlap with the paperdoll button
-	bool getInventoryOverlapsPaperdoll() const { return _inventoryOverlapsPaperdoll; }
 	/// Gets max view distance in BattleScape.
 	int getMaxViewDistance() const { return _maxViewDistance; }
 	/// Gets threshold of darkness for LoS calculation.

--- a/src/Mod/RuleInventory.cpp
+++ b/src/Mod/RuleInventory.cpp
@@ -19,6 +19,7 @@
 #include "RuleInventory.h"
 #include <cmath>
 #include "RuleItem.h"
+#include "../Savegame/BattleUnit.h"
 
 namespace YAML
 {
@@ -48,12 +49,14 @@ namespace YAML
 namespace OpenXcom
 {
 
+const std::vector<std::string> RuleInventory::DefaultInventories = { "STR_GROUND", "STR_RIGHT_HAND", "STR_LEFT_HAND", "STR_BELT", "STR_RIGHT_LEG", "STR_LEFT_LEG", "STR_RIGHT_SHOULDER", "STR_LEFT_SHOULDER", "STR_BACK_PACK" };
+
 /**
  * Creates a blank ruleset for a certain
  * type of inventory section.
  * @param id String defining the id.
  */
-RuleInventory::RuleInventory(const std::string &id): _id(id), _x(0), _y(0), _type(INV_SLOT), _listOrder(0), _hand(0)
+RuleInventory::RuleInventory(const std::string &id): _id(id), _x(0), _y(0), _type(INV_SLOT), _listOrder(0)
 {
 }
 
@@ -79,18 +82,6 @@ void RuleInventory::load(const YAML::Node &node, int listOrder)
 	_slots = node["slots"].as< std::vector<RuleSlot> >(_slots);
 	_costs = node["costs"].as< std::map<std::string, int> >(_costs);
 	_listOrder = node["listOrder"].as<int>(listOrder);
-	if (_id == "STR_RIGHT_HAND")
-	{
-		_hand = 2;
-	}
-	else if (_id == "STR_LEFT_HAND")
-	{
-		_hand = 1;
-	}
-	else
-	{
-		_hand = 0;
-	}
 }
 
 /**
@@ -131,24 +122,6 @@ int RuleInventory::getY() const
 InventoryType RuleInventory::getType() const
 {
 	return _type;
-}
-
-/**
- * Gets if this slot is right hand.
- * @return This is right hand.
- */
-bool RuleInventory::isRightHand() const
-{
-	return _hand == 2;
-}
-
-/**
- * Gets if this slot is left hand.
- * @return This is wrong hand.
- */
-bool RuleInventory::isLeftHand() const
-{
-	return _hand == 1;
 }
 
 /**

--- a/src/Mod/RuleInventory.h
+++ b/src/Mod/RuleInventory.h
@@ -33,6 +33,7 @@ struct RuleSlot
 enum InventoryType { INV_SLOT, INV_HAND, INV_GROUND };
 
 class RuleItem;
+class BattleUnit;
 
 /**
  * Represents a specific section of the inventory,
@@ -48,7 +49,6 @@ private:
 	std::vector<RuleSlot> _slots;
 	std::map<std::string, int> _costs;
 	int _listOrder;
-	int _hand;
 public:
 	static const int SLOT_W = 16;
 	static const int SLOT_H = 16;
@@ -58,6 +58,7 @@ public:
 	static const int PAPERDOLL_H = 70;
 	static const int PAPERDOLL_X = 60;
 	static const int PAPERDOLL_Y = 65;
+	static const std::vector<std::string> DefaultInventories;
 	/// Creates a blank inventory ruleset.
 	RuleInventory(const std::string &id);
 	/// Cleans up the inventory ruleset.
@@ -72,10 +73,6 @@ public:
 	int getY() const;
 	/// Gets the inventory type.
 	InventoryType getType() const;
-	/// Gets if this slot is right hand;
-	bool isRightHand() const;
-	/// Gets if this slot is left hand;
-	bool isLeftHand() const;
 	/// Gets all the slots in the inventory.
 	std::vector<struct RuleSlot> *getSlots();
 	/// Checks for a slot in a certain position.

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -2260,8 +2260,8 @@ bool BattleUnit::fitItemToInventory(RuleInventory *slot, BattleItem *item)
  */
 bool BattleUnit::addItem(BattleItem *item, const Mod *mod, bool allowSecondClip, bool allowAutoLoadout, bool allowUnloadedWeapons)
 {
-	RuleInventory *rightHand = mod->getInventory("STR_RIGHT_HAND");
-	RuleInventory *leftHand = mod->getInventory("STR_LEFT_HAND");
+	RuleInventory *rightHand = mod->getInventory(_armor->getDefaultInventoryMap("STR_RIGHT_HAND"));
+	RuleInventory *leftHand = mod->getInventory(_armor->getDefaultInventoryMap("STR_LEFT_HAND"));
 	bool placed = false;
 	bool loaded = false;
 	const RuleItem *rule = item->getRules();
@@ -2414,7 +2414,7 @@ bool BattleUnit::addItem(BattleItem *item, const Mod *mod, bool allowSecondClip,
 		{
 			if (getBaseStats()->strength >= weight) // weight is always considered 0 for aliens
 			{
-				for (const std::string &s : mod->getInvsList())
+				for (const std::string &s : _armor->getInventorySlots())
 				{
 					RuleInventory *slot = mod->getInventory(s);
 					if (slot->getType() == INV_SLOT)
@@ -2541,7 +2541,7 @@ Tile *BattleUnit::getTile() const
  * @param y Y position in slot.
  * @return Item in the slot, or NULL if none.
  */
-BattleItem *BattleUnit::getItem(RuleInventory *slot, int x, int y) const
+BattleItem *BattleUnit::getItem(const RuleInventory *slot, int x, int y) const
 {
 	// Soldier items
 	if (slot->getType() != INV_GROUND)
@@ -2719,7 +2719,7 @@ BattleItem *BattleUnit::getRightHandWeapon() const
 	for (auto i : _inventory)
 	{
 		auto slot = i->getSlot();
-		if (slot && slot->isRightHand())
+		if (slot && _armor->getDefaultInventoryMap("STR_RIGHT_HAND") == slot->getId())
 		{
 			return i;
 		}
@@ -2736,7 +2736,7 @@ BattleItem *BattleUnit::getLeftHandWeapon() const
 	for (auto i : _inventory)
 	{
 		auto slot = i->getSlot();
-		if (slot && slot->isLeftHand())
+		if (slot && _armor->getDefaultInventoryMap("STR_LEFT_HAND") == slot->getId())
 		{
 			return i;
 		}

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -372,7 +372,7 @@ public:
 	/// Gets the unit's tile.
 	Tile *getTile() const;
 	/// Gets the item in the specified slot.
-	BattleItem *getItem(RuleInventory *slot, int x = 0, int y = 0) const;
+	BattleItem *getItem(const RuleInventory *slot, int x = 0, int y = 0) const;
 	/// Gets the item in the specified slot.
 	BattleItem *getItem(const std::string &slot, int x = 0, int y = 0) const;
 	/// Gets the item in the main hand.


### PR DESCRIPTION
Creation inspired by the workarounds Solarius_Scorch did in the XCOM-Files mod to hide some inventory slots...
This PR will allow to create many overloading inventory rules (different size of e.g. belts, backpacks, etc.), which may overlap, and they may even have no slots and blank ("") label to be fully hidden besides being fully unusable.
Modding descriptions =>
Each armor rule may contain an inventorySlots vector stating the inventory rules this armor has - e.g.:
inventorySlots:
- STR_GROUND
- STR_RIGHT_HAND
- STR_LEFT_HAND
- STR_SMALL_BELT
- STR_SMALL_RIGHT_LEG
- STR_SMALL_LEFT_LEG
- STR_RIGHT_SHOULDER
- STR_LEFT_SHOULDER
- STR_SMALL_BACK_PACK
Plus a map which will map the overloaded inventory rules to new ones:
defaultInventoriesMap:
  STR_BELT: STR_SMALL_BELT
  STR_RIGHT_LEG: STR_SMALL_RIGHT_LEG
  STR_LEFT_LEG: STR_SMALL_LEFT_LEG
  STR_BACK_PACK: STR_SMALL_BACK_PACK
Both are optional, the default existing inventory rules and armors will work without any change.
The new inventory rules shall  (aside of being defined) have, of course, the appropriate translations also.