### PR TITLE
StateStrings: Optional state information via tags

### DIFF
--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -1307,6 +1307,8 @@ void Mod::loadAll()
 	//back master
 	_modCurrent = &_modData.at(0);
 	_scriptGlobal->endLoad();
+	
+	cacheScriptTagNames();
 
 	// post-processing item categories
 	std::map<std::string, std::string> replacementRules;
@@ -2241,6 +2243,31 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 	}
 }
 
+/**
+ * Helper function that makes tag names from rulesets/scripts readily available in the Mod
+ * class by caching them on load. Note: All Mods/Rulesets must have been loaded beforehand.
+ */
+void Mod::cacheScriptTagNames()
+{
+	_battleUnitTags.clear();
+	
+	ArgEnum index = ScriptParserBase::getArgType<ScriptTag<BattleUnit>>();
+	
+	for (const auto& v : _scriptGlobal->getTagNames().at(index).values)
+	{
+		_battleUnitTags.push_back(v.name.toString());
+	}
+}
+
+/**
+ * Access the tag names of the BattleUnits.
+ * @return A list of the tag names as strings.
+ */
+const std::vector<std::string> Mod::getBattleUnitTags() const
+{
+	return _battleUnitTags;
+}
+	
 /**
  * Helper function protecting from circular references in node definition.
  * @param node Node to test

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -244,6 +244,7 @@ private:
 	std::vector<SDL_Color> _transparencies;
 	int _facilityListOrder, _craftListOrder, _itemCategoryListOrder, _itemListOrder, _researchListOrder,  _manufactureListOrder, _transformationListOrder, _ufopaediaListOrder, _invListOrder, _soldierListOrder;
 	std::vector<ModData> _modData;
+	std::vector<std::string> _battleUnitTags;
 	ModData* _modCurrent;
 	const SDL_Color *_statePalette;
 	std::vector<std::string> _psiRequirements; // it's a cache for psiStrengthEval
@@ -291,6 +292,8 @@ private:
 	void modResources();
 	/// Sorts all our lists according to their weight.
 	void sortLists();
+	/// Loads the tag names from ScriptGlobal and stores them in vectors for easy access
+	void cacheScriptTagNames();
 public:
 	static int DOOR_OPEN;
 	static int SLIDING_DOOR_OPEN;
@@ -761,6 +764,9 @@ public:
 	StatAdjustment *getStatAdjustment(int difficulty);
 	int getDefeatScore() const;
 	int getDefeatFunds() const;
+	
+	/// Get the tag names for the BattleUnits
+	const std::vector<std::string> getBattleUnitTags() const;
 };
 
 }

--- a/src/Mod/StatString.cpp
+++ b/src/Mod/StatString.cpp
@@ -120,7 +120,7 @@ std::string StatString::calcStatString(UnitStats &currentStats, const std::vecto
 	return calculateStatString(statStrings, currentStatsMap, showPsi);
 }
 	
-std::string StatString::calculateStatString(const std::vector<StatString *> &statStrings, std::map<std::string, int> &currentStatsMap, bool showPsi)
+std::string StatString::calculateStatString(const std::vector<StatString *> &statStrings, const std::map<std::string, int> &currentStatsMap, bool showPsi)
 {
 	std::string statString;
 	for (std::vector<StatString *>::const_iterator i = statStrings.begin(); i != statStrings.end(); ++i)
@@ -128,7 +128,7 @@ std::string StatString::calculateStatString(const std::vector<StatString *> &sta
 		bool conditionsMet = true;
 		for (std::vector<StatStringCondition*>::const_iterator j = (*i)->getConditions().begin(); j != (*i)->getConditions().end() && conditionsMet; ++j)
 		{
-			std::map<std::string, int>::iterator name = currentStatsMap.find((*j)->getConditionName());
+			std::map<std::string, int>::const_iterator name = currentStatsMap.find((*j)->getConditionName());
 			if (name != currentStatsMap.end())
 			{
 				conditionsMet = conditionsMet && (*j)->isMet(name->second, showPsi);

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -122,7 +122,7 @@ public:
 	/// Calculate a StatString from UnitStats.
 	static std::string calcStatString(UnitStats &currentStats, const std::vector<StatString*> &statStrings, bool psiStrengthEval, bool inTraining);
 	/// Calculate a StatString.
-	static std::string calculateStatString(const std::vector<StatString *> &statStrings, std::map<std::string, int> &currentStatsMap, bool showPsi);
+	static std::string calculateStatString(const std::vector<StatString *> &statStrings, const std::map<std::string, int> &currentStatsMap, bool showPsi);
 	/// Get the CurrentStats.
 	static std::map<std::string, int> getCurrentStats(UnitStats &currentStats);
 };

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -119,8 +119,10 @@ public:
 	const std::vector<StatStringCondition*> &getConditions() const;
 	/// Get the StatString string.
 	std::string getString() const;
-	/// Calculate a StatString.
+	/// Calculate a StatString from UnitStats.
 	static std::string calcStatString(UnitStats &currentStats, const std::vector<StatString*> &statStrings, bool psiStrengthEval, bool inTraining);
+	/// Calculate a StatString.
+	static std::string calculateStatString(const std::vector<StatString *> &statStrings, std::map<std::string, int> &currentStatsMap, bool showPsi);
 	/// Get the CurrentStats.
 	static std::map<std::string, int> getCurrentStats(UnitStats &currentStats);
 };

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -185,6 +185,8 @@ BattleUnit::BattleUnit(const Mod *mod, Soldier *soldier, int depth) :
 
 	prepareUnitSounds();
 	prepareUnitResponseSounds(mod);
+	
+	prepareTagNames(mod->getScriptGlobal());
 }
 
 /**
@@ -292,7 +294,20 @@ void BattleUnit::prepareUnitSounds()
 			_deathSound = _armor->getFemaleDeathSounds();
 	}
 }
-
+/**
+ * Helper function preparing tag names.
+ */
+void BattleUnit::prepareTagNames(const ScriptGlobal *shared)
+{
+	_tagData.clear();
+	
+	ArgEnum index = ScriptParserBase::getArgType<ScriptTag<BattleUnit>>();
+	
+	for (size_t i = 0; i < shared->getTagNames().at(index).values.size(); ++i)
+	{
+		_tagData.push_back(shared->getTagNames().at(index).values[i].name.toString());
+	}
+}
 /**
  * Helper function preparing unit response sounds.
  */
