### PR TITLE
ScriptedItems

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -1805,9 +1805,15 @@ void BattlescapeGame::primaryAction(Position pos)
 				}
 			}
 		}
-		else if ((_currentAction.type == BA_PANIC || _currentAction.type == BA_MINDCONTROL || _currentAction.type == BA_USE) && _currentAction.weapon->getRules()->getBattleType() == BT_PSIAMP)
+		else if ((_currentAction.type == BA_PANIC
+				  || _currentAction.type == BA_MINDCONTROL
+				  || _currentAction.type == BA_USE)
+				 && (_currentAction.weapon->getRules()->getBattleType() == BT_PSIAMP
+					 || _currentAction.weapon->getRules()->getBattleType() == BT_SCRIPTED))
 		{
-			if (_save->selectUnit(pos) && _save->selectUnit(pos)->getFaction() != _save->getSelectedUnit()->getFaction() && _save->selectUnit(pos)->getVisible())
+			if (_save->selectUnit(pos)
+				&& (_save->selectUnit(pos)->getFaction() != _save->getSelectedUnit()->getFaction() || _currentAction.weapon->getRules()->isFriendlyTargetingAllowed())
+				&& _save->selectUnit(pos)->getVisible())
 			{
 				_currentAction.updateTU();
 				_currentAction.target = pos;

--- a/src/Battlescape/ExplosionBState.cpp
+++ b/src/Battlescape/ExplosionBState.cpp
@@ -110,16 +110,20 @@ void ExplosionBState::init()
 			_damageType = itemRule->getDamageType();
 		}
 
-		if (type == BT_PSIAMP || _hit)
+		if ((type == BT_PSIAMP
+			 || (type == BT_SCRIPTED
+				  && (action == BA_MINDCONTROL || action == BA_PANIC))) || _hit)
 		{
 			Position targetPos = _center.toTile();
 			_targetPsiOrHit = _parent->getSave()->getTile(targetPos)->getOverlappingUnit(_parent->getSave());
 		}
 
 		//testing if we hit target
-		if (type == BT_PSIAMP && !_hit)
+		if ((type == BT_PSIAMP
+			 || (type == BT_SCRIPTED
+				 && (action == BA_MINDCONTROL || action == BA_PANIC))) && !_hit)
 		{
-			if (action != BA_USE)
+			if (action != BA_USE && type != BT_SCRIPTED)
 			{
 				_power = 0;
 			}
@@ -128,7 +132,7 @@ void ExplosionBState::init()
 				_power = 0;
 				miss = true;
 			}
-			else
+			else if (type != BT_SCRIPTED)
 			{
 				_parent->psiAttackMessage(_attack, _targetPsiOrHit);
 			}

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -4106,6 +4106,27 @@ bool TileEngine::medikitUse(BattleAction *action, BattleUnit *target, BattleMedi
 	
 	return canContinueHealing;
 }
+	
+void TileEngine::scriptedItemUse(BattleAction *action)
+{
+	BattleItem *item = action->weapon;
+	BattleActionType actionType = action->type;
+	bool canPerformAction = true;
+	ModScript::ScriptedItemUse::Output args { actionType, canPerformAction };
+	
+	ModScript::ScriptedItemUse::Worker work { action->actor, action->weapon, _save };
+	
+	work.execute(item->getRules()->getScript<ModScript::ScriptedItemUse>(), args);
+	
+	int newActionType = args.getFirst();
+	bool newCanPerformAction = args.getSecond();
+	
+	action->type = static_cast<BattleActionType>(newActionType);
+	if (!newCanPerformAction)
+	{
+		action->result = "STR_SCRIPTED_ITEM_DENIED";
+	}
+}
 
 /**
  * Tries to conceal a unit. Only works if no unit of another faction is watching.

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -204,6 +204,8 @@ public:
 	void medikitRemoveIfEmpty(BattleAction *action);
 	/// Try using medikit heal ability.
 	bool medikitUse(BattleAction *action, BattleUnit *target, BattleMediKitAction medikitAction, int bodyPart);
+	/// Try using a scripted item
+	void scriptedItemUse(BattleAction *action);
 	/// Try to conceal a unit.
 	bool tryConcealUnit(BattleUnit* unit);
 	/// Applies gravity to anything that occupy this tile.

--- a/src/Mod/ModScript.h
+++ b/src/Mod/ModScript.h
@@ -99,7 +99,6 @@ class ModScript
 	{
 		VisibilityUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-
 	struct HitUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, int, int, int>
 	{
 		HitUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
@@ -142,7 +141,10 @@ class ModScript
 	{
 		NewTurnItemParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-
+	struct ScriptedItemUseParser : ScriptParserEvents<ScriptOutputArgs<int&, int&>, BattleUnit*, BattleItem*, SavedBattleGame*>
+	{
+		ScriptedItemUseParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
+	};
 	struct RecolorItemParser : ScriptParserEvents<Output, const BattleItem*, int, int, int>
 	{
 		RecolorItemParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
@@ -256,6 +258,7 @@ public:
 	using SelectItemSprite = MACRO_NAMED_SCRIPT("selectItemSprite", SelectItemParser);
 
 	using ReactionWeaponAction = MACRO_NAMED_SCRIPT("reactionWeaponAction", ReactionUnitParser);
+	using ScriptedItemUse = MACRO_NAMED_SCRIPT("scriptedItemUse", ScriptedItemUseParser);
 
 	using CreateItem = MACRO_NAMED_SCRIPT("createItem", CreateItemParser);
 	using NewTurnItem = MACRO_NAMED_SCRIPT("newTurnItem", NewTurnItemParser);
@@ -330,6 +333,7 @@ public:
 		SelectItemSprite,
 
 		ReactionWeaponAction,
+		ScriptedItemUse,
 
 		CreateItem,
 		NewTurnItem

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -66,7 +66,7 @@ RuleItem::RuleItem(const std::string &type) :
 	_experienceTrainingMode(ETM_DEFAULT), _manaExperience(0), _listOrder(0),
 	_maxRange(200), _minRange(0), _dropoff(2), _bulletSpeed(0), _explosionSpeed(0), _shotgunPellets(0), _shotgunBehaviorType(0), _shotgunSpread(100), _shotgunChoke(100),
 	_spawnUnitFaction(-1),
-	_LOSRequired(false), _underwaterOnly(false), _landOnly(false), _psiReqiured(false), _manaRequired(false),
+	_LOSRequired(false), _isFriendlyTargetingAllowed(false), _underwaterOnly(false), _landOnly(false), _psiReqiured(false), _manaRequired(false),
 	_meleePower(0), _specialType(-1), _vaporColor(-1), _vaporDensity(0), _vaporProbability(15),
 	_kneelBonus(-1), _oneHandedPenalty(-1),
 	_monthlySalary(0), _monthlyMaintenance(0),
@@ -513,7 +513,7 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 		}
 	}
 
-	if ((_battleType == BT_MELEE || _battleType == BT_FIREARM) && _clipSize == 0)
+	if ((_battleType == BT_MELEE || _battleType == BT_FIREARM || _battleType == BT_SCRIPTED) && _clipSize == 0)
 	{
 		for (RuleItemAction* conf : { &_confAimed, &_confAuto, &_confSnap, &_confMelee, })
 		{
@@ -599,6 +599,7 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 	_spawnUnit = node["spawnUnit"].as<std::string>(_spawnUnit);
 	_spawnUnitFaction = node["spawnUnitFaction"].as<int>(_spawnUnitFaction);
 	_LOSRequired = node["LOSRequired"].as<bool>(_LOSRequired);
+	_isFriendlyTargetingAllowed = node["friendlyTargetingAllowed"].as<bool>(_isFriendlyTargetingAllowed);
 	_meleePower = node["meleePower"].as<int>(_meleePower);
 	_underwaterOnly = node["underwaterOnly"].as<bool>(_underwaterOnly);
 	_landOnly = node["landOnly"].as<bool>(_landOnly);
@@ -2215,6 +2216,15 @@ int RuleItem::getMeleePower() const
 bool RuleItem::isLOSRequired() const
 {
 	return _LOSRequired;
+}
+
+/**
+ * Is targeting of units of the own faction allowed?
+ * @return If the item allows targeting of friendly units.
+ */
+bool RuleItem::isFriendlyTargetingAllowed() const
+{
+	return _isFriendlyTargetingAllowed;
 }
 
 /**

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -29,7 +29,7 @@
 namespace OpenXcom
 {
 
-enum BattleType { BT_NONE, BT_FIREARM, BT_AMMO, BT_MELEE, BT_GRENADE, BT_PROXIMITYGRENADE, BT_MEDIKIT, BT_SCANNER, BT_MINDPROBE, BT_PSIAMP, BT_FLARE, BT_CORPSE };
+enum BattleType { BT_NONE, BT_FIREARM, BT_AMMO, BT_MELEE, BT_GRENADE, BT_PROXIMITYGRENADE, BT_MEDIKIT, BT_SCANNER, BT_MINDPROBE, BT_PSIAMP, BT_FLARE, BT_CORPSE, BT_SCRIPTED };
 enum BattleFuseType { BFT_NONE = -3, BFT_INSTANT = -2, BFT_SET = -1, BFT_FIX_MIN = 0, BFT_FIX_MAX = 64 };
 enum BattleMediKitType { BMT_NORMAL = 0, BMT_HEAL = 1, BMT_STIMULANT = 2, BMT_PAINKILLER = 3 };
 enum BattleMediKitAction { BMA_HEAL = 1, BMA_STIMULANT = 2, BMA_PAINKILLER = 4 };
@@ -210,7 +210,7 @@ private:
 	std::map<std::string, std::string> _zombieUnitByArmorMale, _zombieUnitByArmorFemale, _zombieUnitByType;
 	std::string _zombieUnit, _spawnUnit;
 	int _spawnUnitFaction;
-	bool _LOSRequired, _underwaterOnly, _landOnly, _psiReqiured, _manaRequired;
+	bool _LOSRequired, _isFriendlyTargetingAllowed, _underwaterOnly, _landOnly, _psiReqiured, _manaRequired;
 	int _meleePower, _specialType, _vaporColor, _vaporDensity, _vaporProbability;
 	std::vector<int> _customItemPreviewIndex;
 	int _kneelBonus, _oneHandedPenalty;
@@ -635,6 +635,8 @@ public:
 	int getSpawnUnitFaction() const;
 	/// Check if LOS is required to use this item (only applies to psionic type items)
 	bool isLOSRequired() const;
+	/// Check if this item allows targeting of friendly units
+	bool isFriendlyTargetingAllowed() const;
 	/// Is this item restricted to underwater use?
 	bool isWaterOnly() const;
 	/// Is this item restricted to land use?

--- a/src/Savegame/BattleItem.cpp
+++ b/src/Savegame/BattleItem.cpp
@@ -55,7 +55,7 @@ BattleItem::BattleItem(const RuleItem *rules, int *id) : _id(*id), _rules(rules)
 			setStimulantQuantity (_rules->getStimulantQuantity());
 		}
 		// weapon does not need ammo, ammo item points to weapon
-		else if (_rules->getBattleType() == BT_FIREARM || _rules->getBattleType() == BT_MELEE)
+		else if (_rules->getBattleType() == BT_FIREARM || _rules->getBattleType() == BT_MELEE || _rules->getBattleType() == BT_SCRIPTED)
 		{
 			_confAimedOrLaunch = _rules->getConfigAimed();
 			_confAuto = _rules->getConfigAuto();
@@ -1495,6 +1495,21 @@ ModScript::SelectItemParser::SelectItemParser(ScriptGlobal* shared, const std::s
 
 	setDefault("add sprite_index sprite_offset; return sprite_index;");
 }
+
+ModScript::ScriptedItemUseParser::ScriptedItemUseParser(ScriptGlobal* shared, const std::string& name, Mod* mod) : ScriptParserEvents{ shared, name,
+	"action_type",
+	"can_perform_action",
+	"actor",
+	"item",
+	"battle_game"}
+{
+	BindBase b { this };
+	
+	b.addCustomPtr<const Mod>("rules", mod);
+	
+	setEmptyReturn();
+}
+
 
 ModScript::CreateItemParser::CreateItemParser(ScriptGlobal* shared, const std::string& name, Mod* mod) : ScriptParserEvents{ shared, name, "item", "battle_game", "turn", }
 {

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -265,9 +265,9 @@ std::vector<SoldierCommendations*> *SoldierDiary::getSoldierCommendations()
  */
 bool SoldierDiary::manageCommendations(Mod *mod, std::vector<MissionStatistics*> *missionStatistics)
 {
-	const int BATTLE_TYPES = 13;
+	const int BATTLE_TYPES = 14;
 	const std::string battleTypeArray[BATTLE_TYPES] = { "BT_NONE", "BT_FIREARM", "BT_AMMO", "BT_MELEE", "BT_GRENADE",
-		"BT_PROXIMITYGRENADE", "BT_MEDIKIT", "BT_SCANNER", "BT_MINDPROBE", "BT_PSIAMP", "BT_FLARE", "BT_CORPSE", "BT_END" };
+		"BT_PROXIMITYGRENADE", "BT_MEDIKIT", "BT_SCANNER", "BT_MINDPROBE", "BT_PSIAMP", "BT_FLARE", "BT_CORPSE", "BT_SCRIPTED", "BT_END" };
 	const int DAMAGE_TYPES = 21;
 	const std::string damageTypeArray[DAMAGE_TYPES] = { "DT_NONE", "DT_AP", "DT_IN", "DT_HE", "DT_LASER", "DT_PLASMA",
 		"DT_STUN", "DT_MELEE", "DT_ACID", "DT_SMOKE",

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -890,6 +890,7 @@ void StatsForNerdsState::addBattleType(std::ostringstream &ss, const BattleType 
 		case BT_PSIAMP: ss << tr("BT_PSIAMP"); break;
 		case BT_FLARE: ss << tr("BT_FLARE"); break;
 		case BT_CORPSE: ss << tr("BT_CORPSE"); break;
+		case BT_SCRIPTED: ss << tr("BT_SCRIPTED"); break;
 		default: ss << tr("STR_UNKNOWN"); break;
 	}
 	if (_showIds)
@@ -1444,6 +1445,7 @@ void StatsForNerdsState::initItemList()
 	addBoolean(ss, itemRule->isPsiRequired(), "psiRequired", psiRequiredDefault);
 	addBoolean(ss, itemRule->isManaRequired(), "manaRequired");
 	addBoolean(ss, itemRule->isLOSRequired(), "LOSRequired");
+	addBoolean(ss, itemRule->isFriendlyTargetingAllowed(), "friendlyTargetingAllowed");
 
 	if (itemBattleType == BT_FIREARM
 		|| itemBattleType == BT_GRENADE


### PR DESCRIPTION
Items with a dedicated "use" script hook and fully configurable actions.
 - added new BattleType 12 BT_SCRIPTED
 - added script hook scriptedItemUse, called after an user clicks on the action menu item
 - added script hook psiAttack, called after the psi attack success calculation, allows override
 - scriptedItems support up to 5 scriptable actions
 - allowed scripted items to act as firearms
 - allowed scripted items to have actions with zero TU cost, if mana is used instead
 - extended action menu display, zero TU actions will display their mana cost
 - allowed scripted items to act as psi amp
 - allowed scripted items to target friendly units