### PR TITLE
small bugfix for reaction fire

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2033,8 +2033,8 @@ bool TileEngine::tryReaction(ReactionScore *reaction, BattleUnit *target, const 
 				{
 					_save->getBattleGame()->statePushBack(new ProjectileFlyBState(_save->getBattleGame(), action));
 				}
+				return true;
 			}
-			return arg.getFirst() > 0;
 		}
 	}
 	return false;


### PR DESCRIPTION
if the reaction_chance is something other than 0 or 100 the units would stop while moving (even when holding shift) when no reaction shots were made. this has been fixed here. the function now returns wether a reaction shot was made or not (as was probably intended).