### PR TITLE
Transient component wise position getters for BattleUnit in ModScripts

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -777,8 +777,6 @@ Position BattleUnit::getPositionVexels() const
 	center += Position(8, 8, 0) * _armor->getSize();
 	return center;
 }
-	
-/* memaker: testing script access */
 
 /**
  * Get the X part of the tile coordinate of this unit.

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -777,6 +777,35 @@ Position BattleUnit::getPositionVexels() const
 	center += Position(8, 8, 0) * _armor->getSize();
 	return center;
 }
+	
+/* memaker: testing script access */
+
+/**
+ * Get the X part of the tile coordinate of this unit.
+ * @return X Position.
+ */
+int BattleUnit::getPositionX() const
+{
+	return getPosition().x;
+}
+
+/**
+ * Get the Y part of the tile coordinate of this unit.
+ * @return Y Position.
+ */
+int BattleUnit::getPositionY() const
+{
+	return getPosition().y;
+}
+
+/**
+ * Get the Z part of the tile coordinate of this unit.
+ * @return Z Position.
+ */
+int BattleUnit::getPositionZ() const
+{
+	return getPosition().z;
+}
 
 /**
  * Gets the BattleUnit's destination.
@@ -5093,6 +5122,10 @@ void BattleUnit::ScriptRegister(ScriptParserBase* parser)
 	bu.addFunc<reduceByBraveryScript>("reduceByBravery");
 	bu.addFunc<reduceByResistanceScript>("reduceByResistance");
 
+	//memmaker: testing getters for position
+	bu.add<&BattleUnit::getPositionX>("getPositionX");
+	bu.add<&BattleUnit::getPositionY>("getPositionY");
+	bu.add<&BattleUnit::getPositionZ>("getPositionZ");
 
 	bu.addScriptValue<&BattleUnit::_scriptValues>();
 	bu.addDebugDisplay<&debugDisplayScript>();

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -5122,10 +5122,9 @@ void BattleUnit::ScriptRegister(ScriptParserBase* parser)
 	bu.addFunc<reduceByBraveryScript>("reduceByBravery");
 	bu.addFunc<reduceByResistanceScript>("reduceByResistance");
 
-	//memmaker: testing getters for position
-	bu.add<&BattleUnit::getPositionX>("getPositionX");
-	bu.add<&BattleUnit::getPositionY>("getPositionY");
-	bu.add<&BattleUnit::getPositionZ>("getPositionZ");
+	bu.add<&BattleUnit::getPositionX>("getPosition.getX");
+	bu.add<&BattleUnit::getPositionY>("getPosition.getY");
+	bu.add<&BattleUnit::getPositionZ>("getPosition.getZ");
 
 	bu.addScriptValue<&BattleUnit::_scriptValues>();
 	bu.addDebugDisplay<&debugDisplayScript>();

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -782,27 +782,42 @@ Position BattleUnit::getPositionVexels() const
  * Get the X part of the tile coordinate of this unit.
  * @return X Position.
  */
-int BattleUnit::getPositionX() const
+void getPositionX(const BattleUnit *bu, int &ret)
 {
-	return getPosition().x;
+	if (bu)
+	{
+		ret = bu->getPosition().x;
+		return;
+	}
+	ret = 0;
 }
 
 /**
  * Get the Y part of the tile coordinate of this unit.
  * @return Y Position.
  */
-int BattleUnit::getPositionY() const
+void getPositionY(const BattleUnit *bu, int &ret)
 {
-	return getPosition().y;
+	if (bu)
+	{
+		ret = bu->getPosition().y;
+		return;
+	}
+	ret = 0;
 }
 
 /**
  * Get the Z part of the tile coordinate of this unit.
  * @return Z Position.
  */
-int BattleUnit::getPositionZ() const
+void getPositionZ(const BattleUnit *bu, int &ret)
 {
-	return getPosition().z;
+	if (bu)
+	{
+		ret = bu->getPosition().z;
+		return;
+	}
+	ret = 0;
 }
 
 /**
@@ -5120,9 +5135,9 @@ void BattleUnit::ScriptRegister(ScriptParserBase* parser)
 	bu.addFunc<reduceByBraveryScript>("reduceByBravery");
 	bu.addFunc<reduceByResistanceScript>("reduceByResistance");
 
-	bu.add<&BattleUnit::getPositionX>("getPosition.getX");
-	bu.add<&BattleUnit::getPositionY>("getPosition.getY");
-	bu.add<&BattleUnit::getPositionZ>("getPosition.getZ");
+	bu.add<&getPositionX>("getPosition.getX");
+	bu.add<&getPositionY>("getPosition.getY");
+	bu.add<&getPositionZ>("getPosition.getZ");
 
 	bu.addScriptValue<&BattleUnit::_scriptValues>();
 	bu.addDebugDisplay<&debugDisplayScript>();

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -207,12 +207,6 @@ public:
 	Position getLastPosition() const;
 	/// Gets the unit's position of center in voxels.
 	Position getPositionVexels() const;
-	/// Gets the unit's X position.
-	int getPositionX() const;
-	/// Gets the unit's Y position.
-	int getPositionY() const;
-	/// Gets the unit's Z position.
-	int getPositionZ() const;
 	/// Sets the unit's direction 0-7.
 	void setDirection(int direction);
 	/// Sets the unit's face direction (only used by strafing moves)

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -207,6 +207,12 @@ public:
 	Position getLastPosition() const;
 	/// Gets the unit's position of center in voxels.
 	Position getPositionVexels() const;
+	/// Gets the unit's X position.
+	int getPositionX() const;
+	/// Gets the unit's Y position.
+	int getPositionY() const;
+	/// Gets the unit's Z position.
+	int getPositionZ() const;
 	/// Sets the unit's direction 0-7.
 	void setDirection(int direction);
 	/// Sets the unit's face direction (only used by strafing moves)


### PR DESCRIPTION
This adds getters for the X/Y/Z position of a battle for ModScripts.