### PR TITLE
Inventories by armor revised

### DIFF
--- a/bin/standard/xcom1/inventories.rul
+++ b/bin/standard/xcom1/inventories.rul
@@ -16,6 +16,13 @@ invs:
     x: 0
     y: 63
     type: 1
+    slots:
+      - [0, 0]
+      - [0, 1]
+      - [0, 2]
+      - [1, 0]
+      - [1, 1]
+      - [1, 2]
     costs:
       STR_BACK_PACK: 14
       STR_BELT: 8
@@ -29,6 +36,13 @@ invs:
     x: 128
     y: 63
     type: 1
+    slots:
+      - [0, 0]
+      - [0, 1]
+      - [0, 2]
+      - [1, 0]
+      - [1, 1]
+      - [1, 2]
     costs:
       STR_BACK_PACK: 14
       STR_BELT: 8

--- a/bin/standard/xcom2/inventories.rul
+++ b/bin/standard/xcom2/inventories.rul
@@ -16,6 +16,13 @@ invs:
     x: 0
     y: 63
     type: 1
+    slots:
+      - [0, 0]
+      - [0, 1]
+      - [1, 0]
+      - [1, 1]
+      - [2, 0]
+      - [2, 1]
     costs:
       STR_BACK_PACK: 14
       STR_BELT: 8
@@ -29,6 +36,13 @@ invs:
     x: 128
     y: 63
     type: 1
+    slots:
+      - [0, 0]
+      - [0, 1]
+      - [1, 0]
+      - [1, 1]
+      - [2, 0]
+      - [2, 1]
     costs:
       STR_BACK_PACK: 14
       STR_BELT: 8

--- a/src/Battlescape/AlienInventory.cpp
+++ b/src/Battlescape/AlienInventory.cpp
@@ -112,34 +112,8 @@ void AlienInventory::drawGrid()
 	RuleInterface *rule = _game->getMod()->getInterface("inventory");
 	Uint8 color = rule->getElement("grid")->color;
 
