### PR TITLE
StateStrings: Optional state information via tags

### DIFF
--- a/bin/standard/xcom1/soldiers.rul
+++ b/bin/standard/xcom1/soldiers.rul
@@ -44,5 +44,14 @@ soldiers:
     femaleFrequency: 25
     soldierNames:
       - SoldierName/
+    nameInTitles: "{NAME}"
+    nameInTitlesLong: "{NAME}{STATSTRING}"
+    nameInLists: "{NAME}"
+    nameInListsLong: "{NAME}{STATSTRING}"
+    nameInPilotLists: "{NAME}"
+    nameInBattleScape: "{NAME}{STATSTRING}"
+    nameInBattleScapeAlternate: "{CALLSIGN}{TAGSTRING}"
+    nameStatStringSeparator: "/"
+    nameTagStatStringSeparator: ">"
     deathMale: [41, 42, 43]
     deathFemale: [44, 45, 46]

--- a/bin/standard/xcom2/soldiers.rul
+++ b/bin/standard/xcom2/soldiers.rul
@@ -51,5 +51,14 @@ soldiers: #done
     femaleFrequency: 25
     soldierNames:
       - SoldierName/
+    nameInTitles: "{NAME}"
+    nameInTitlesLong: "{NAME}{STATSTRING}"
+    nameInLists: "{NAME}"
+    nameInListsLong: "{NAME}{STATSTRING}"
+    nameInPilotLists: "{NAME}"
+    nameInBattleScape: "{NAME}{STATSTRING}"
+    nameInBattleScapeAlternate: "{CALLSIGN}{TAGSTRING}"
+    nameStatStringSeparator: "/"
+    nameTagStatStringSeparator: ">"
     deathMale: 48
     deathFemale: 48

--- a/src/Basescape/CraftArmorState.cpp
+++ b/src/Basescape/CraftArmorState.cpp
@@ -277,11 +277,11 @@ void CraftArmorState::initList(size_t scrl)
 			int dynStat = (*_dynGetter)(_game, *i);
 			std::ostringstream ss;
 			ss << dynStat;
-			_lstSoldiers->addRow(4, (*i)->getName(true).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), tr((*i)->getArmor()->getType()).c_str(), ss.str().c_str());
+			_lstSoldiers->addRow(4, (*i)->getName(NDM_LIST_LONG).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), tr((*i)->getArmor()->getType()).c_str(), ss.str().c_str());
 		}
 		else
 		{
-			_lstSoldiers->addRow(3, (*i)->getName(true).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), tr((*i)->getArmor()->getType()).c_str());
+			_lstSoldiers->addRow(3, (*i)->getName(NDM_LIST_LONG).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), tr((*i)->getArmor()->getType()).c_str());
 		}
 
 		Uint8 color;

--- a/src/Basescape/CraftPilotSelectState.cpp
+++ b/src/Basescape/CraftPilotSelectState.cpp
@@ -111,7 +111,7 @@ CraftPilotSelectState::CraftPilotSelectState(Base *base, size_t craft) : _base(b
 				ss2 << (*i)->getStatsWithSoldierBonusesOnly()->reactions;
 				std::ostringstream ss3;
 				ss3 << (*i)->getStatsWithSoldierBonusesOnly()->bravery;
-				_lstPilot->addRow(4, (*i)->getName(false).c_str(), ss1.str().c_str(), ss2.str().c_str(), ss3.str().c_str());
+				_lstPilot->addRow(4, (*i)->getName(NDM_LIST_PILOT).c_str(), ss1.str().c_str(), ss2.str().c_str(), ss3.str().c_str());
 			}
 		}
 	}

--- a/src/Basescape/CraftPilotsState.cpp
+++ b/src/Basescape/CraftPilotsState.cpp
@@ -172,7 +172,7 @@ void CraftPilotsState::updateUI()
 		ss2 << (*i)->getStatsWithSoldierBonusesOnly()->reactions;
 		std::ostringstream ss3;
 		ss3 << (*i)->getStatsWithSoldierBonusesOnly()->bravery;
-		_lstPilots->addRow(5, (*i)->getName(false).c_str(), ss1.str().c_str(), ss2.str().c_str(), ss3.str().c_str(), "");
+		_lstPilots->addRow(5, (*i)->getName(NDM_LIST_PILOT).c_str(), ss1.str().c_str(), ss2.str().c_str(), ss3.str().c_str(), "");
 	}
 
 	std::ostringstream ss1;