@@ -3551,8 +3566,21 @@ std::string BattleUnit::getName(Language *lang, bool debugAppendId) const
 		}
 		return ret;
 	}
+	
+	// prepare soldier tags
+	std::map<std::string, int> unitTags;
+	
+	auto tagValues = _scriptValues.getValuesRaw();
 
-	return _name;
+	for (size_t i = 0; i < tagValues.size(); ++i)
+	{
+		auto nameAsString = _tagData[i];
+		int value = tagValues.at(i);
+		unitTags[nameAsString] = value;
+	}
+	
+	_geoscapeSoldier->calcStateString(unitTags);
+	return _geoscapeSoldier->getName(true);
 }
 
 /**

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -69,6 +69,7 @@ BattleUnit::BattleUnit(const Mod *mod, Soldier *soldier, int depth) :
 	_statistics(), _murdererId(0), _mindControllerID(0), _fatalShotSide(SIDE_FRONT), _fatalShotBodyPart(BODYPART_HEAD), _armor(0),
 	_geoscapeSoldier(soldier), _unitRules(0), _rankInt(0), _turretType(-1), _hidingForTurn(false), _floorAbove(false), _respawn(false), _alreadyRespawned(false), _isLeeroyJenkins(false), _summonedPlayerUnit(false), _capturable(true)
 {
+	_mod = mod;
 	_name = soldier->getName(true);
 	_id = soldier->getId();
 	_type = "SOLDIER";
@@ -185,8 +186,6 @@ BattleUnit::BattleUnit(const Mod *mod, Soldier *soldier, int depth) :
 
 	prepareUnitSounds();
 	prepareUnitResponseSounds(mod);
-	
-	prepareTagNames(mod->getScriptGlobal());
 }
 
 /**
@@ -292,20 +291,6 @@ void BattleUnit::prepareUnitSounds()
 	{
 		if (!_armor->getFemaleDeathSounds().empty())
 			_deathSound = _armor->getFemaleDeathSounds();
-	}
-}
-/**
- * Helper function preparing tag names.
- */
-void BattleUnit::prepareTagNames(const ScriptGlobal *shared)
-{
-	_tagData.clear();
-	
-	ArgEnum index = ScriptParserBase::getArgType<ScriptTag<BattleUnit>>();
-	
-	for (size_t i = 0; i < shared->getTagNames().at(index).values.size(); ++i)
-	{
-		_tagData.push_back(shared->getTagNames().at(index).values[i].name.toString());
 	}
 }
 /**
@@ -3571,15 +3556,15 @@ std::string BattleUnit::getName(Language *lang, bool debugAppendId) const
 	std::map<std::string, int> unitTags;
 	
 	auto tagValues = _scriptValues.getValuesRaw();
-
+	auto tagData = _mod->getBattleUnitTags();
 	for (size_t i = 0; i < tagValues.size(); ++i)
 	{
-		auto nameAsString = _tagData[i];
+		auto nameAsString = tagData[i];
 		int value = tagValues.at(i);
 		unitTags[nameAsString] = value;
 	}
 	
-	_geoscapeSoldier->calcStateString(unitTags);
+	_geoscapeSoldier->calcStatTagString(unitTags);
 	return _geoscapeSoldier->getName(true);
 }
 

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -123,6 +123,7 @@ private:
 	UnitSide _fatalShotSide;
 	UnitBodyPart _fatalShotBodyPart;
 	std::string _murdererWeapon, _murdererWeaponAmmo;
+	const Mod *_mod;
 
 	// static data
 	std::string _type;
@@ -155,7 +156,6 @@ private:
 	std::vector<std::pair<Uint8, Uint8> > _recolor;
 	bool _capturable;
 	ScriptValues<BattleUnit> _scriptValues;
-	std::vector<std::string> _tagData;
 
 	/// Calculate stat improvement.
 	int improveStat(int exp) const;
@@ -177,8 +177,6 @@ private:
 	void prepareUnitSounds();
 	/// Helper function preparing unit response sounds.
 	void prepareUnitResponseSounds(const Mod *mod);
-	/// Helper function preparing tag names.
-	void prepareTagNames(const ScriptGlobal *shared);
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Name of class used in script.

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -155,6 +155,7 @@ private:
 	std::vector<std::pair<Uint8, Uint8> > _recolor;
 	bool _capturable;
 	ScriptValues<BattleUnit> _scriptValues;
+	std::vector<std::string> _tagData;
 
 	/// Calculate stat improvement.
 	int improveStat(int exp) const;
@@ -176,6 +177,8 @@ private:
 	void prepareUnitSounds();
 	/// Helper function preparing unit response sounds.
 	void prepareUnitResponseSounds(const Mod *mod);
+	/// Helper function preparing tag names.
+	void prepareTagNames(const ScriptGlobal *shared);
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Name of class used in script.

--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -262,15 +262,24 @@ YAML::Node Soldier::save(const ScriptGlobal *shared) const
  */
 std::string Soldier::getName(bool statstring, unsigned int maxLength) const
 {
-	if (statstring && !_statString.empty())
+	if (statstring)
 	{
-		if (_name.length() + _statString.length() > maxLength)
+		std::string suffix;
+		if (!_statString.empty())
 		{
-			return _name.substr(0, maxLength - _statString.length()) + "/" + _statString;
+			suffix += "/" + _statString;
+		}
+		if (!_stateString.empty())
+		{
+			suffix += "/" + _stateString;
+		}
+		if (_name.length() + suffix.length() > maxLength)
+		{
+			return _name.substr(0, maxLength - suffix.length()) + suffix;
 		}
 		else
 		{
-			return _name + "/" + _statString;
+			return _name + suffix;
 		}
 	}
 	else
@@ -1039,12 +1048,13 @@ void Soldier::resetDiary()
 
 /**
  * Calculates the soldier's statString
- * Calculates the soldier's statString.
  * @param statStrings List of statString rules.
  * @param psiStrengthEval Are psi stats available?
  */
 void Soldier::calcStatString(const std::vector<StatString *> &statStrings, bool psiStrengthEval)
 {
+	// cache the statstrings for statestrings
+	_globalStatStrings = &statStrings;
 	if (_rules->getStatStrings().empty())
 	{
 		_statString = StatString::calcStatString(_currentStats, statStrings, psiStrengthEval, _psiTraining);
@@ -1052,6 +1062,14 @@ void Soldier::calcStatString(const std::vector<StatString *> &statStrings, bool 
 	else
 	{
 		_statString = StatString::calcStatString(_currentStats, _rules->getStatStrings(), psiStrengthEval, _psiTraining);
+	}
+}
+	
+void Soldier::calcStateString(std::map<std::string, int> unitTags)
+{
+	if (_globalStatStrings != nullptr && !_globalStatStrings->empty())
+	{
+		_stateString = StatString::calculateStatString(*_globalStatStrings, unitTags, false);
 	}
 }
 

--- a/src/Savegame/Soldier.cpp
+++ b/src/Savegame/Soldier.cpp
@@ -269,9 +269,9 @@ std::string Soldier::getName(bool statstring, unsigned int maxLength) const
 		{
 			suffix += "/" + _statString;
 		}
-		if (!_stateString.empty())
+		if (!_statTagString.empty())
 		{
-			suffix += "/" + _stateString;
+			suffix += "/" + _statTagString;
 		}
 		if (_name.length() + suffix.length() > maxLength)
 		{
@@ -1065,11 +1065,12 @@ void Soldier::calcStatString(const std::vector<StatString *> &statStrings, bool 
 	}
 }
 	
-void Soldier::calcStateString(std::map<std::string, int> unitTags)
+void Soldier::calcStatTagString(const std::map<std::string, int> &unitTags)
 {
+	
 	if (_globalStatStrings != nullptr && !_globalStatStrings->empty())
 	{
-		_stateString = StatString::calculateStatString(*_globalStatStrings, unitTags, false);
+		_statTagString = StatString::calculateStatString(*_globalStatStrings, unitTags, false);
 	}
 }
 

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -78,7 +78,7 @@ private:
 	SoldierDeath *_death;
 	SoldierDiary *_diary;
 	std::string _statString;
-	std::string _stateString;
+	std::string _statTagString;
 	bool _corpseRecovered;
 	std::map<std::string, int> _previousTransformations, _transformationBonuses;
 	std::vector<const RuleSoldierBonus*> _bonusCache;
@@ -213,7 +213,7 @@ public:
 	/// Calculate statString.
 	void calcStatString(const std::vector<StatString *> &statStrings, bool psiStrengthEval);
 	/// Calculate unit state string
-	void calcStateString(std::map<std::string, int> unitTags);
+	void calcStatTagString(const std::map<std::string, int> &unitTags);
 	/// Trains a soldier's physical stats
 	void trainPhys(int customTrainingFactor);
 	/// Is the soldier already fully trained?

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -78,10 +78,12 @@ private:
 	SoldierDeath *_death;
 	SoldierDiary *_diary;
 	std::string _statString;
+	std::string _stateString;
 	bool _corpseRecovered;
 	std::map<std::string, int> _previousTransformations, _transformationBonuses;
 	std::vector<const RuleSoldierBonus*> _bonusCache;
 	ScriptValues<Soldier> _scriptValues;
+	const std::vector<StatString *> *_globalStatStrings;
 public:
 	/// Creates a new soldier.
 	Soldier(RuleSoldier *rules, Armor *armor, int id = 0);
@@ -210,6 +212,8 @@ public:
 	void resetDiary();
 	/// Calculate statString.
 	void calcStatString(const std::vector<StatString *> &statStrings, bool psiStrengthEval);
+	/// Calculate unit state string
+	void calcStateString(std::map<std::string, int> unitTags);
 	/// Trains a soldier's physical stats
 	void trainPhys(int customTrainingFactor);
 	/// Is the soldier already fully trained?


### PR DESCRIPTION
This commit extends the StatString definitions to allow for the usage of script tags.
StatStrings resulting from tags are appended as an additional separated statstring.

Possible use cases:
 - Status effects display (poison, stunned, acid, etc.)
 - Fatal Wounds Indicator
 - Skill Effect Indicator
 - Recovery Status Indicator
 - Class Strings
 - And many more, since modders will find some interesting uses for this