-	for (std::map<std::string, RuleInventory*>::iterator i = _game->getMod()->getInventories()->begin(); i != _game->getMod()->getInventories()->end(); ++i)
-	{
-		if (i->second->getType() == INV_HAND)
-		{
-			SDL_Rect r;
-			r.x = i->second->getX();
-			r.x += _game->getMod()->getAlienInventoryOffsetX();
-
-			if (i->second->getId() == "STR_RIGHT_HAND")
-				r.x -= _dynamicOffset;
-			else if (i->second->getId() == "STR_LEFT_HAND")
-				r.x += _dynamicOffset;
-
-			r.y = i->second->getY();
-			r.w = RuleInventory::HAND_W * RuleInventory::SLOT_W;
-			r.h = RuleInventory::HAND_H * RuleInventory::SLOT_H;
-			_grid->drawRect(&r, color);
-			r.x++;
-			r.y++;
-			r.w -= 2;
-			r.h -= 2;
-			_grid->drawRect(&r, 0);
-		}
-		else
-		{
-			continue;
-		}
-	}
+	if (_selUnit != 0) for (auto i : _selUnit->getArmor()->getInventorySlots())
+		i->draw(_grid, color);
 }
 
 /**
@@ -159,9 +133,9 @@ void AlienInventory::drawItems()
 				int x = (*i)->getSlot()->getX() + (*i)->getRules()->getHandSpriteOffX();
 				x += _game->getMod()->getAlienInventoryOffsetX();
 
-				if ((*i)->getSlot()->getId() == "STR_RIGHT_HAND")
+				if ((*i)->getSlot()->isRightHand())
 					x -= _dynamicOffset;
-				else if ((*i)->getSlot()->getId() == "STR_LEFT_HAND")
+				else if ((*i)->getSlot()->isLeftHand())
 					x += _dynamicOffset;
 
 				frame->blitNShade(_items, x, (*i)->getSlot()->getY() + (*i)->getRules()->getHandSpriteOffY());

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -1489,7 +1489,15 @@ bool BattlescapeGenerator::placeItemByLayout(BattleItem *item, const std::vector
 				if (itemType != layoutItem->getItemType()) continue;
 
 				auto inventorySlot = _game->getMod()->getInventory(layoutItem->getSlot(), true);
-
+				bool hasSlot = false;
+				for(auto inv:unit->getArmor()->getInventorySlots())
+					if (inv == inventorySlot)
+					{
+						hasSlot = true;
+						break;
+					}
+				if (!hasSlot)
+					continue;
 				if (unit->getItem(inventorySlot, layoutItem->getSlotX(), layoutItem->getSlotY())) continue;
 
 				auto toLoad = 0;

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1362,7 +1362,7 @@ void BattlescapeState::btnLeftHandItemClick(Action *action)
 
 		_battleGame->cancelCurrentAction();
 
-		_save->getSelectedUnit()->setActiveHand("STR_LEFT_HAND");
+		_save->getSelectedUnit()->setActiveHand(_save->getSelectedUnit()->getArmor()->getLeftHand()->getId());
 		_map->draw();
 		BattleItem *leftHandItem = _save->getSelectedUnit()->getLeftHandWeapon();
 		if (!leftHandItem)
@@ -1402,7 +1402,7 @@ void BattlescapeState::btnRightHandItemClick(Action *action)
 
 		_battleGame->cancelCurrentAction();
 
-		_save->getSelectedUnit()->setActiveHand("STR_RIGHT_HAND");
+		_save->getSelectedUnit()->setActiveHand(_save->getSelectedUnit()->getArmor()->getRightHand()->getId());
 		_map->draw();
 		BattleItem *rightHandItem = _save->getSelectedUnit()->getRightHandWeapon();
 		if (!rightHandItem)
@@ -1687,8 +1687,8 @@ void BattlescapeState::drawItem(BattleItem* item, Surface* hand, std::vector<Num
 		{
 			const int Pulsate[8] = { 0, 1, 2, 3, 4, 3, 2, 1 };
 			Surface *tempSurface = _game->getMod()->getSurfaceSet("SCANG.DAT")->getFrame(6);
-			int x = (RuleInventory::HAND_W - rule->getInventoryWidth()) * RuleInventory::SLOT_W / 2;
-			int y = (RuleInventory::HAND_H - rule->getInventoryHeight()) * RuleInventory::SLOT_H / 2;
+			int x = (RuleInventory::MAX_HAND_W - rule->getInventoryWidth()) * RuleInventory::SLOT_W / 2;
+			int y = (RuleInventory::MAX_HAND_H - rule->getInventoryHeight()) * RuleInventory::SLOT_H / 2;
 			tempSurface->blitNShade(hand, x, y, Pulsate[_save->getAnimFrame() % 8], false, item->isFuseEnabled() ? 0 : 32);
 		}
 	}
@@ -3036,7 +3036,7 @@ void BattlescapeState::txtTooltipInExtra(Action *action, bool leftHand, bool spe
 		BattleItem *weapon;
 		if (leftHand)
 		{
-			weapon = selectedUnit->getItem("STR_LEFT_HAND");
+			weapon = selectedUnit->getItem(selectedUnit->getArmor()->getRightHand()->getId());
 		}
 		else if (special)
 		{
@@ -3045,7 +3045,7 @@ void BattlescapeState::txtTooltipInExtra(Action *action, bool leftHand, bool spe
 		}
 		else
 		{
-			weapon = selectedUnit->getItem("STR_RIGHT_HAND");
+			weapon = selectedUnit->getItem(selectedUnit->getArmor()->getRightHand()->getId());
 		}
 
 		// no weapon selected... do normal tooltip

--- a/src/Battlescape/Inventory.h
+++ b/src/Battlescape/Inventory.h
@@ -58,14 +58,13 @@ private:
 	int _depth, _groundSlotsX, _groundSlotsY;
 	RuleInventory *_inventorySlotRightHand = nullptr;
 	RuleInventory *_inventorySlotLeftHand = nullptr;
-	RuleInventory *_inventorySlotBackPack = nullptr;
-	RuleInventory *_inventorySlotBelt = nullptr;
 	RuleInventory *_inventorySlotGround = nullptr;
+	std::vector<RuleInventory*> _inventories;
 
 	/// Clear all occupied slots markers.
 	std::vector<std::vector<char>>* clearOccupiedSlotsCache();
 	/// Moves an item to a specified slot.
-	void moveItem(BattleItem *item, RuleInventory *slot, int x, int y);
+	void moveItem(BattleItem *item, const RuleInventory *slot, int x, int y);
 	/// Gets the slot in the specified position.
 	RuleInventory *getSlotInPosition(int *x, int *y) const;
 public:
@@ -116,11 +115,11 @@ public:
 	/// Arranges items on the ground.
 	void arrangeGround(int alterOffset = 0);
 	/// Attempts to place an item in an inventory slot.
-	bool fitItem(RuleInventory *newSlot, BattleItem *item, std::string &warning);
+	bool fitItem(const RuleInventory *newSlot, BattleItem *item, std::string &warning);
 	/// Checks if two items can be stacked on one another.
 	bool canBeStacked(BattleItem *itemA, BattleItem *itemB);
 	/// Checks for item overlap.
-	static bool overlapItems(BattleUnit *unit, BattleItem *item, RuleInventory *slot, int x = 0, int y = 0);
+	static bool overlapItems(BattleUnit *unit, BattleItem *item, const RuleInventory *slot, int x = 0, int y = 0);
 	/// Shows a warning message.
 	void showWarning(const std::string &msg);
 	/// Animate surface.

--- a/src/Battlescape/InventoryState.h
+++ b/src/Battlescape/InventoryState.h
@@ -56,7 +56,7 @@ private:
 	const bool _tu, _noCraft;
 	BattlescapeState *_parent;
 	Base *_base;
-	std::string _currentTooltip;
+	std::string _currentTooltip, _armorToolTip;
 	std::string _currentDamageTooltip;
 	int _mouseHoverItemFrame = 0;
 	BattleItem *_mouseHoverItem = nullptr;

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -4180,7 +4180,7 @@ void TileEngine::itemDropInventory(Tile *t, BattleUnit *unit, bool unprimeItems,
 /**
  * Move item to other place in inventory or ground.
  */