--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -273,11 +273,11 @@ void CraftSoldiersState::initList(size_t scrl)
 			int dynStat = (*_dynGetter)(_game, *i);
 			std::ostringstream ss;
 			ss << dynStat;
-			_lstSoldiers->addRow(4, (*i)->getName(true, 19).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), ss.str().c_str());
+			_lstSoldiers->addRow(4, (*i)->getName(NDM_LIST_LONG, 19).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str(), ss.str().c_str());
 		}
 		else
 		{
-			_lstSoldiers->addRow(3, (*i)->getName(true, 19).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str());
+			_lstSoldiers->addRow(3, (*i)->getName(NDM_LIST_LONG, 19).c_str(), tr((*i)->getRankString()).c_str(), (*i)->getCraftString(_game->getLanguage(), absBonus, relBonus).c_str());
 		}
 
 		Uint8 color;

--- a/src/Basescape/SackSoldierState.cpp
+++ b/src/Basescape/SackSoldierState.cpp
@@ -76,7 +76,7 @@ SackSoldierState::SackSoldierState(Base *base, size_t soldierId) : _base(base), 
 	_txtTitle->setText(tr("STR_SACK"));
 
 	std::ostringstream ss;
-	ss << _base->getSoldiers()->at(_soldierId)->getName(true) << "?";
+	ss << _base->getSoldiers()->at(_soldierId)->getName(NDM_TITLE_LONG) << "?";
 
 	_txtSoldier->setAlign(ALIGN_CENTER);
 	_txtSoldier->setText(ss.str());

--- a/src/Basescape/SellState.cpp
+++ b/src/Basescape/SellState.cpp
@@ -178,7 +178,7 @@ SellState::SellState(Base *base, DebriefingState *debriefingState, OptionsOrigin
 		if (_debriefingState) break;
 		if ((*i)->getCraft() == 0)
 		{
-			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(true), 0, 1, 0, 0 };
+			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(NDM_LIST_LONG), 0, 1, 0, 0 };
 			_items.push_back(row);
 			std::string cat = getCategory(_items.size() - 1);
 			if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())

--- a/src/Basescape/SoldierDiaryOverviewState.cpp
+++ b/src/Basescape/SoldierDiaryOverviewState.cpp
@@ -185,7 +185,7 @@ void SoldierDiaryOverviewState::init()
 		_soldierId = 0;
 	}
 	_soldier = _list->at(_soldierId);
-	_txtTitle->setText(_soldier->getName());
+	_txtTitle->setText(_soldier->getName(NDM_TITLE));
 
 	if (!_base && _soldier->getDeath())
 	{

--- a/src/Basescape/SoldierDiaryPerformanceState.cpp
+++ b/src/Basescape/SoldierDiaryPerformanceState.cpp
@@ -239,7 +239,7 @@ void SoldierDiaryPerformanceState::init()
 	_lstMissionTotals->clearList();
 	_commendationsListEntry.clear();
 	_commendationsNames.clear();
-	_txtTitle->setText(_soldier->getName());
+	_txtTitle->setText(_soldier->getName(NDM_TITLE));
 	_lstPerformance->clearList();
 	_lstCommendations->clearList();
 	if (_display == DIARY_KILLS)

--- a/src/Basescape/SoldierTransformationState.cpp
+++ b/src/Basescape/SoldierTransformationState.cpp
@@ -482,7 +482,8 @@ void SoldierTransformationState::performTransformation()
 		destinationSoldier->setGender(_sourceSoldier->getGender());
 		destinationSoldier->setLook(_sourceSoldier->getLook());
 		destinationSoldier->setLookVariant(_sourceSoldier->getLookVariant());
-
+		destinationSoldier->setCallsign(_sourceSoldier->getCallsign());
+		
 		// preserve nationality only for soldiers of the same type
 		if (_sourceSoldier->getRules() == newSoldierType)
 		{

--- a/src/Basescape/SoldiersState.cpp
+++ b/src/Basescape/SoldiersState.cpp
@@ -393,11 +393,11 @@ void SoldiersState::initList(size_t scrl)
 			int dynStat = (*_dynGetter)(_game, *i);
 			std::ostringstream ss;
 			ss << dynStat;
-			_lstSoldiers->addRow(4, (*i)->getName(true).c_str(), tr((*i)->getRankString()).c_str(), craftString.c_str(), ss.str().c_str());
+			_lstSoldiers->addRow(4, (*i)->getName(NDM_LIST_LONG).c_str(), tr((*i)->getRankString()).c_str(), craftString.c_str(), ss.str().c_str());
 		}
 		else
 		{
-			_lstSoldiers->addRow(3, (*i)->getName(true).c_str(), tr((*i)->getRankString()).c_str(), craftString.c_str());
+			_lstSoldiers->addRow(3, (*i)->getName(NDM_LIST_LONG).c_str(), tr((*i)->getRankString()).c_str(), craftString.c_str());
 		}
 
 		if ((*i)->getCraft() == 0)

--- a/src/Basescape/TransferItemsState.cpp
+++ b/src/Basescape/TransferItemsState.cpp
@@ -154,7 +154,7 @@ TransferItemsState::TransferItemsState(Base *baseFrom, Base *baseTo, DebriefingS
 		if (_debriefingState) break;
 		if ((*i)->getCraft() == 0)
 		{
-			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(true), (int)(5 * _distance), 1, 0, 0 };
+			TransferRow row = { TRANSFER_SOLDIER, (*i), (*i)->getName(NDM_LIST_LONG), (int)(5 * _distance), 1, 0, 0 };
 			_items.push_back(row);
 			std::string cat = getCategory(_items.size() - 1);
 			if (std::find(_cats.begin(), _cats.end(), cat) == _cats.end())

--- a/src/Battlescape/AlienInventoryState.cpp
+++ b/src/Battlescape/AlienInventoryState.cpp
@@ -96,7 +96,9 @@ AlienInventoryState::AlienInventoryState(BattleUnit *unit)
 			else
 			{
 				// e.g. Sectoid
-				_txtName->setText(tr(unit->getUnitRules()->getRace()));
+				std::string alienRace = tr(unit->getUnitRules()->getRace());
+				alienRace += unit->getStatTagString();
+				_txtName->setText(alienRace);
 			}
 		}
 		else

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1744,14 +1744,10 @@ void BattlescapeState::updateSoldierInfo(bool checkFOV)
 		return;
 	}
 
-	_txtName->setText(battleUnit->getName(_game->getLanguage(), false));
+	_txtName->setText(battleUnit->getName(_game->getLanguage(), false, _save->isNameDisplay()));
 	Soldier *soldier = battleUnit->getGeoscapeSoldier();
 	if (soldier != 0)
 	{
-		if (soldier->hasCallsign() && !_save->isNameDisplay())
-		{
-			_txtName->setText(soldier->getCallsign());
-		}
 		// presence of custom background determines what should happen
 		Surface *customBg = _game->getMod()->getSurface("AvatarBackground", false);
 		if (customBg == 0)

--- a/src/Battlescape/CommendationLateState.cpp
+++ b/src/Battlescape/CommendationLateState.cpp
@@ -98,7 +98,7 @@ CommendationLateState::CommendationLateState(std::vector<Soldier*> soldiersMedal
 	for (std::vector<Soldier*>::iterator s = soldiersMedalled.begin() ; s != soldiersMedalled.end(); ++s)
 	{
 		// Establish some base information
-		_lstSoldiers->addRow(3, (*s)->getName().c_str(),
+		_lstSoldiers->addRow(3, (*s)->getName(NDM_LIST).c_str(),
 								tr((*s)->getRankString()).c_str(),
 								tr("STR_KILLS").arg((*s)->getDiary()->getKillTotal()).c_str());
 		_lstSoldiers->setRowColor(row, _lstSoldiers->getSecondaryColor());

--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -524,8 +524,6 @@ void InventoryState::edtSoldierChange(Action *)
 		{
 			// set the soldier's name
 			s->setName(_txtName->getText());
-			// also set the unit's name (with a statstring)
-			unit->setName(s->getName(true));
 		}
 	}
 }

--- a/src/Battlescape/PromotionsState.cpp
+++ b/src/Battlescape/PromotionsState.cpp
@@ -89,7 +89,7 @@ PromotionsState::PromotionsState()
 		{
 			if ((*j)->isPromoted())
 			{
-				_lstSoldiers->addRow(3, (*j)->getName().c_str(), tr((*j)->getRankString()).c_str(), (*i)->getName().c_str());
+				_lstSoldiers->addRow(3, (*j)->getName(NDM_LIST).c_str(), tr((*j)->getRankString()).c_str(), (*i)->getName().c_str());
 			}
 		}
 	}

--- a/src/Geoscape/AllocatePsiTrainingState.cpp
+++ b/src/Geoscape/AllocatePsiTrainingState.cpp
@@ -276,12 +276,12 @@ void AllocatePsiTrainingState::initList(size_t scrl)
 		}
 		if ((*s)->isInPsiTraining())
 		{
-			_lstSoldiers->addRow(4, (*s)->getName(true).c_str(), ssStr.str().c_str(), ssSkl.str().c_str(), tr("STR_YES").c_str());
+			_lstSoldiers->addRow(4, (*s)->getName(NDM_LIST_LONG).c_str(), ssStr.str().c_str(), ssSkl.str().c_str(), tr("STR_YES").c_str());
 			_lstSoldiers->setRowColor(row, _lstSoldiers->getSecondaryColor());
 		}
 		else
 		{
-			_lstSoldiers->addRow(4, (*s)->getName(true).c_str(), ssStr.str().c_str(), ssSkl.str().c_str(), tr("STR_NO").c_str());
+			_lstSoldiers->addRow(4, (*s)->getName(NDM_LIST_LONG).c_str(), ssStr.str().c_str(), ssSkl.str().c_str(), tr("STR_NO").c_str());
 			_lstSoldiers->setRowColor(row, _lstSoldiers->getColor());
 		}
 		row++;