-void TileEngine::itemMoveInventory(Tile *t, BattleUnit *unit, BattleItem *item, RuleInventory *slot, int x, int y)
+void TileEngine::itemMoveInventory(Tile *t, BattleUnit *unit, BattleItem *item, const RuleInventory *slot, int x, int y)
 {
 	// Handle dropping from/to ground.
 	if (slot != item->getSlot())

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -217,7 +217,7 @@ public:
 	/// Drop all unit items on ground.
 	void itemDropInventory(Tile *t, BattleUnit *unit, bool unprimeItems = false, bool deleteFixedItems = false);
 	/// Move item to other place in inventory or ground.
-	void itemMoveInventory(Tile *t, BattleUnit *unit, BattleItem *item, RuleInventory *slot, int x, int y);
+	void itemMoveInventory(Tile *t, BattleUnit *unit, BattleItem *item, const RuleInventory *slot, int x, int y);
 
 	/// Add moving unit.
 	void addMovingUnit(BattleUnit* unit);

--- a/src/Battlescape/UnitSprite.cpp
+++ b/src/Battlescape/UnitSprite.cpp
@@ -949,7 +949,7 @@ void UnitSprite::drawRoutine4()
 		}
 		else
 		{
-			if (_itemR->getSlot()->getId() == "STR_RIGHT_HAND")
+			if (_itemR->getSlot() == _unit->getArmor()->getRightHand())
 			{
 				selectItem(itemR, _itemR, unitDir);
 				itemR.offX = (0);
@@ -1460,7 +1460,7 @@ void UnitSprite::sortRifles()
 	{
 		if (_itemL && _itemL->getRules()->isTwoHanded())
 		{
-			if (_unit->getActiveHand() == "STR_LEFT_HAND")
+			if (_unit->getActiveHand() == _unit->getArmor()->getLeftHand()->getId())
 			{
 				_itemR = _itemL;
 			}

--- a/src/Mod/Armor.h
+++ b/src/Mod/Armor.h
@@ -25,6 +25,7 @@
 #include "RuleStatBonus.h"
 #include "RuleDamageType.h"
 #include "ModScript.h"
+#include "RuleInventory.h"
 
 namespace OpenXcom
 {
@@ -83,12 +84,16 @@ private:
 	RuleStatBonus _timeRecovery, _energyRecovery, _moraleRecovery, _healthRecovery, _stunRecovery, _manaRecovery;
 	ModScript::BattleUnitScripts::Container _battleUnitScripts;
 
-	std::vector<std::string> _units;
+	std::vector<std::string> _units, _inventorySlots;
 	ScriptValues<Armor> _scriptValues;
 	std::vector<int> _customArmorPreviewIndex;
 	Sint8 _allowsRunning, _allowsStrafing, _allowsKneeling, _allowsMoving;
 	bool _instantWoundRecovery;
 	int _standHeight, _kneelHeight, _floatHeight;
+	bool _inventoryOverlapsPaperdoll;
+	std::vector<RuleInventory*> _invRules;
+	RuleInventory *_rhs, *_lhs, *_gnd;
+	bool compCost(const RuleInventory* lop, const RuleInventory* rop) const;
 public:
 	/// Creates a blank armor ruleset.
 	Armor(const std::string &type);
@@ -289,6 +294,15 @@ public:
 	int getKneelHeight() const;
 	/// Gets a unit's float elevation while wearing this armor.
 	int getFloatHeight() const;
+	/// Cross link with other rules.
+	void afterLoad(const Mod * mod);
+	/// Gets the armor's inventory slots, cost-ordered wrt utilization.
+	const std::vector<RuleInventory*> getInventorySlots() const { return _invRules; }
+	/// coordinate is in the armor's inventory slots
+	bool isCoordInInventory(int x, int y) const;
+	const RuleInventory* getRightHand() const { return _rhs; }
+	const RuleInventory* getLeftHand() const { return _lhs; }
+	const RuleInventory* getGround() const { return _gnd; }
 };
 
 }

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -308,7 +308,6 @@ public:
  * Creates an empty mod.
  */
 Mod::Mod() :
-	_inventoryOverlapsPaperdoll(false),
 	_maxViewDistance(20), _maxDarknessToSeeUnits(9), _maxStaticLightDistance(16), _maxDynamicLightDistance(24), _enhancedLighting(0),
 	_costHireEngineer(0), _costHireScientist(0),
 	_costEngineer(0), _costScientist(0), _timePersonnel(0), _initialFunding(0),
@@ -336,7 +335,7 @@ Mod::Mod() :
 	_defeatScore(0), _defeatFunds(0), _startingTime(6, 1, 1, 1999, 12, 0, 0), _startingDifficulty(0),
 	_baseDefenseMapFromLocation(0), _disableUnderwaterSounds(false), _enableUnitResponseSounds(false), _pediaReplaceCraftFuelWithRangeType(-1),
 	_facilityListOrder(0), _craftListOrder(0), _itemCategoryListOrder(0), _itemListOrder(0),
-	_researchListOrder(0),  _manufactureListOrder(0), _transformationListOrder(0), _ufopaediaListOrder(0), _invListOrder(0), _soldierListOrder(0), _modCurrent(0), _statePalette(0)
+	_researchListOrder(0),  _manufactureListOrder(0), _transformationListOrder(0), _ufopaediaListOrder(0), _invListOrder(0), _soldierListOrder(0), _modCurrent(0), _statePalette(0), _explicitInventoriesByArmor(false)
 {
 	_muteMusic = new Music();
 	_muteSound = new Sound();
@@ -1322,30 +1321,6 @@ void Mod::loadAll()
 		j->second->updateCategories(&replacementRules);
 	}
 
-	// find out if paperdoll overlaps with inventory slots
-	int x1 = RuleInventory::PAPERDOLL_X;
-	int y1 = RuleInventory::PAPERDOLL_Y;
-	int w1 = RuleInventory::PAPERDOLL_W;
-	int h1 = RuleInventory::PAPERDOLL_H;
-	for (auto invCategory : _invs)
-	{
-		for (auto invSlot : *invCategory.second->getSlots())
-		{
-			int x2 = invCategory.second->getX() + (invSlot.x * RuleInventory::SLOT_W);
-			int y2 = invCategory.second->getY() + (invSlot.y * RuleInventory::SLOT_H);
-			int w2 = RuleInventory::SLOT_W;
-			int h2 = RuleInventory::SLOT_H;
-			if (x1 + w1 < x2 || x2 + w2 < x1 || y1 + h1 < y2 || y2 + h2 < y1)
-			{
-				// intersection is empty
-			}
-			else
-			{
-				_inventoryOverlapsPaperdoll = true;
-			}
-		}
-	}
-
 	afterLoadHelper("research", this, _research, &RuleResearch::afterLoad);
 	afterLoadHelper("items", this, _items, &RuleItem::afterLoad);
 	afterLoadHelper("manufacture", this, _manufacture, &RuleManufacture::afterLoad);
@@ -1353,6 +1328,8 @@ void Mod::loadAll()
 	afterLoadHelper("facilities", this, _facilities, &RuleBaseFacility::afterLoad);
 	afterLoadHelper("enviroEffects", this, _enviroEffects, &RuleEnviroEffects::afterLoad);
 	afterLoadHelper("commendations", this, _commendations, &RuleCommendations::afterLoad);
+	afterLoadHelper("inventories", this, _invs, &RuleInventory::afterLoad);
+	afterLoadHelper("armors", this, _armors, &Armor::afterLoad);
 
 	// fixed user options
 	if (!_fixedUserOptions.empty())
@@ -1831,6 +1808,7 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 	_fontName = doc["fontName"].as<std::string>(_fontName);
 	_psiUnlockResearch = doc["psiUnlockResearch"].as<std::string>(_psiUnlockResearch);
 	_destroyedFacility = doc["destroyedFacility"].as<std::string>(_destroyedFacility);
+	_explicitInventoriesByArmor = doc["explicitInventoriesByArmor"].as<bool>(_explicitInventoriesByArmor);
 
 	_aiUseDelayGrenade = doc["turnAIUseGrenade"].as<int>(_aiUseDelayGrenade);
 	_aiUseDelayBlaster = doc["turnAIUseBlaster"].as<int>(_aiUseDelayBlaster);

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -151,7 +151,7 @@ private:
 	std::map<std::string, Armor*> _armors;
 	std::map<std::string, ArticleDefinition*> _ufopaediaArticles;
 	std::map<std::string, RuleInventory*> _invs;
-	bool _inventoryOverlapsPaperdoll;
+	bool _explicitInventoriesByArmor;
 	std::map<std::string, RuleResearch *> _research;
 	std::map<std::string, RuleManufacture *> _manufacture;
 	std::map<std::string, RuleSoldierBonus *> _soldierBonus;
@@ -471,8 +471,6 @@ public:
 	std::map<std::string, RuleInventory*> *getInventories();
 	/// Gets the ruleset for a specific inventory.
 	RuleInventory *getInventory(const std::string &id, bool error = false) const;
-	/// Gets whether or not the inventory slots overlap with the paperdoll button
-	bool getInventoryOverlapsPaperdoll() const { return _inventoryOverlapsPaperdoll; }
 	/// Gets max view distance in BattleScape.
 	int getMaxViewDistance() const { return _maxViewDistance; }
 	/// Gets threshold of darkness for LoS calculation.
@@ -758,6 +756,11 @@ public:
 	StatAdjustment *getStatAdjustment(int difficulty);
 	int getDefeatScore() const;
 	int getDefeatFunds() const;
+	/// returns explicitInventoriesByArmor mod setting
+	bool getExplicitInventoriesByArmor() const {
+		return _explicitInventoriesByArmor
+			;
+	}
 };
 
 }

--- a/src/Mod/RuleInventory.h
+++ b/src/Mod/RuleInventory.h
@@ -27,12 +27,15 @@ namespace OpenXcom
 
 struct RuleSlot
 {
-	int x, y;
+	int x, y, adj;
+	RuleSlot(int x_ = 0, int y_ = 0, int adj_ = 0) :x(x_), y(y_), adj(adj_) {};
 };
 
 enum InventoryType { INV_SLOT, INV_HAND, INV_GROUND };
 
 class RuleItem;
+class Surface;
+class Mod;
 
 /**
  * Represents a specific section of the inventory,
@@ -41,6 +44,15 @@ class RuleItem;
  */
 class RuleInventory
 {
+public:
+	static const int SLOT_W = 16;
+	static const int SLOT_H = 16;
+	static const int MAX_HAND_W = 2;
+	static const int MAX_HAND_H = 3;
+	static const int PAPERDOLL_W = 40;
+	static const int PAPERDOLL_H = 85;
+	static const int PAPERDOLL_X = 60;
+	static const int PAPERDOLL_Y = 50;
 private:
 	std::string _id;
 	int _x, _y;
@@ -48,16 +60,8 @@ private:
 	std::vector<RuleSlot> _slots;
 	std::map<std::string, int> _costs;
 	int _listOrder;
-	int _hand;
+	int _hand, _handWidth, _handHeight, _fit[MAX_HAND_W][MAX_HAND_H];
 public:
-	static const int SLOT_W = 16;
-	static const int SLOT_H = 16;
-	static const int HAND_W = 2;
-	static const int HAND_H = 3;
-	static const int PAPERDOLL_W = 40;
-	static const int PAPERDOLL_H = 70;
-	static const int PAPERDOLL_X = 60;
-	static const int PAPERDOLL_Y = 65;
 	/// Creates a blank inventory ruleset.
 	RuleInventory(const std::string &id);
 	/// Cleans up the inventory ruleset.
@@ -77,14 +81,18 @@ public:
 	/// Gets if this slot is left hand;
 	bool isLeftHand() const;
 	/// Gets all the slots in the inventory.
-	std::vector<struct RuleSlot> *getSlots();
+	const std::vector<struct RuleSlot> *getSlots() const;
 	/// Checks for a slot in a certain position.
 	bool checkSlotInPosition(int *x, int *y) const;
 	/// Checks if an item fits in a slot.
-	bool fitItemInSlot(const RuleItem *item, int x, int y) const;
+	int fitItemInSlot(const RuleItem *item, int x, int y) const;
 	/// Gets a certain cost in the inventory.
-	int getCost(RuleInventory *slot) const;
-	int getListOrder() const;
+	int getCost(const RuleInventory *slot) const;
+	int getListOrder() const { return _listOrder; };
+	int getHandWidth() const { return _handWidth; };
+	int getHandHeight() const { return _handHeight; };
+	void draw(Surface *, int) const;
+	void afterLoad(const Mod*);
 };
 
 }

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -1572,7 +1572,7 @@ void RuleItem::drawHandSprite(SurfaceSet *texture, Surface *surface, BattleItem 
  */
 int RuleItem::getHandSpriteOffX() const
 {
-	return (RuleInventory::HAND_W - getInventoryWidth()) * RuleInventory::SLOT_W/2;
+	return (RuleInventory::MAX_HAND_W - getInventoryWidth()) * RuleInventory::SLOT_W/2;
 }
 
 /**
@@ -1581,7 +1581,7 @@ int RuleItem::getHandSpriteOffX() const
  */
 int RuleItem::getHandSpriteOffY() const
 {
-	return (RuleInventory::HAND_H - getInventoryHeight()) * RuleInventory::SLOT_H/2;
+	return (RuleInventory::MAX_HAND_H - getInventoryHeight()) * RuleInventory::SLOT_H/2;
 }
 
 /**

--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -524,7 +524,7 @@ void BattleItem::moveToOwner(BattleUnit *owner)
  * Gets the item's inventory slot.
  * @return The slot id.
  */
-RuleInventory *BattleItem::getSlot() const
+const RuleInventory *BattleItem::getSlot() const
 {
 	return _inventorySlot;
 }
@@ -533,7 +533,7 @@ RuleInventory *BattleItem::getSlot() const
  * Sets the item's inventory slot.
  * @param slot The slot id.
  */
-void BattleItem::setSlot(RuleInventory *slot)
+void BattleItem::setSlot(const RuleInventory *slot)
 {
 	_inventorySlot = slot;
 }

--- a/src/Savegame/BattleItem.h
+++ b/src/Savegame/BattleItem.h
@@ -52,7 +52,7 @@ private:
 	BattleUnit *_owner, *_previousOwner;
 	BattleUnit *_unit;
 	Tile *_tile;
-	RuleInventory *_inventorySlot;
+	const RuleInventory *_inventorySlot;
 	int _inventoryX, _inventoryY;
 	BattleItem *_ammoItem[RuleItem::AmmoSlotMax] = { };
 	bool _ammoVisibility[RuleItem::AmmoSlotMax] = { };
@@ -123,9 +123,9 @@ public:
 	/// Removes the item from previous owner and moves to new owner.
 	void moveToOwner(BattleUnit *owner);
 	/// Gets the item's inventory slot.
-	RuleInventory *getSlot() const;
+	const RuleInventory *getSlot() const;
 	/// Sets the item's inventory slot.
-	void setSlot(RuleInventory *slot);
+	void setSlot(const RuleInventory *slot);
 	/// Gets the item's inventory X position.
 	int getSlotX() const;
 	/// Sets the item's inventory X position.

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -372,7 +372,7 @@ public:
 	/// Get the list of items in the inventory.
 	std::vector<BattleItem*> *getInventory();
 	/// Fit item into inventory slot.
-	bool fitItemToInventory(RuleInventory *slot, BattleItem *item);
+	bool fitItemToInventory(const RuleInventory *slot, BattleItem *item);
 	/// Add item to unit.
 	bool addItem(BattleItem *item, const Mod *mod, bool allowSecondClip = false, bool allowAutoLoadout = false, bool allowUnloadedWeapons = false);
 

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -805,7 +805,7 @@ int Tile::getAnimationOffset() const
  * @param item
  * @param ground
  */
-void Tile::addItem(BattleItem *item, RuleInventory *ground)
+void Tile::addItem(BattleItem *item, const RuleInventory *ground)
 {
 	item->setSlot(ground);
 	_inventory.push_back(item);

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -324,7 +324,7 @@ public:
 	/// Get fire and smoke animation offset.
 	int getAnimationOffset() const;
 	/// Add item
-	void addItem(BattleItem *item, RuleInventory *ground);
+	void addItem(BattleItem *item, const RuleInventory *ground);
 	/// Remove item
 	void removeItem(BattleItem *item);
 	/// Get top-most item


### PR DESCRIPTION
Second proposition for inventory slots setup by armor.
The feature is enabled by a new boolean mod variable  explicitInventoriesByArmor (keeps old behavior if not - i.e. all armors have all invs).
Features 
- alternative resized and "shaped" hands may be defined (need an inventory mod boolean key mainHand for right hand replacement or offHand for left hand replacement)
- items are placed in inventory in the first fitting slot so that usage cost (cost to transfer to either hands) is minimal (so no more explicit belt or backpack reference in the code)
- if enabled, all armors shall reference all needed inventory keys
Example mod attached
[Test.zip](https://github.com/MeridianOXC/OpenXcom/files/3964709/Test.zip)