--- a/src/Geoscape/AllocateTrainingState.cpp
+++ b/src/Geoscape/AllocateTrainingState.cpp
@@ -297,7 +297,7 @@ void AllocateTrainingState::initList(size_t scrl)
 			status = tr("STR_NO");
 
 		_lstSoldiers->addRow(9,
-			(*s)->getName(true).c_str(),
+			(*s)->getName(NDM_LIST_LONG).c_str(),
 			tu.str().c_str(),
 			stamina.str().c_str(),
 			health.str().c_str(),

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -1307,6 +1307,8 @@ void Mod::loadAll()
 	//back master
 	_modCurrent = &_modData.at(0);
 	_scriptGlobal->endLoad();
+	
+	cacheScriptTagNames();
 
 	// post-processing item categories
 	std::map<std::string, std::string> replacementRules;
@@ -2242,6 +2244,31 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 	}
 }
 
+/**
+ * Helper function that makes tag names from rulesets/scripts readily available in the Mod
+ * class by caching them on load. Note: All Mods/Rulesets must have been loaded beforehand.
+ */
+void Mod::cacheScriptTagNames()
+{
+	_battleUnitTags.clear();
+	
+	ArgEnum index = ScriptParserBase::getArgType<ScriptTag<BattleUnit>>();
+	
+	for (const auto& v : _scriptGlobal->getTagNames().at(index).values)
+	{
+		_battleUnitTags.push_back(v.name.toString());
+	}
+}
+
+/**
+ * Access the tag names of the BattleUnits.
+ * @return A list of the tag names as strings.
+ */
+const std::vector<std::string> Mod::getBattleUnitTags() const
+{
+	return _battleUnitTags;
+}
+	
 /**
  * Helper function protecting from circular references in node definition.
  * @param node Node to test

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -244,6 +244,7 @@ private:
 	std::vector<SDL_Color> _transparencies;
 	int _facilityListOrder, _craftListOrder, _itemCategoryListOrder, _itemListOrder, _researchListOrder,  _manufactureListOrder, _transformationListOrder, _ufopaediaListOrder, _invListOrder, _soldierListOrder;
 	std::vector<ModData> _modData;
+	std::vector<std::string> _battleUnitTags;
 	ModData* _modCurrent;
 	const SDL_Color *_statePalette;
 	std::vector<std::string> _psiRequirements; // it's a cache for psiStrengthEval
@@ -291,6 +292,8 @@ private:
 	void modResources();
 	/// Sorts all our lists according to their weight.
 	void sortLists();
+	/// Loads the tag names from ScriptGlobal and stores them in vectors for easy access
+	void cacheScriptTagNames();
 public:
 	static int DOOR_OPEN;
 	static int SLIDING_DOOR_OPEN;
@@ -761,6 +764,9 @@ public:
 	StatAdjustment *getStatAdjustment(int difficulty);
 	int getDefeatScore() const;
 	int getDefeatFunds() const;
+	
+	/// Get the tag names for the BattleUnits
+	const std::vector<std::string> getBattleUnitTags() const;
 };
 
 }

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -43,6 +43,15 @@ RuleSoldier::RuleSoldier(const std::string &type) : _type(type), _listOrder(0), 
 	_allowPromotion(true), _allowPiloting(true), _showTypeInInventory(false),
 	_rankSprite(42), _rankSpriteBattlescape(20), _rankSpriteTiny(0)
 {
+	_nameFormats[NDM_TITLE] = "{NAME}";
+	_nameFormats[NDM_TITLE_LONG] = "{NAME}{STATSTRING}";
+	_nameFormats[NDM_LIST] = "{NAME}";
+	_nameFormats[NDM_LIST_LONG] = "{NAME}{STATSTRING}";
+	_nameFormats[NDM_LIST_PILOT] = "{NAME}";
+	_nameFormats[NDM_BATTLESCAPE_PRIMARY] = "{NAME}{STATSTRING}";
+	_nameFormats[NDM_BATTLESCAPE_SECONDARY] = "{CALLSIGN}{TAGSTRING}";
+	_nameFormats[NDM_STAT_SEPARATOR] = "/";
+	_nameFormats[NDM_TAG_SEPARATOR] = ">";
 }
 
 /**
@@ -117,6 +126,17 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod, int listOrder, const Mo
 	_value = node["value"].as<int>(_value);
 	_transferTime = node["transferTime"].as<int>(_transferTime);
 	_moraleLossWhenKilled = node["moraleLossWhenKilled"].as<int>(_moraleLossWhenKilled);
+	
+	_nameFormats[NDM_TITLE] = node["nameInTitles"].as<std::string>(_nameFormats[NDM_TITLE]);
+	_nameFormats[NDM_TITLE_LONG] = node["nameInTitlesLong"].as<std::string>(_nameFormats[NDM_TITLE_LONG]);
+	_nameFormats[NDM_LIST] = node["nameInLists"].as<std::string>(_nameFormats[NDM_LIST]);
+	_nameFormats[NDM_LIST_LONG] = node["nameInListsLong"].as<std::string>(_nameFormats[NDM_LIST_LONG]);
+	_nameFormats[NDM_LIST_PILOT] = node["nameInPilotLists"].as<std::string>(_nameFormats[NDM_LIST_PILOT]);
+	_nameFormats[NDM_BATTLESCAPE_PRIMARY] = node["nameInBattleScape"].as<std::string>(_nameFormats[NDM_BATTLESCAPE_PRIMARY]);
+	_nameFormats[NDM_BATTLESCAPE_SECONDARY] = node["nameInBattleScapeAlternate"].as<std::string>(_nameFormats[NDM_BATTLESCAPE_SECONDARY]);
+	_nameFormats[NDM_STAT_SEPARATOR] = node["nameStatStringSeparator"].as<std::string>(_nameFormats[NDM_STAT_SEPARATOR]);
+	_nameFormats[NDM_TAG_SEPARATOR] = node["nameTagStatStringSeparator"].as<std::string>(_nameFormats[NDM_TAG_SEPARATOR]);
+	
 	_showTypeInInventory = node["showTypeInInventory"].as<bool>(_showTypeInInventory);
 
 	mod->loadSoundOffset(_type, _deathSoundMale, node["deathMale"], "BATTLE.CAT");
@@ -559,6 +579,11 @@ int RuleSoldier::getRankSpriteBattlescape() const
 int RuleSoldier::getRankSpriteTiny() const
 {
 	return _rankSpriteTiny;
+}
+
+std::map<NameDisplayMode, std::string> RuleSoldier::getNameFormats() const
+{
+	return _nameFormats;
 }
 
 namespace

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -25,6 +25,8 @@
 namespace OpenXcom
 {
 
+enum NameDisplayMode { NDM_DEFAULT, NDM_TITLE, NDM_TITLE_LONG, NDM_LIST, NDM_LIST_LONG, NDM_LIST_PILOT, NDM_BATTLESCAPE_PRIMARY, NDM_BATTLESCAPE_SECONDARY, NDM_STAT_SEPARATOR, NDM_TAG_SEPARATOR };
+
 class Mod;
 class ModScript;
 class SoldierNamePool;
@@ -84,7 +86,7 @@ private:
 	std::vector<std::string> _rankStrings;
 	int _rankSprite, _rankSpriteBattlescape, _rankSpriteTiny;
 	ScriptValues<RuleSoldier> _scriptValues;
-
+	std::map<NameDisplayMode, std::string> _nameFormats;
 	void addSoldierNamePool(const std::string &namFile);
 public:
 	/// Creates a blank soldier ruleset.
@@ -191,6 +193,8 @@ public:
 	int getRankSpriteBattlescape() const;
 	/// Gets the offset of the rank sprite in TinyRanks.
 	int getRankSpriteTiny() const;
+	/// Gets the format strings for the name display
+	std::map<NameDisplayMode, std::string> getNameFormats() const;
 };
 
 }

--- a/src/Mod/StatString.cpp
+++ b/src/Mod/StatString.cpp
@@ -45,11 +45,17 @@ void StatString::load(const YAML::Node &node)
 {
 	std::string conditionNames[] = {"psiStrength", "psiSkill", "bravery", "strength", "firing", "reactions", "stamina", "tu", "health", "throwing", "melee", "psiTraining", "manaPool"};
 	_stringToBeAddedIfAllConditionsAreMet = node["string"].as<std::string>(_stringToBeAddedIfAllConditionsAreMet);
-	for (size_t i = 0; i < std::size(conditionNames); i++)
+
+	for (auto it = node.begin(); it != node.end(); ++it)
 	{
-		if (node[conditionNames[i]])
+		std::string keyName = it->first.as<std::string>();
+		auto *foo = std::find(std::begin(conditionNames), std::end(conditionNames), keyName);
+		if (keyName.substr(0, 4) == "Tag." || foo != std::end(conditionNames))
 		{
-			_conditions.push_back(getCondition(conditionNames[i], node));
+			if (node[keyName])
+			{
+				_conditions.push_back(getCondition(keyName, node));
+			}
 		}
 	}
 }
@@ -103,21 +109,29 @@ std::string StatString::getString() const
  */
 std::string StatString::calcStatString(UnitStats &currentStats, const std::vector<StatString *> &statStrings, bool psiStrengthEval, bool inTraining)
 {
-	std::string statString;
 	std::map<std::string, int> currentStatsMap = getCurrentStats(currentStats);
+
 	if (inTraining)
 	{
 		currentStatsMap["psiTraining"] = 1;
 	}
+	bool showPsi = currentStats.psiSkill > 0 || psiStrengthEval;
+	
+	return calculateStatString(statStrings, currentStatsMap, showPsi);
+}
+	
+std::string StatString::calculateStatString(const std::vector<StatString *> &statStrings, const std::map<std::string, int> &currentStatsMap, bool showPsi)
+{
+	std::string statString;
 	for (std::vector<StatString *>::const_iterator i = statStrings.begin(); i != statStrings.end(); ++i)
 	{
 		bool conditionsMet = true;
 		for (std::vector<StatStringCondition*>::const_iterator j = (*i)->getConditions().begin(); j != (*i)->getConditions().end() && conditionsMet; ++j)
 		{
-			std::map<std::string, int>::iterator name = currentStatsMap.find((*j)->getConditionName());
+			std::map<std::string, int>::const_iterator name = currentStatsMap.find((*j)->getConditionName());
 			if (name != currentStatsMap.end())
 			{
-				conditionsMet = conditionsMet && (*j)->isMet(name->second, currentStats.psiSkill > 0 || psiStrengthEval);
+				conditionsMet = conditionsMet && (*j)->isMet(name->second, showPsi);
 			}
 			else
 			{

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -119,8 +119,10 @@ public:
 	const std::vector<StatStringCondition*> &getConditions() const;
 	/// Get the StatString string.
 	std::string getString() const;
-	/// Calculate a StatString.
+	/// Calculate a StatString from UnitStats.
 	static std::string calcStatString(UnitStats &currentStats, const std::vector<StatString*> &statStrings, bool psiStrengthEval, bool inTraining);
+	/// Calculate a StatString.
+	static std::string calculateStatString(const std::vector<StatString *> &statStrings, const std::map<std::string, int> &currentStatsMap, bool showPsi);
 	/// Get the CurrentStats.
 	static std::map<std::string, int> getCurrentStats(UnitStats &currentStats);
 };

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -123,6 +123,7 @@ private:
 	UnitSide _fatalShotSide;
 	UnitBodyPart _fatalShotBodyPart;
 	std::string _murdererWeapon, _murdererWeaponAmmo;
+	const Mod *_mod;
 
 	// static data
 	std::string _type;
@@ -176,6 +177,8 @@ private:
 	void prepareUnitSounds();
 	/// Helper function preparing unit response sounds.
 	void prepareUnitResponseSounds(const Mod *mod);
+	/// Gets the script values (tags) of this unit as map
+	std::map<std::string, int> getUnitTagValues() const;
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Name of class used in script.
@@ -466,8 +469,12 @@ public:
 	const Armor *getArmor() const;
 	/// Sets the unit's name.
 	void setName(const std::string &name);
+	std::map<std::string, int> extracted() const;
+	
 	/// Gets the unit's name.
-	std::string getName(Language *lang, bool debugAppendId = false) const;
+	std::string getName(Language *lang, bool debugAppendId = false, bool primaryDisplay = true) const;
+	/// Gets the units StatTagString
+	std::string getStatTagString();
 	/// Gets the unit's stats.
 	UnitStats *getBaseStats();
 	/// Gets the unit's stats.

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -59,7 +59,7 @@ namespace OpenXcom
 SavedBattleGame::SavedBattleGame(Mod *rule, Language *lang) :
 	_battleState(0), _rule(rule), _mapsize_x(0), _mapsize_y(0), _mapsize_z(0), _selectedUnit(0),
 	_lastSelectedUnit(0), _pathfinding(0), _tileEngine(0), _enviroEffects(nullptr), _ecEnabledFriendly(false), _ecEnabledHostile(false), _ecEnabledNeutral(false),
-	_globalShade(0), _side(FACTION_PLAYER), _turn(0), _bughuntMinTurn(20), _animFrame(0), _nameDisplay(false),
+	_globalShade(0), _side(FACTION_PLAYER), _turn(0), _bughuntMinTurn(20), _animFrame(0), _nameDisplay(true),
 	_debugMode(false), _bughuntMode(false), _aborted(false), _itemId(0), _objectiveType(-1), _objectivesDestroyed(0), _objectivesNeeded(0), _unitsFalling(false),
 	_cheating(false), _tuReserved(BA_NONE), _kneelReserved(false), _depth(0),
 	_ambience(-1), _ambientVolume(0.5), _minAmbienceRandomDelay(20), _maxAmbienceRandomDelay(60), _currentAmbienceDelay(0),

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <yaml-cpp/yaml.h>
 #include "../Mod/Unit.h"
+#include "../Mod/RuleSoldier.h"
 #include "../Mod/StatString.h"
 #include "../Engine/Script.h"
 
@@ -79,10 +80,12 @@ private:
 	SoldierDeath *_death;
 	SoldierDiary *_diary;
 	std::string _statString;
+	std::string _statTagString;
 	bool _corpseRecovered;
 	std::map<std::string, int> _previousTransformations, _transformationBonuses;
 	std::vector<const RuleSoldierBonus*> _bonusCache;
 	ScriptValues<Soldier> _scriptValues;
+	const std::vector<StatString *> *_globalStatStrings;
 public:
 	/// Creates a new soldier.
 	Soldier(RuleSoldier *rules, Armor *armor, int id = 0);
@@ -93,7 +96,7 @@ public:
 	/// Saves the soldier to YAML.
 	YAML::Node save(const ScriptGlobal *shared) const;
 	/// Gets the soldier's name.
-	std::string getName(bool statstring = false, unsigned int maxLength = 20) const;
+	std::string getName(NameDisplayMode displayMode = NDM_DEFAULT, unsigned int maxLength = 20) const;
 	/// Sets the soldier's name.
 	void setName(const std::string &name);
 	/// Gets the soldier's callsign.
@@ -217,6 +220,8 @@ public:
 	void resetDiary();
 	/// Calculate statString.
 	void calcStatString(const std::vector<StatString *> &statStrings, bool psiStrengthEval);
+	/// Calculate unit state string
+	void calcStatTagString(const std::map<std::string, int> &unitTags);
 	/// Trains a soldier's physical stats
 	void trainPhys(int customTrainingFactor);
 	/// Is the soldier already fully trained?


### PR DESCRIPTION
This commit extends the StatString definitions to allow for the usage of script tags.
StatStrings resulting from tags are appended as an additional separated statstring.

Possible use cases:
 - Status effects display (poison, stunned, acid, etc.)
 - Fatal Wounds Indicator
 - Skill Effect Indicator
 - Recovery Status Indicator
 - Class Strings
 - And many more, since modders will find some interesting uses for this