### PR TITLE
Skill menu for soldiers

### DIFF
--- a/bin/standard/xcom1/Language/OXCE/en-US.yml
+++ b/bin/standard/xcom1/Language/OXCE/en-US.yml
@@ -12,6 +12,8 @@ en-US:
 #=================== Battlescape ===================
 #InventoryState.cpp
   STR_PSI_SHORT: "PSI>{ALT}{0}/{1}"
+#SkillMenuState.cpp
+  STR_MANA_SHORT: "MA>{ALT}{0}"
 #=================== Geoscape ===================
 #DogfightState.cpp
   STR_EVASIVE_MANEUVERS: "EVASIVE MANEUVERS"

--- a/src/Battlescape/ActionMenuItem.cpp
+++ b/src/Battlescape/ActionMenuItem.cpp
@@ -96,7 +96,14 @@ void ActionMenuItem::setAction(BattleActionType action, const std::string &descr
 	_tu = tu;
 	_redraw = true;
 }
-
+/**
+ * Links with a skill.
+ * @param skill The linked skill.
+ */
+void ActionMenuItem::setSkill(const RuleSkill *skill)
+{
+	_skill = skill;
+}
 /**
  * Gets the action that was linked to this menu item.
  * @return Action that was linked to this menu item.
@@ -105,7 +112,14 @@ BattleActionType ActionMenuItem::getAction() const
 {
 	return _action;
 }
-
+/**
+ * Gets the action that was linked to this menu item.
+ * @return Action that was linked to this menu item.
+ */
+const RuleSkill* ActionMenuItem::getSkill() const
+{
+	return _skill;
+}
 /**
  * Gets the action tus that were linked to this menu item.
  * @return The timeunits that were linked to this menu item.

--- a/src/Battlescape/ActionMenuItem.h
+++ b/src/Battlescape/ActionMenuItem.h
@@ -28,6 +28,7 @@ class Font;
 class Language;
 class Text;
 class Frame;
+class RuleSkill;
 
 /**
  * A class that represents a single box in the action popup menu on the battlescape.
@@ -42,6 +43,7 @@ private:
 	int _tu, _highlightModifier;
 	Frame *_frame;
 	Text *_txtDescription, *_txtAcc, *_txtTU;
+	const RuleSkill* _skill;
 public:
 	/// Creates a new ActionMenuItem.
 	ActionMenuItem(int id, Game *game, int x, int y);
@@ -49,8 +51,11 @@ public:
 	~ActionMenuItem();
 	/// Assigns an action to it.
 	void setAction(BattleActionType action, const std::string &description, const std::string &accuracy, const std::string &timeunits, int tu);
+	void setSkill(const RuleSkill* skill);
 	/// Gets the assigned action.
 	BattleActionType getAction() const;
+	/// Gets the assigned skill.
+	const RuleSkill* getSkill() const;
 	/// Gets the assigned action TUs.
 	int getTUs() const;
 	/// Sets the palettes.

--- a/src/Battlescape/ActionMenuState.cpp
+++ b/src/Battlescape/ActionMenuState.cpp
@@ -491,7 +491,7 @@ void ActionMenuState::handleAction()
 	{
 		_game->getSavedGame()->getSavedBattle()->appendToHitLog(HITLOG_PLAYER_FIRING, FACTION_PLAYER, tr(weapon->getType()));
 	}
-	}
+}
 
 /**
  * Updates the scale.

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -177,7 +177,7 @@ bool BattleActionCost::spendTU(std::string *message)
  * @param unit unit performing attack.
  * @param item weapon of choice.
  */
-BattleActionAttack::BattleActionAttack(BattleActionType action, BattleUnit *unit, BattleItem *item, BattleItem *ammo) : type{ action }, attacker{ unit }, weapon_item{ nullptr }, damage_item{ nullptr }
+BattleActionAttack::BattleActionAttack(BattleActionType action, BattleUnit *unit, BattleItem *item, BattleItem *ammo) : type{ action }, attacker{ unit }
 {
 	if (item)
 	{

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -38,7 +38,7 @@ class Pathfinding;
 class Mod;
 class InfoboxOKState;
 class SoldierDiary;
-struct RuleSkill;
+class RuleSkill;
 
 enum BattleActionType : Uint8 { BA_NONE, BA_TURN, BA_WALK, BA_KNEEL, BA_PRIME, BA_UNPRIME, BA_THROW, BA_AUTOSHOT, BA_SNAPSHOT, BA_AIMEDSHOT, BA_HIT, BA_USE, BA_LAUNCH, BA_MINDCONTROL, BA_PANIC, BA_RETHINK, BA_CQB };
 enum BattleActionMove { BAM_NORMAL = 0, BAM_RUN = 1, BAM_STRAFE = 2 };

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -46,18 +46,18 @@ enum BattleActionMove { BAM_NORMAL = 0, BAM_RUN = 1, BAM_STRAFE = 2 };
 struct BattleActionCost : RuleItemUseCost
 {
 	BattleActionType type;
-	BattleUnit *actor;
-	BattleItem *weapon;
-	const RuleSkill* skillRules; // if defined, this is a skill action
+	BattleUnit *actor = nullptr;
+	BattleItem *weapon = nullptr;
+	const RuleSkill* skillRules = nullptr; // if defined, this is a skill action
 
 	/// Default constructor.
-	BattleActionCost() : type(BA_NONE), actor(0), weapon(0), skillRules(0) { }
+	BattleActionCost() : type(BA_NONE) { }
 
 	/// Constructor from unit.
-	BattleActionCost(BattleUnit *unit) : type(BA_NONE), actor(unit), weapon(0), skillRules(0) { }
+	BattleActionCost(BattleUnit *unit) : type(BA_NONE), actor(unit) { }
 
 	/// Constructor with update.
-	BattleActionCost(BattleActionType action, BattleUnit *unit, BattleItem *item) : type(action), actor(unit), weapon(item), skillRules(0) { updateTU(); }
+	BattleActionCost(BattleActionType action, BattleUnit *unit, BattleItem *item) : type(action), actor(unit), weapon(item) { updateTU(); }
 
 	/// Update value of TU based of actor, weapon and type.
 	void updateTU();
@@ -99,13 +99,13 @@ struct BattleAction : BattleActionCost
 struct BattleActionAttack
 {
 	BattleActionType type;
-	BattleUnit *attacker;
-	BattleItem *weapon_item;
-	BattleItem *damage_item;
-	const RuleSkill *skill_rules;
+	BattleUnit *attacker = nullptr;
+	BattleItem *weapon_item = nullptr;
+	BattleItem *damage_item = nullptr;
+	const RuleSkill *skill_rules = nullptr;
 
 	/// Default constructor.
-	BattleActionAttack(BattleActionType action = BA_NONE, BattleUnit *unit = nullptr) : type{ action }, attacker{ unit }, weapon_item{ nullptr }, damage_item{ nullptr }, skill_rules{ nullptr }
+	BattleActionAttack(BattleActionType action = BA_NONE, BattleUnit *unit = nullptr) : type{ action }, attacker{ unit }
 	{
 
 	}

--- a/src/Battlescape/BattlescapeGame.h
+++ b/src/Battlescape/BattlescapeGame.h
@@ -48,27 +48,28 @@ struct BattleActionCost : RuleItemUseCost
 	BattleActionType type;
 	BattleUnit *actor;
 	BattleItem *weapon;
+	const RuleSkill* skillRules; // if defined, this is a skill action
 
 	/// Default constructor.
-	BattleActionCost() : type(BA_NONE), actor(0), weapon(0) { }
+	BattleActionCost() : type(BA_NONE), actor(0), weapon(0), skillRules(0) { }
 
 	/// Constructor from unit.
-	BattleActionCost(BattleUnit *unit) : type(BA_NONE), actor(unit), weapon(0) { }
+	BattleActionCost(BattleUnit *unit) : type(BA_NONE), actor(unit), weapon(0), skillRules(0) { }
 
 	/// Constructor with update.
-	BattleActionCost(BattleActionType action, BattleUnit *unit, BattleItem *item) : type(action), actor(unit), weapon(item) { updateTU(); }
+	BattleActionCost(BattleActionType action, BattleUnit *unit, BattleItem *item) : type(action), actor(unit), weapon(item), skillRules(0) { updateTU(); }
 
 	/// Update value of TU based of actor, weapon and type.
-	virtual void updateTU();
+	void updateTU();
 	/// Set TU to zero.
-	virtual void clearTU();
+	void clearTU();
 	/// Test if actor have enough TU to perform weapon action.
-	virtual bool haveTU(std::string *message = 0);
+	bool haveTU(std::string *message = 0);
 	/// Spend TU when actor have enough TU.
-	virtual bool spendTU(std::string *message = 0);
+	bool spendTU(std::string *message = 0);
 };
 
-struct BattleAction final : BattleActionCost
+struct BattleAction : BattleActionCost
 {
 	Position target;
 	std::list<Position> waypoints;
@@ -82,16 +83,12 @@ struct BattleAction final : BattleActionCost
 	bool desperate; // ignoring newly-spotted units
 	int finalFacing;
 	bool finalAction;
-	const RuleSkill* skillRules; // if defined, this is a skill action
 	int number; // first action of turn, second, etc.?
 	bool sprayTargeting; // Used to separate waypoint checks between confirm firing mode and the "spray" autoshot
 
 	/// Default constructor
-	BattleAction() : target(-1, -1, -1), targeting(false), value(0), strafe(false), run(false), ignoreSpottedEnemies(false), diff(0), autoShotCounter(0), cameraPosition(0, 0, -1), desperate(false), finalFacing(-1), finalAction(false), skillRules(nullptr), number(0), sprayTargeting(false) { }
+	BattleAction() : target(-1, -1, -1), targeting(false), value(0), strafe(false), run(false), ignoreSpottedEnemies(false), diff(0), autoShotCounter(0), cameraPosition(0, 0, -1), desperate(false), finalFacing(-1), finalAction(false), number(0), sprayTargeting(false) { }
 
-	bool haveTU(std::string *message = 0);
-	void updateTU();
-	
 	/// Get move type
 	BattleActionMove getMoveType() const
 	{

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1988,7 +1988,13 @@ void BattlescapeState::updateSoldierInfo(bool checkFOV)
 		}
 	}
 
+	updateUiButton(battleUnit);
+}
+
+void BattlescapeState::updateUiButton(const BattleUnit *battleUnit)
+{
 	bool hasPsiWeapon = battleUnit->getSpecialWeapon(BT_PSIAMP) != 0;
+	auto soldier = battleUnit->getGeoscapeSoldier();
 	
 	BattleType type = BT_NONE;
 	BattleItem *specialWeapon = battleUnit->getSpecialIconWeapon(type); // updates type!
@@ -2002,27 +2008,46 @@ void BattlescapeState::updateSoldierInfo(bool checkFOV)
 	}
 	if (hasSpecialWeapon)
 	{
-		showPsiButton(false);
-		showSpecialButton(true, specialWeapon->getRules()->getSpecialIconSprite());
-		showSkillsButton(false);
+		showUiButton(BTN_SPECIAL, specialWeapon->getRules()->getSpecialIconSprite());
 	}
 	else if (hasSkills)
 	{
-		showPsiButton(false);
-		showSpecialButton(false);
-		showSkillsButton(true, soldier->getRules()->getSkillIconSprite());
+		showUiButton(BTN_SKILL, soldier->getRules()->getSkillIconSprite());
 	}
 	else if (hasPsiWeapon)
 	{
-		showPsiButton(true);
-		showSpecialButton(false);
-		showSkillsButton(false);
+		showUiButton(BTN_PSI);
 	}
 	else
 	{
-		showPsiButton(false);
-		showSpecialButton(false);
-		showSkillsButton(false);
+		showUiButton(BTN_NONE);
+	}
+}
+
+void BattlescapeState::showUiButton(ButtonType buttonType, int spriteIndex)
+{
+	switch (buttonType) {
+		case BTN_PSI:
+			showPsiButton(true);
+			showSpecialButton(false);
+			showSkillsButton(false);
+			break;
+		case BTN_SPECIAL:
+			showPsiButton(false);
+			showSpecialButton(true, spriteIndex);
+			showSkillsButton(false);
+			break;
+		case BTN_SKILL:
+			showPsiButton(false);
+			showSpecialButton(false);
+			showSkillsButton(true, spriteIndex);
+			break;
+		case BTN_NONE:
+		default:
+			showPsiButton(false);
+			showSpecialButton(false);
+			showSkillsButton(false);
+			break;
 	}
 }
 

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -1762,9 +1762,7 @@ void BattlescapeState::updateSoldierInfo(bool checkFOV)
 	if (!playableUnit)
 	{
 		_txtName->setText("");
-		showPsiButton(false);
-		showSpecialButton(false);
-		showSkillsButton(false);
+		showUiButton();
 		toggleKneelButton(0);
 		return;
 	}

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -52,7 +52,7 @@ private:
 	Map *_map;
 	BattlescapeButton *_btnUnitUp, *_btnUnitDown, *_btnMapUp, *_btnMapDown, *_btnShowMap, *_btnKneel;
 	BattlescapeButton *_btnInventory, *_btnCenter, *_btnNextSoldier, *_btnNextStop, *_btnShowLayers, *_btnHelp;
-	BattlescapeButton *_btnEndTurn, *_btnAbort, *_btnLaunch, *_btnPsi, *_btnSpecial, *_reserve;
+	BattlescapeButton *_btnEndTurn, *_btnAbort, *_btnLaunch, *_btnPsi, *_btnSpecial, *_btnSkills, *_reserve;
 	InteractiveSurface *_btnStats;
 	BattlescapeButton *_btnReserveNone, *_btnReserveSnap, *_btnReserveAimed, *_btnReserveAuto, *_btnReserveKneel, *_btnZeroTUs;
 	InteractiveSurface *_btnLeftHandItem, *_btnRightHandItem;
@@ -175,6 +175,8 @@ public:
 	void btnPsiClick(Action *action);
 	/// Handler for clicking the use special weapon button.
 	void btnSpecialClick(Action *action);
+	/// Handler for clicking the skills menu button.
+	void btnSkillsClick(Action *action);
 	/// Handler for clicking a reserved button.
 	void btnReserveClick(Action *action);
 	/// Handler for clicking the reload button.
@@ -219,6 +221,8 @@ public:
 	void showPsiButton(bool show);
 	/// Shows the special weapon button.
 	void showSpecialButton(bool show, int sprite = 1);
+	/// Shows the skills menu button.
+	void showSkillsButton(bool show, int sprite = 1);
 	/// Clears mouse-scrolling state.
 	void clearMouseScrollingState();
 	/// Returns a pointer to the battlegame, in case we need its functions.

--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -46,6 +46,9 @@ class BattlescapeGame;
  */
 class BattlescapeState : public State
 {
+
+enum ButtonType { BTN_NONE, BTN_PSI, BTN_SPECIAL, BTN_SKILL };
+
 private:
 	Surface *_rank, *_rankTiny;
 	InteractiveSurface *_icons;
@@ -104,6 +107,12 @@ private:
 	void blinkHealthBar();
 	/// Shows the unit kneel state.
 	void toggleKneelButton(BattleUnit* unit);
+	/// Shows the PSI button.
+	void showPsiButton(bool show);
+	/// Shows the special weapon button.
+	void showSpecialButton(bool show, int sprite = 1);
+	/// Shows the skills menu button.
+	void showSkillsButton(bool show, int sprite = 1);
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false, bool checkFOV = true);
@@ -217,12 +226,10 @@ public:
 	void finishBattle(bool abort, int inExitArea);
 	/// Show the launch button.
 	void showLaunchButton(bool show);
-	/// Shows the PSI button.
-	void showPsiButton(bool show);
-	/// Shows the special weapon button.
-	void showSpecialButton(bool show, int sprite = 1);
-	/// Shows the skills menu button.
-	void showSkillsButton(bool show, int sprite = 1);
+	/// Show one of Psi, Special or Skill button
+	void showUiButton(ButtonType buttonType = BTN_NONE, int spriteIndex = 1);
+	/// Updates the special/psi/skill button display based on the battle unit
+	void updateUiButton(const BattleUnit *battleUnit);
 	/// Clears mouse-scrolling state.
 	void clearMouseScrollingState();
 	/// Returns a pointer to the battlegame, in case we need its functions.

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2010-2020 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "SkillMenuState.h"
+#include "../Engine/Game.h"
+#include "../Engine/Options.h"
+#include "../Engine/LocalizedText.h"
+#include "../Engine/Action.h"
+#include "../Engine/Sound.h"
+#include "../Engine/Unicode.h"
+#include "../Savegame/BattleUnit.h"
+#include "../Savegame/BattleItem.h"
+#include "../Savegame/SoldierDiary.h"
+#include "../Mod/Mod.h"
+#include "../Mod/RuleSoldier.h"
+#include "../Mod/RuleSoldierBonus.h"
+#include "ActionMenuItem.h"
+#include "PrimeGrenadeState.h"
+#include "MedikitState.h"
+#include "ScannerState.h"
+#include "../Savegame/SavedGame.h"
+#include "../Savegame/SavedBattleGame.h"
+#include "../Savegame/Tile.h"
+#include "Pathfinding.h"
+#include "TileEngine.h"
+#include "../Interface/Text.h"
+#include "../Savegame/EquipmentLayoutItem.h"
+
+namespace OpenXcom
+{
+	
+/**
+ * Initializes all the elements in the Action Menu window.
+ * @param game Pointer to the core game.
+ * @param action Pointer to the action.
+ * @param x Position on the x-axis.
+ * @param y position on the y-axis.
+ */
+	SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuState(action)
+{
+	_screen = false;
+	
+	// Set palette
+	_game->getSavedGame()->getSavedBattle()->setPaletteByDepth(this);
+
+	for (int i = 0; i < 6; ++i)
+	{
+		_actionMenu[i] = new ActionMenuItem(i, _game, x, y);
+		add(_actionMenu[i]);
+		_actionMenu[i]->setVisible(false);
+		_actionMenu[i]->onMouseClick((ActionHandler)&SkillMenuState::btnActionMenuItemClick);
+	}
+
+	auto soldier = _action->actor->getGeoscapeSoldier();
+	const RuleSoldier *soldierRules = soldier->getRules();
+	
+	// Build up the popup menu
+	int id = 0;
+	
+	auto skills = soldierRules->getSkills();
+	std::vector<SDLKey> hotkeys = {Options::keyBattleActionItem5, Options::keyBattleActionItem4, Options::keyBattleActionItem3, Options::keyBattleActionItem2, Options::keyBattleActionItem1};
+	for (auto skill : skills)
+	{
+		if (hasBonus(soldier, skill)
+			&& (skill->Cost.Time > 0 || skill->Cost.Mana > 0)
+			&& (!skill->IsPsiRequired || _action->actor->getBaseStats()->psiSkill > 0))
+		{
+			_action->skillRules = skill;
+			chooseWeaponForSkill(_action, skill->CompatibleWeapons, skill->CheckHandsOnly);
+			addItem(skill->TargetMode, skill->Name, &id, hotkeys.back());
+			hotkeys.pop_back();
+		}
+	}
+	_action->skillRules = nullptr;
+	_action->weapon = 0;
+}
+
+/**
+ * Deletes the SkillMenuState.
+ */
+SkillMenuState::~SkillMenuState()
+{
+
+}
+
+bool SkillMenuState::hasBonus(Soldier *soldier, const RuleSkill *skillRules)
+{
+	// Does the soldier have the required commendations?
+	for (auto reqd_bonus : skillRules->RequiredBonus)
+	{
+		bool found = false;
+		for (const RuleSoldierBonus *bonus : *soldier->getBonuses(_game->getMod()))
+		{
+			if (bonus->getName() == reqd_bonus)
+			{
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+			return false;
+	}
+	return true;
+}
+
+/**
+ * Adds a new menu item for an action.
+ * @param ba Action type.
+ * @param name Action description.
+ * @param id Pointer to the new item ID.
+ */
+void SkillMenuState::addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key)
+{
+	std::string s1, s2;
+	RuleItemUseCost cost = _action->actor->getActionTUs(ba, _action->skillRules);
+	
+	if (_action->weapon)
+	{
+		int acc = _action->actor->getFiringAccuracy(ba, _action->weapon, _game->getMod());
+		if (ba == BA_THROW || ba == BA_AIMEDSHOT || ba == BA_SNAPSHOT || ba == BA_AUTOSHOT || ba == BA_LAUNCH || ba == BA_HIT)
+			s1 = tr("STR_ACCURACY_SHORT").arg(Unicode::formatPercentage(acc));
+	}
+	
+	if (cost.Time > 0)
+	{
+		s2 = tr("STR_TIME_UNITS_SHORT").arg(cost.Time);
+	}
+	else if (cost.Mana > 0)
+	{
+		s2 = tr("STR_MANA_SHORT").arg(cost.Mana);
+	}
+
+	_actionMenu[*id]->setAction(ba, tr(name), s1, s2, cost.Time);
+	_actionMenu[*id]->setVisible(true);
+	
+	if (key != SDLK_UNKNOWN)
+	{
+		_actionMenu[*id]->onKeyboardPress((ActionHandler)&SkillMenuState::btnActionMenuItemClick, key);
+	}
+	(*id)++;
+}
+
+
+/**
+ * Executes the action corresponding to this action menu item.
+ * @param action Pointer to an action.
+ */
+void SkillMenuState::btnActionMenuItemClick(Action *action)
+{
+	_game->getSavedGame()->getSavedBattle()->getPathfinding()->removePreview();
+	
+	int btnID = -1;
+
+	// got to find out which button was pressed
+	for (size_t i = 0; i < std::size(_actionMenu) && btnID == -1; ++i)
+	{
+		if (action->getSender() == _actionMenu[i])
+		{
+			btnID = i;
+			break;
+		}
+	}
+
+	if (btnID != -1)
+	{
+		std::string actionResult = "STR_UNKNOWN"; // needs a non-empty default/fall-back !
+		
+		OpenXcom::TileEngine *tileEngine = _game->getSavedGame()->getSavedBattle()->getTileEngine();
+		auto skills = _action->actor->getGeoscapeSoldier()->getRules()->getSkills();
+		const RuleSkill *selectedSkill = skills.at(btnID);
+		_action->skillRules = selectedSkill;
+		_action->type = _actionMenu[btnID]->getAction();
+		_action->value = btnID;
+		if (selectedSkill->CompatibleWeapons.size() > 0)
+		{
+			chooseWeaponForSkill(_action, selectedSkill->CompatibleWeapons, selectedSkill->CheckHandsOnly);
+		}
+		_action->updateTU();
+		
+		bool continueAction = tileEngine->skillUse(_action, selectedSkill, btnID);
+
+		if (!continueAction || _action->type == BA_NONE)
+		{
+			_action->type = BA_NONE;
+			_action->targeting = false;
+			_game->popState();
+			return;
+		}
+		
+		// check if the skill needs an item, if so check if an item was found
+		BattleItem *item = _action->weapon;
+		if (_action->type != BA_NONE)
+		{
+			if (!item)
+			{
+				_action->result = tr("STR_SKILL_NEEDS_ITEM");
+				_game->popState();
+				return;
+			}
+		}
+		
+		if (_action->type == BA_THROW && _action->weapon->getRules()->getBattleType() == BT_GRENADE)
+		{
+			// instant grenades
+			_action->weapon->setFuseTimer(0);
+			_action->weapon->setFuseEnabled(true);
+		}
+		else if (_action->type == BA_PRIME || _action->type == BA_UNPRIME)
+		{
+			// nothing, skill menu only supports instant grenades for now
+			_game->popState();
+			return;
+		}
+		// default handling from here on...
+		ActionMenuState::handleAction();
+	}
+}
+
+void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> compatibleWeaponTypes, bool checkHandsOnly)
+{
+	auto unit = action->actor;
+	action->weapon = nullptr;
+	
+	// skip the vehicles, we need only X-Com soldiers WITH equipment-layout
+	if (unit->getGeoscapeSoldier()->getEquipmentLayout()->empty())
+	{
+		return;
+	}
+	
+	for (auto itemType : compatibleWeaponTypes)
+	{
+		// check both hands, right first
+		if (unit->getRightHandWeapon() && unit->getRightHandWeapon()->getRules()->getType() == itemType)
+		{
+			action->weapon = unit->getRightHandWeapon();
+			return;
+		}
+		else if (unit->getLeftHandWeapon() && unit->getLeftHandWeapon()->getRules()->getType() == itemType)
+		{
+			action->weapon = unit->getLeftHandWeapon();
+			return;
+		}
+		
+		if (!checkHandsOnly)
+		{
+			// check special weapons
+			BattleItem *item = unit->getSpecialWeapon(itemType);
+			if (item)
+			{
+				action->weapon = item;
+				return;
+			}
+			
+			// check inventory
+			for (auto layoutItem : *unit->getGeoscapeSoldier()->getEquipmentLayout())
+			{
+				if (itemType != layoutItem->getItemType()) continue;
+				
+				auto inventorySlot = _game->getMod()->getInventory(layoutItem->getSlot(), true);
+				
+				auto item = unit->getItem(inventorySlot, layoutItem->getSlotX(), layoutItem->getSlotY());
+				
+				if (item)
+				{
+					action->weapon = item;
+					return;
+				}
+			}
+		}
+	}
+}
+
+}

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -51,7 +51,7 @@ namespace OpenXcom
  * @param x Position on the x-axis.
  * @param y position on the y-axis.
  */
-	SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuState(action)
+SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuState(action)
 {
 	_screen = false;
 	
@@ -231,7 +231,7 @@ void SkillMenuState::btnActionMenuItemClick(Action *action)
 	}
 }
 
-void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> compatibleWeaponTypes, bool checkHandsOnly)
+void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, bool checkHandsOnly)
 {
 	auto unit = action->actor;
 	action->weapon = nullptr;

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -232,9 +232,8 @@ void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vecto
 {
 	auto unit = action->actor;
 	action->weapon = nullptr;
-	
-	// skip the vehicles, we need only X-Com soldiers WITH equipment-layout
-	if (unit->getGeoscapeSoldier()->getEquipmentLayout()->empty() || action->type == BA_NONE)
+
+	if (action->type == BA_NONE)
 	{
 		return;
 	}
@@ -263,14 +262,11 @@ void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vecto
 					return;
 				}
 				// check inventory
-				for (auto layoutItem : *unit->getGeoscapeSoldier()->getEquipmentLayout())
+				for (auto invItem : *unit->getInventory())
 				{
-					if (itemType != layoutItem->getItemType()) continue;
-					auto inventorySlot = _game->getMod()->getInventory(layoutItem->getSlot(), true);
-					auto item = unit->getItem(inventorySlot, layoutItem->getSlotX(), layoutItem->getSlotY());
-					if (item)
+					if (invItem->getRules()->getType() == itemType)
 					{
-						action->weapon = item;
+						action->weapon = invItem;
 						return;
 					}
 				}
@@ -310,16 +306,14 @@ BattleType SkillMenuState::getBattleTypeFromActionType(BattleActionType actionTy
 	}
 }
 
-BattleItem *SkillMenuState::findItemInInventory(const BattleUnit *unit, BattleType battleType)
+BattleItem *SkillMenuState::findItemInInventory(BattleUnit *unit, BattleType battleType)
 {
 	// check inventory
-	for (auto layoutItem : *unit->getGeoscapeSoldier()->getEquipmentLayout())
+	for (auto invItem : *unit->getInventory())
 	{
-		auto inventorySlot = _game->getMod()->getInventory(layoutItem->getSlot(), true);
-		auto item = unit->getItem(inventorySlot, layoutItem->getSlotX(), layoutItem->getSlotY());
-		if (item->getRules()->getBattleType() == battleType)
+		if (invItem->getRules()->getBattleType() == battleType)
 		{
-			return item;
+			return invItem;
 		}
 	}
 	return 0;

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -285,36 +285,14 @@ void SkillMenuState::chooseWeaponForSkill(BattleAction* action, const std::vecto
 			}
 		}
 	}
-	if (compatibleBattleType == BT_NONE)
+	if (compatibleBattleType != BT_NONE)
 	{
-		compatibleBattleType = getBattleTypeFromActionType(action->type);
-	}
-	BattleItem *item = findItemInInventory(action->actor, compatibleBattleType);
-	if (item)
-	{
-		action->weapon = item;
-		return;
-	}
-}
-
-BattleType SkillMenuState::getBattleTypeFromActionType(BattleActionType actionType)
-{
-	switch (actionType) {
-		case BA_HIT:
-			return BT_MELEE;
-		case BA_SNAPSHOT:
-		case BA_AIMEDSHOT:
-		case BA_AUTOSHOT:
-		case BA_LAUNCH:
-			return BT_FIREARM;
-		case BA_THROW:
-			return BT_GRENADE;
-		case BA_USE:
-		case BA_PANIC:
-		case BA_MINDCONTROL:
-			return BT_PSIAMP;
-		default:
-			return BT_NONE;
+		BattleItem *item = findItemInInventory(action->actor, compatibleBattleType);
+		if (item)
+		{
+			action->weapon = item;
+			return;
+		}
 	}
 }
 

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -87,7 +87,7 @@ SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuS
 		{
 			_action->skillRules = skill;
 			chooseWeaponForSkill(_action, skill->getCompatibleWeapons(), skill->getCompatibleBattleType(), skill->checkHandsOnly());
-			addItem(skill->getTargetMode(), skill->getType(), &id, hotkeys.back());
+			addItem(skill, &id, hotkeys.back());
 			hotkeys.pop_back();
 		}
 	}
@@ -106,7 +106,7 @@ SkillMenuState::~SkillMenuState()
 
 bool SkillMenuState::hasBonus(Soldier *soldier, const RuleSkill *skillRules)
 {
-	// Does the soldier have the required commendations?
+	// Does the soldier have the required bonus?
 	for (auto reqd_bonus : skillRules->getRequiredBonus())
 	{
 		bool found = false;
@@ -130,8 +130,12 @@ bool SkillMenuState::hasBonus(Soldier *soldier, const RuleSkill *skillRules)
  * @param name Action description.
  * @param id Pointer to the new item ID.
  */
-void SkillMenuState::addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key)
+void SkillMenuState::addItem(const RuleSkill* skill, int *id, SDLKey key)
 {
+	BattleActionType ba = skill->getTargetMode();
+	const std::string &name = skill->getType();
+
+
 	std::string s1, s2;
 	RuleItemUseCost cost = _action->actor->getActionTUs(ba, _action->skillRules);
 	
@@ -152,6 +156,7 @@ void SkillMenuState::addItem(BattleActionType ba, const std::string &name, int *
 	}
 
 	_actionMenu[*id]->setAction(ba, tr(name), s1, s2, cost.Time);
+	_actionMenu[*id]->setSkill(skill);
 	_actionMenu[*id]->setVisible(true);
 	
 	if (key != SDLK_UNKNOWN)
@@ -187,8 +192,7 @@ void SkillMenuState::btnActionMenuItemClick(Action *action)
 		std::string actionResult = "STR_UNKNOWN"; // needs a non-empty default/fall-back !
 		
 		OpenXcom::TileEngine *tileEngine = _game->getSavedGame()->getSavedBattle()->getTileEngine();
-		auto skills = _action->actor->getGeoscapeSoldier()->getRules()->getSkills();
-		const RuleSkill *selectedSkill = skills.at(btnID);
+		const RuleSkill *selectedSkill = _actionMenu[btnID]->getSkill();
 		_action->skillRules = selectedSkill;
 		_action->type = _actionMenu[btnID]->getAction();
 		chooseWeaponForSkill(_action, selectedSkill->getCompatibleWeapons(), selectedSkill->getCompatibleBattleType(), selectedSkill->checkHandsOnly());

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -54,6 +54,10 @@ namespace OpenXcom
  */
 SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuState(action)
 {
+	// cache the currently selected weapon and skill
+	const RuleSkill *currentSkill = _action->skillRules;
+	BattleItem *currentWeapon = _action->weapon;
+
 	_screen = false;
 	
 	// Set palette
@@ -87,8 +91,9 @@ SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuS
 			hotkeys.pop_back();
 		}
 	}
-	_action->skillRules = nullptr;
-	_action->weapon = 0;
+	// restore previously selected weapon and skill
+	_action->skillRules = currentSkill;
+	_action->weapon = currentWeapon;
 }
 
 /**

--- a/src/Battlescape/SkillMenuState.cpp
+++ b/src/Battlescape/SkillMenuState.cpp
@@ -57,6 +57,7 @@ SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuS
 	// cache the currently selected weapon and skill
 	const RuleSkill *currentSkill = _action->skillRules;
 	BattleItem *currentWeapon = _action->weapon;
+	BattleActionType currentActionType = _action->type;
 
 	_screen = false;
 	
@@ -86,12 +87,14 @@ SkillMenuState::SkillMenuState(BattleAction *action, int x, int y) : ActionMenuS
 			&& (!skill->isPsiRequired() || _action->actor->getBaseStats()->psiSkill > 0))
 		{
 			_action->skillRules = skill;
+			_action->type = skill->getTargetMode();
 			chooseWeaponForSkill(_action, skill->getCompatibleWeapons(), skill->getCompatibleBattleType(), skill->checkHandsOnly());
 			addItem(skill, &id, hotkeys.back());
 			hotkeys.pop_back();
 		}
 	}
 	// restore previously selected weapon and skill
+	_action->type = currentActionType;
 	_action->skillRules = currentSkill;
 	_action->weapon = currentWeapon;
 }

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -40,7 +40,9 @@ private:
 	bool hasBonus(Soldier *soldier, const RuleSkill *skillRules);
 	/// Adds a new menu item for an action.
 	void addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key);
-	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, bool checkHandsOnly);
+	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, BattleType compatibleWeaponType, bool checkHandsOnly);
+	BattleItem *findItemInInventory(const BattleUnit *unit, BattleType battleType);
+	BattleType getBattleTypeFromActionType(BattleActionType actionType);
 public:
 	/// Creates the Action Menu state.
 	SkillMenuState(BattleAction *action, int x, int y);

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -42,7 +42,6 @@ private:
 	void addItem(const RuleSkill* skill, int *id, SDLKey key);
 	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, BattleType compatibleWeaponType, bool checkHandsOnly);
 	BattleItem *findItemInInventory(BattleUnit *unit, BattleType battleType);
-	BattleType getBattleTypeFromActionType(BattleActionType actionType);
 public:
 	/// Creates the Action Menu state.
 	SkillMenuState(BattleAction *action, int x, int y);

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -41,7 +41,7 @@ private:
 	/// Adds a new menu item for an action.
 	void addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key);
 	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, BattleType compatibleWeaponType, bool checkHandsOnly);
-	BattleItem *findItemInInventory(const BattleUnit *unit, BattleType battleType);
+	BattleItem *findItemInInventory(BattleUnit *unit, BattleType battleType);
 	BattleType getBattleTypeFromActionType(BattleActionType actionType);
 public:
 	/// Creates the Action Menu state.

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -17,41 +17,37 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http:///www.gnu.org/licenses/>.
  */
-#include "../Engine/State.h"
+#include "ActionMenuState.h"
 #include "BattlescapeGame.h"
+
 
 namespace OpenXcom
 {
 
+struct RuleItemUseCost;
+class ActionMenuState;
 class ActionMenuItem;
-
+class EquipmentLayoutItem;
+	
 /**
  * Window that allows the player
  * to select a battlescape action.
  */
-class ActionMenuState : public State
+class SkillMenuState : public ActionMenuState
 {
-protected:
-	BattleAction *_action;
-	ActionMenuItem *_actionMenu[6];
+private:
+	/// Checck if the required commendations for this skill are available
+	bool hasBonus(Soldier *soldier, const RuleSkill *skillRules);
 	/// Adds a new menu item for an action.
 	void addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key);
-	/// Acts on the action instance that has been chosen and set
-	void handleAction();
+	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> compatibleWeaponTypes, bool checkHandsOnly);
 public:
-	ActionMenuState(BattleAction *action);
 	/// Creates the Action Menu state.
-	ActionMenuState(BattleAction *action, int x, int y);
+	SkillMenuState(BattleAction *action, int x, int y);
 	/// Cleans up the Action Menu state.
-	~ActionMenuState();
-	/// Init function.
-	void init() override;
-	/// Handler for right-clicking anything.
-	void handle(Action *action) override;
+	~SkillMenuState();
 	/// Handler for clicking a action menu item.
-	virtual void btnActionMenuItemClick(Action *action);
-	/// Update the resolution settings, we just resized the window.
-	void resize(int &dX, int &dY) override;
+	void btnActionMenuItemClick(Action *action);
 };
 
 }

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -36,10 +36,10 @@ class EquipmentLayoutItem;
 class SkillMenuState : public ActionMenuState
 {
 private:
-	/// Checck if the required commendations for this skill are available
+	/// Checck if the required bonuses for this skill are available
 	bool hasBonus(Soldier *soldier, const RuleSkill *skillRules);
 	/// Adds a new menu item for an action.
-	void addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key);
+	void addItem(const RuleSkill* skill, int *id, SDLKey key);
 	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, BattleType compatibleWeaponType, bool checkHandsOnly);
 	BattleItem *findItemInInventory(BattleUnit *unit, BattleType battleType);
 	BattleType getBattleTypeFromActionType(BattleActionType actionType);

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -40,7 +40,7 @@ private:
 	bool hasBonus(Soldier *soldier, const RuleSkill *skillRules);
 	/// Adds a new menu item for an action.
 	void addItem(BattleActionType ba, const std::string &name, int *id, SDLKey key);
-	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> compatibleWeaponTypes, bool checkHandsOnly);
+	void chooseWeaponForSkill(BattleAction* action, const std::vector<std::string> &compatibleWeaponTypes, bool checkHandsOnly);
 public:
 	/// Creates the Action Menu state.
 	SkillMenuState(BattleAction *action, int x, int y);

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -40,6 +40,7 @@
 #include "../Mod/Armor.h"
 #include "../Mod/Mod.h"
 #include "../Mod/RuleSoldier.h"
+#include "../Mod/RuleSkill.h"
 #include "Pathfinding.h"
 #include "../Engine/Game.h"
 #include "../Engine/Options.h"
@@ -4121,7 +4122,7 @@ bool TileEngine::medikitUse(BattleAction *action, BattleUnit *target, BattleMedi
  * Executes the skillUseUnit script hook and determines further steps.
  * @return True if the current action should be continued, false if the action should be cancelled (usually because the script took care of any effects itself).
  */
-bool TileEngine::skillUse(BattleAction *action, const RuleSkill *skill, int skillId)
+bool TileEngine::skillUse(BattleAction *action, const RuleSkill *skill)
 {
 	bool continueAction = true;
 	bool spendTu = false;
@@ -4130,7 +4131,7 @@ bool TileEngine::skillUse(BattleAction *action, const RuleSkill *skill, int skil
 	bool hasTu = action->haveTU(&message);
 	
 	ModScript::SkillUseUnit::Output args { continueAction, spendTu };
-	ModScript::SkillUseUnit::Worker work { actor, action->weapon, _save, action->type, skillId, hasTu };
+	ModScript::SkillUseUnit::Worker work { actor, action->weapon, _save, action->type, skill->getScriptId(), hasTu };
 	
 	work.execute(actor->getArmor()->getScript<ModScript::SkillUseUnit>(), args);
 

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -4131,7 +4131,7 @@ bool TileEngine::skillUse(BattleAction *action, const RuleSkill *skill)
 	bool hasTu = action->haveTU(&message);
 	
 	ModScript::SkillUseUnit::Output args { continueAction, spendTu };
-	ModScript::SkillUseUnit::Worker work { actor, action->weapon, _save, action->type, skill->getScriptId(), hasTu };
+	ModScript::SkillUseUnit::Worker work { actor, action->weapon, _save, skill, action->type, hasTu };
 	
 	work.execute(actor->getArmor()->getScript<ModScript::SkillUseUnit>(), args);
 

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -31,7 +31,7 @@ class SavedBattleGame;
 class BattleUnit;
 class BattleItem;
 class Tile;
-struct RuleSkill;
+class RuleSkill;
 struct BattleAction;
 struct GraphSubset;
 
@@ -206,7 +206,7 @@ public:
 	/// Try using medikit heal ability.
 	bool medikitUse(BattleAction *action, BattleUnit *target, BattleMediKitAction medikitAction, int bodyPart);
 	/// Try using a skill.
-	bool skillUse(BattleAction *action, const RuleSkill *skill, int skillId);
+	bool skillUse(BattleAction *action, const RuleSkill *skill);
 	/// Try to conceal a unit.
 	bool tryConcealUnit(BattleUnit* unit);
 	/// Applies gravity to anything that occupy this tile.

--- a/src/Battlescape/TileEngine.h
+++ b/src/Battlescape/TileEngine.h
@@ -31,6 +31,7 @@ class SavedBattleGame;
 class BattleUnit;
 class BattleItem;
 class Tile;
+struct RuleSkill;
 struct BattleAction;
 struct GraphSubset;
 
@@ -204,6 +205,8 @@ public:
 	void medikitRemoveIfEmpty(BattleAction *action);
 	/// Try using medikit heal ability.
 	bool medikitUse(BattleAction *action, BattleUnit *target, BattleMediKitAction medikitAction, int bodyPart);
+	/// Try using a skill.
+	bool skillUse(BattleAction *action, const RuleSkill *skill, int skillId);
 	/// Try to conceal a unit.
 	bool tryConcealUnit(BattleUnit* unit);
 	/// Applies gravity to anything that occupy this tile.

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -262,6 +262,7 @@ void UnitDieBState::convertUnitToCorpse()
 	{
 		_parent->getSave()->getBattleState()->showPsiButton(false);
 		_parent->getSave()->getBattleState()->showSpecialButton(false);
+		_parent->getSave()->getBattleState()->showSkillsButton(false);
 	}
 	// remove the unconscious body item corresponding to this unit, and if it was being carried, keep track of what slot it was in
 	if (lastPosition != TileEngine::invalid)

--- a/src/Battlescape/UnitDieBState.cpp
+++ b/src/Battlescape/UnitDieBState.cpp
@@ -260,9 +260,7 @@ void UnitDieBState::convertUnitToCorpse()
 
 	if (!_noSound)
 	{
-		_parent->getSave()->getBattleState()->showPsiButton(false);
-		_parent->getSave()->getBattleState()->showSpecialButton(false);
-		_parent->getSave()->getBattleState()->showSkillsButton(false);
+		_parent->getSave()->getBattleState()->showUiButton();
 	}
 	// remove the unconscious body item corresponding to this unit, and if it was being carried, keep track of what slot it was in
 	if (lastPosition != TileEngine::invalid)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ set ( battlescape_src
   Battlescape/PsiAttackBState.cpp
   Battlescape/ScannerState.cpp
   Battlescape/ScannerView.cpp
+  Battlescape/SkillMenuState.cpp
   Battlescape/TileEngine.cpp
   Battlescape/TurnDiaryState.cpp
   Battlescape/UnitDieBState.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,6 +312,7 @@ set ( mod_src
   Mod/RuleMusic.cpp
   Mod/RuleRegion.cpp
   Mod/RuleResearch.cpp
+  Mod/RuleSkill.cpp
   Mod/RuleSoldier.cpp
   Mod/RuleSoldierBonus.cpp
   Mod/RuleSoldierTransformation.cpp

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -556,6 +556,10 @@ Mod::~Mod()
 	{
 		delete i->second;
 	}
+	for (std::map<std::string, RuleSkill*>::iterator i = _skills.begin(); i != _skills.end(); ++i)
+	{
+		delete i->second;
+	}
 	for (std::map<std::string, Unit*>::iterator i = _units.begin(); i != _units.end(); ++i)
 	{
 		delete i->second;

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -65,6 +65,7 @@
 #include "RuleTerrain.h"
 #include "MapScript.h"
 #include "RuleSoldier.h"
+#include "RuleSkill.h"
 #include "RuleCommendations.h"
 #include "AlienRace.h"
 #include "RuleEnviroEffects.h"
@@ -1657,6 +1658,14 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 			rule->load(*i, parsers, this);
 		}
 	}
+	for (YAML::const_iterator i = doc["skills"].begin(); i != doc["skills"].end(); ++i)
+	{
+		RuleSkill *rule = loadRule(*i, &_skills, &_skillsIndex);
+		if (rule != 0)
+		{
+			rule->load(*i, this, parsers);
+		}
+	}
 	for (YAML::const_iterator i = doc["soldiers"].begin(); i != doc["soldiers"].end(); ++i)
 	{
 		RuleSoldier *rule = loadRule(*i, &_soldiers, &_soldiersIndex);
@@ -2698,6 +2707,16 @@ MapDataSet *Mod::getMapDataSet(const std::string &name)
 	{
 		return map->second;
 	}
+}
+
+/**
+ * Returns the rules for the specified skill.
+ * @param id Skill type.
+ * @return Rules for the skill, or 0 when the skill is not found.
+ */
+RuleSkill *Mod::getSkill(const std::string &name, bool error) const
+{
+	return getRule(name, "Skill", _skills, error);
 }
 
 /**

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -56,6 +56,7 @@ struct RuleDamageType;
 class RuleUfo;
 class RuleTerrain;
 class MapDataSet;
+class RuleSkill;
 class RuleSoldier;
 class Unit;
 class Armor;
@@ -144,6 +145,7 @@ private:
 	std::map<std::string, RuleUfo*> _ufos;
 	std::map<std::string, RuleTerrain*> _terrains;
 	std::map<std::string, MapDataSet*> _mapDataSets;
+	std::map<std::string, RuleSkill*> _skills;
 	std::map<std::string, RuleSoldier*> _soldiers;
 	std::map<std::string, Unit*> _units;
 	std::map<std::string, AlienRace*> _alienRaces;
@@ -238,7 +240,7 @@ private:
 	std::map<std::string, int> _ufopaediaSections;
 	std::vector<std::string> _countriesIndex, _extraGlobeLabelsIndex, _regionsIndex, _facilitiesIndex, _craftsIndex, _craftWeaponsIndex, _itemCategoriesIndex, _itemsIndex, _invsIndex, _ufosIndex;
 	std::vector<std::string> _aliensIndex, _enviroEffectsIndex, _startingConditionsIndex, _deploymentsIndex, _armorsIndex, _ufopaediaIndex, _ufopaediaCatIndex, _researchIndex, _manufactureIndex;
-	std::vector<std::string> _soldiersIndex, _soldierTransformationIndex, _soldierBonusIndex;
+	std::vector<std::string> _skillsIndex, _soldiersIndex, _soldierTransformationIndex, _soldierBonusIndex;
 	std::vector<std::string> _alienMissionsIndex, _terrainIndex, _customPalettesIndex, _arcScriptIndex, _eventScriptIndex, _eventIndex, _missionScriptIndex;
 	std::vector<std::vector<int> > _alienItemLevels;
 	std::vector<SDL_Color> _transparencies;
@@ -433,6 +435,8 @@ public:
 	const std::vector<std::string> &getTerrainList() const;
 	/// Gets mapdatafile for battlescape games.
 	MapDataSet *getMapDataSet(const std::string &name);
+	/// Gets skill rules.
+	RuleSkill *getSkill(const std::string &name, bool error = false) const;
 	/// Gets soldier unit rules.
 	RuleSoldier *getSoldier(const std::string &name, bool error = false) const;
 	/// Gets the available soldiers.

--- a/src/Mod/ModScript.h
+++ b/src/Mod/ModScript.h
@@ -99,9 +99,13 @@ class ModScript
 	{
 		VisibilityUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-	struct HitUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, int, int, int>
+	struct HitUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, int, int, int, int>
 	{
 		HitUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
+	};
+	struct SkillUseUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&>, BattleUnit*, BattleItem*, SavedBattleGame*, int, int, int>
+	{
+		SkillUseUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
 	struct TryPsiAttackUnitParser : ScriptParserEvents<ScriptOutputArgs<int&>, const BattleItem*, const BattleUnit*, const BattleUnit*, int, int, int>
 	{
@@ -239,6 +243,7 @@ public:
 	using ReactionUnitAction = MACRO_NAMED_SCRIPT("reactionUnitAction", ReactionUnitParser);
 	using ReactionUnitReaction = MACRO_NAMED_SCRIPT("reactionUnitReaction", ReactionUnitParser);
 
+	using SkillUseUnit = MACRO_NAMED_SCRIPT("skillUseUnit", SkillUseUnitParser);
 	using TryPsiAttackUnit = MACRO_NAMED_SCRIPT("tryPsiAttackUnit", TryPsiAttackUnitParser);
 	using HitUnit = MACRO_NAMED_SCRIPT("hitUnit", HitUnitParser);
 	using DamageUnit = MACRO_NAMED_SCRIPT("damageUnit", DamageUnitParser);
@@ -316,6 +321,7 @@ public:
 		ReactionUnitAction,
 		ReactionUnitReaction,
 
+		SkillUseUnit,
 		TryPsiAttackUnit,
 		HitUnit,
 		DamageUnit,

--- a/src/Mod/ModScript.h
+++ b/src/Mod/ModScript.h
@@ -41,6 +41,7 @@ class Armor;
 class RuleInventory;
 class RuleResearch;
 class RuleManufacture;
+class RuleSkill;
 class AlienRace;
 class RuleAlienMission;
 class Base;
@@ -99,11 +100,11 @@ class ModScript
 	{
 		VisibilityUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-	struct HitUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, int, int, int, int>
+	struct HitUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, const RuleSkill*, int, int, int>
 	{
 		HitUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-	struct SkillUseUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&>, BattleUnit*, BattleItem*, SavedBattleGame*, int, int, int>
+	struct SkillUseUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&>, BattleUnit*, BattleItem*, SavedBattleGame*, const RuleSkill*, int, int>
 	{
 		SkillUseUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
@@ -111,7 +112,7 @@ class ModScript
 	{
 		TryPsiAttackUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};
-	struct DamageUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&, int&, int&, int&, int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, int, int, int, int, int, int>
+	struct DamageUnitParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&, int&, int&, int&, int&, int&, int&>, BattleUnit*, BattleItem*, BattleItem*, BattleUnit*, SavedBattleGame*, const RuleSkill*, int, int, int, int, int, int>
 	{
 		DamageUnitParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
 	};

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -210,52 +210,6 @@ void RuleItem::loadInt(int& a, const YAML::Node& node) const
 }
 
 /**
- * Load item use cost type (flat or percent).
- * @param a Item use type.
- * @param node YAML node.
- * @param name Name of action type.
- */
-void RuleItem::loadPercent(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const
-{
-	if (const YAML::Node& cost = node["flat" + name])
-	{
-		if (cost.IsScalar())
-		{
-			loadTriBool(a.Time, cost);
-		}
-		else
-		{
-			loadTriBool(a.Time, cost["time"]);
-			loadTriBool(a.Energy, cost["energy"]);
-			loadTriBool(a.Morale, cost["morale"]);
-			loadTriBool(a.Health, cost["health"]);
-			loadTriBool(a.Stun, cost["stun"]);
-			loadTriBool(a.Mana, cost["mana"]);
-		}
-	}
-}
-
-/**
- * Load item use cost.
- * @param a Item use cost.
- * @param node YAML node.
- * @param name Name of action type.
- */
-void RuleItem::loadCost(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const
-{
-	loadInt(a.Time, node["tu" + name]);
-	if (const YAML::Node& cost = node["cost" + name])
-	{
-		loadInt(a.Time, cost["time"]);
-		loadInt(a.Energy, cost["energy"]);
-		loadInt(a.Morale, cost["morale"]);
-		loadInt(a.Health, cost["health"]);
-		loadInt(a.Stun, cost["stun"]);
-		loadInt(a.Mana, cost["mana"]);
-	}
-}
-
-/**
  * Load RuleItemAction from yaml.
  * @param a Item use config.
  * @param node YAML node.
@@ -468,27 +422,27 @@ void RuleItem::load(const YAML::Node &node, Mod *mod, int listOrder, const ModSc
 	_accuracyCloseQuarters = node["accuracyCloseQuarters"].as<int>(_accuracyCloseQuarters);
 	_noLOSAccuracyPenalty = node["noLOSAccuracyPenalty"].as<int>(_noLOSAccuracyPenalty);
 
-	loadCost(_confAimed.cost, node, "Aimed");
-	loadCost(_confAuto.cost, node, "Auto");
-	loadCost(_confSnap.cost, node, "Snap");
-	loadCost(_confMelee.cost, node, "Melee");
-	loadCost(_costUse, node, "Use");
-	loadCost(_costMind, node, "MindControl");
-	loadCost(_costPanic, node, "Panic");
-	loadCost(_costThrow, node, "Throw");
-	loadCost(_costPrime, node, "Prime");
-	loadCost(_costUnprime, node, "Unprime");
+	_confAimed.cost.loadCost(node, "Aimed");
+	_confAuto.cost.loadCost(node, "Auto");
+	_confSnap.cost.loadCost(node, "Snap");
+	_confMelee.cost.loadCost(node, "Melee");
+	_costUse.loadCost(node, "Use");
+	_costMind.loadCost(node, "MindControl");
+	_costPanic.loadCost(node, "Panic");
+	_costThrow.loadCost(node, "Throw");
+	_costPrime.loadCost(node, "Prime");
+	_costUnprime.loadCost(node, "Unprime");
 
 	loadTriBool(_flatUse.Time, node["flatRate"]);
 
-	loadPercent(_confAimed.flat, node, "Aimed");
-	loadPercent(_confAuto.flat, node, "Auto");
-	loadPercent(_confSnap.flat, node, "Snap");
-	loadPercent(_confMelee.flat, node, "Melee");
-	loadPercent(_flatUse, node, "Use");
-	loadPercent(_flatThrow, node, "Throw");
-	loadPercent(_flatPrime, node, "Prime");
-	loadPercent(_flatUnprime, node, "Unprime");
+	_confAimed.flat.loadPercent(node, "Aimed");
+	_confAuto.flat.loadPercent(node, "Auto");
+	_confSnap.flat.loadPercent(node, "Snap");
+	_confMelee.flat.loadPercent(node, "Melee");
+	_flatUse.loadPercent(node, "Use");
+	_flatThrow.loadPercent(node, "Throw");
+	_flatPrime.loadPercent(node, "Prime");
+	_flatUnprime.loadPercent(node, "Unprime");
 
 	loadConfAction(_confAimed, node, "Aimed");
 	loadConfAction(_confAuto, node, "Auto");

--- a/src/Mod/RuleItem.h
+++ b/src/Mod/RuleItem.h
@@ -91,6 +91,91 @@ struct RuleItemUseCost
 		Mana += cost.Mana;
 		return *this;
 	}
+
+	/**
+	 * Load use cost.
+	 * @param a Item use cost.
+	 * @param node YAML node.
+	 * @param name Name of action type.
+	 */
+	void loadCost(const YAML::Node& node, const std::string& name)
+	{
+		loadInt(Time, node["tu" + name]);
+		if (const YAML::Node& cost = node["cost" + name])
+		{
+			loadInt(Time, cost["time"]);
+			loadInt(Energy, cost["energy"]);
+			loadInt(Morale, cost["morale"]);
+			loadInt(Health, cost["health"]);
+			loadInt(Stun, cost["stun"]);
+			loadInt(Mana, cost["mana"]);
+		}
+	}
+	/**
+	 * Load use cost type (flat or percent).
+	 * @param a Item use type.
+	 * @param node YAML node.
+	 * @param name Name of action type.
+	 */
+	void loadPercent(const YAML::Node& node, const std::string& name)
+	{
+		if (const YAML::Node& cost = node["flat" + name])
+		{
+			if (cost.IsScalar())
+			{
+				loadTriBool(Time, cost);
+			}
+			else
+			{
+				loadTriBool(Time, cost["time"]);
+				loadTriBool(Energy, cost["energy"]);
+				loadTriBool(Morale, cost["morale"]);
+				loadTriBool(Health, cost["health"]);
+				loadTriBool(Stun, cost["stun"]);
+				loadTriBool(Mana, cost["mana"]);
+			}
+		}
+	}
+
+	/**
+	 * Load nullable bool value and store it in int (with null as -1).
+	 * @param a value to set.
+	 * @param node YAML node.
+	 */
+	void loadTriBool(int& a, const YAML::Node& node) const
+	{
+		if (node)
+		{
+			if (node.IsNull())
+			{
+				a = -1;
+			}
+			else
+			{
+				a = node.as<bool>();
+			}
+		}
+	}
+
+	/**
+	 * Load nullable int (with null as -1).
+	 * @param a value to set.
+	 * @param node YAML node.
+	 */
+	void loadInt(int& a, const YAML::Node& node) const
+	{
+		if (node)
+		{
+			if (node.IsNull())
+			{
+				a = -1;
+			}
+			else
+			{
+				a = node.as<int>();
+			}
+		}
+	}
 };
 
 /**

--- a/src/Mod/RuleSkill.cpp
+++ b/src/Mod/RuleSkill.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2010-2020 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "RuleSkill.h"
+
+namespace OpenXcom
+{
+
+RuleSkill::RuleSkill(const std::string &type) : _type(type), _targetMode(BA_NONE), _compatibleWeapons({}), _requiredBonus({}), _isPsiRequired(false), _checkHandsOnly(true), _scriptId(-1)
+{}
+
+/**
+ * Loads the skill from a YAML file.
+ * @param node YAML node.
+ * @param mod Mod for the skill.
+ */
+void RuleSkill::load(const YAML::Node &node, Mod *mod, const ModScript &parsers)
+{
+	if (const YAML::Node &parent = node["refNode"])
+	{
+		load(parent, mod, parsers);
+	}
+	_scriptId = node["scriptId"].as<int>(_scriptId);
+	
+	_cost.loadCost(node, "Use");
+	_flat.loadPercent(node, "Use");
+	
+	_requiredBonus = node["requiredBonus"].as<std::vector<std::string>>(_requiredBonus);
+	int targetMode = node["targetMode"].as<int>(_targetMode);
+	targetMode = targetMode < 0 ? 0 : targetMode;
+	targetMode = targetMode > BA_CQB ? 0 : targetMode;
+	_targetMode = static_cast<BattleActionType>(targetMode);
+	_isPsiRequired = node["isPsiRequired"].as<bool>(_isPsiRequired);
+	_checkHandsOnly = node["checkHandsOnly"].as<bool>(_checkHandsOnly);
+	_compatibleWeapons = node["compatibleWeapons"].as<std::vector<std::string>>(_compatibleWeapons);
+}
+	
+
+const std::string RuleSkill::getType() const
+{
+	return _type;
+}
+int RuleSkill::getScriptId() const
+{
+	return _scriptId;
+}
+bool RuleSkill::isPsiRequired() const
+{
+	return _isPsiRequired;
+}
+bool RuleSkill::checkHandsOnly() const
+{
+	return _checkHandsOnly;
+}
+const RuleItemUseCost RuleSkill::getFlat() const
+{
+	return _flat;
+}
+const RuleItemUseCost RuleSkill::getCost() const
+{
+	return _cost;
+}
+BattleActionType RuleSkill::getTargetMode() const
+{
+	return _targetMode;
+}
+const std::vector<std::string> RuleSkill::getCompatibleWeapons() const
+{
+	return _compatibleWeapons;
+}
+const std::vector<std::string> RuleSkill::getRequiredBonus() const
+{
+	return _requiredBonus;
+}
+
+void RuleSkill::setScriptId(int scriptId)
+{
+	_scriptId = scriptId;
+}
+void RuleSkill::setIsPsiRequired(bool isPsiRequired)
+{
+	_isPsiRequired = isPsiRequired;
+}
+void RuleSkill::setCheckHandsOnly(bool checkHandsOnly)
+{
+	_checkHandsOnly = checkHandsOnly;
+}
+void RuleSkill::setFlat(RuleItemUseCost flat)
+{
+	_flat = flat;
+}
+void RuleSkill::setCost(RuleItemUseCost cost)
+{
+	_cost = cost;
+}
+void RuleSkill::setTargetMode(BattleActionType targetMode)
+{
+	_targetMode = targetMode;
+}
+void RuleSkill::setCompatibleWeapons(std::vector<std::string> compatibleWeapons)
+{
+	_compatibleWeapons = compatibleWeapons;
+}
+void RuleSkill::setRequiredBonus(std::vector<std::string> requiredBonus)
+{
+	_requiredBonus = requiredBonus;
+}
+
+}

--- a/src/Mod/RuleSkill.cpp
+++ b/src/Mod/RuleSkill.cpp
@@ -57,6 +57,8 @@ void RuleSkill::load(const YAML::Node &node, Mod *mod, const ModScript &parsers)
 	compBattleType = compBattleType > BT_CORPSE ? 0 : compBattleType;
 	_compatibleBattleType = static_cast<BattleType>(compBattleType);
 
+	_battleUnitScripts.load(_type, node, parsers.battleUnitScripts);
+
 	_scriptValues.load(node, parsers.getShared());
 }
 

--- a/src/Mod/RuleSkill.cpp
+++ b/src/Mod/RuleSkill.cpp
@@ -97,9 +97,31 @@ const std::vector<std::string> RuleSkill::getRequiredBonus() const
 	return _requiredBonus;
 }
 
+namespace
+{
+std::string debugDisplayScript(const RuleSkill* rs)
+{
+	if (rs)
+	{
+		std::string s;
+		s += RuleSkill::ScriptName;
+		s += "(name: \"";
+		s += rs->getType();
+		s += "\")";
+		return s;
+	}
+	else
+	{
+		return "null";
+	}
+}
+}
+
 void RuleSkill::ScriptRegister(ScriptParserBase* parser)
 {
 	Bind<RuleSkill> rs = { parser };
 	rs.addScriptValue<&RuleSkill::_scriptValues>();
+	rs.addDebugDisplay<&debugDisplayScript>();
 }
+
 }

--- a/src/Mod/RuleSkill.h
+++ b/src/Mod/RuleSkill.h
@@ -1,0 +1,65 @@
+#pragma once
+/*
+ * Copyright 2010-2020 OpenXcom Developers.
+ *
+ * This file is part of OpenXcom.
+ *
+ * OpenXcom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenXcom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <string>
+#include <vector>
+#include "RuleSoldier.h"
+
+namespace OpenXcom
+{
+
+class RuleSkill
+{
+	private:
+		std::string _type;
+		RuleItemUseCost _cost;
+		RuleItemUseCost _flat;
+		BattleActionType _targetMode;
+		std::vector<std::string> _compatibleWeapons;
+		std::vector<std::string> _requiredBonus;
+		bool _isPsiRequired;
+		bool _checkHandsOnly;
+		int _scriptId;
+
+	public:
+		/// Default constructor.
+		RuleSkill(const std::string &type);
+
+		void load(const YAML::Node &node, Mod *mod, const ModScript &parsers);
+		const std::string getType() const;
+		int getScriptId() const;
+		bool isPsiRequired() const;
+		bool checkHandsOnly() const;
+		const RuleItemUseCost getFlat() const;
+		const RuleItemUseCost getCost() const;
+		BattleActionType getTargetMode() const;
+		const std::vector<std::string> getCompatibleWeapons() const;
+		const std::vector<std::string> getRequiredBonus() const;
+	
+		void setScriptId(int scriptId);
+		void setIsPsiRequired(bool isPsiRequired);
+		void setCheckHandsOnly(bool checkHandsOnly);
+		void setFlat(RuleItemUseCost flat);
+		void setCost(RuleItemUseCost cost);
+		void setTargetMode(BattleActionType targetMode);
+		void setCompatibleWeapons(std::vector<std::string> compatibleWeapons);
+		void setRequiredBonus(std::vector<std::string> requiredBonus);
+};
+
+}

--- a/src/Mod/RuleSkill.h
+++ b/src/Mod/RuleSkill.h
@@ -20,46 +20,43 @@
 #include <string>
 #include <vector>
 #include "RuleSoldier.h"
+#include "ModScript.h"
 
 namespace OpenXcom
 {
 
 class RuleSkill
 {
-	private:
-		std::string _type;
-		RuleItemUseCost _cost;
-		RuleItemUseCost _flat;
-		BattleActionType _targetMode;
-		std::vector<std::string> _compatibleWeapons;
-		std::vector<std::string> _requiredBonus;
-		bool _isPsiRequired;
-		bool _checkHandsOnly;
-		int _scriptId;
+private:
+	std::string _type;
+	RuleItemUseCost _cost;
+	RuleItemUseCost _flat;
+	BattleActionType _targetMode;
+	std::vector<std::string> _compatibleWeapons;
+	BattleType _compatibleBattleType;
+	std::vector<std::string> _requiredBonus;
+	bool _isPsiRequired;
+	bool _checkHandsOnly;
+	ScriptValues<RuleSkill> _scriptValues;
+public:
+	/// Default constructor.
+	RuleSkill(const std::string &type);
 
-	public:
-		/// Default constructor.
-		RuleSkill(const std::string &type);
+	void load(const YAML::Node &node, Mod *mod, const ModScript &parsers);
+	const std::string getType() const;
+	bool isPsiRequired() const;
+	bool checkHandsOnly() const;
+	const RuleItemUseCost getFlat() const;
+	const RuleItemUseCost getCost() const;
+	BattleActionType getTargetMode() const;
+	const std::vector<std::string> getCompatibleWeapons() const;
+	BattleType getCompatibleBattleType() const;
+	const std::vector<std::string> getRequiredBonus() const;
 
-		void load(const YAML::Node &node, Mod *mod, const ModScript &parsers);
-		const std::string getType() const;
-		int getScriptId() const;
-		bool isPsiRequired() const;
-		bool checkHandsOnly() const;
-		const RuleItemUseCost getFlat() const;
-		const RuleItemUseCost getCost() const;
-		BattleActionType getTargetMode() const;
-		const std::vector<std::string> getCompatibleWeapons() const;
-		const std::vector<std::string> getRequiredBonus() const;
-	
-		void setScriptId(int scriptId);
-		void setIsPsiRequired(bool isPsiRequired);
-		void setCheckHandsOnly(bool checkHandsOnly);
-		void setFlat(RuleItemUseCost flat);
-		void setCost(RuleItemUseCost cost);
-		void setTargetMode(BattleActionType targetMode);
-		void setCompatibleWeapons(std::vector<std::string> compatibleWeapons);
-		void setRequiredBonus(std::vector<std::string> requiredBonus);
+	/// Name of class used in script.
+	static constexpr const char *ScriptName = "RuleSkill";
+	/// Register all useful function used by script.
+	static void ScriptRegister(ScriptParserBase* parser);
 };
 
 }

--- a/src/Mod/RuleSkill.h
+++ b/src/Mod/RuleSkill.h
@@ -38,6 +38,7 @@ private:
 	bool _isPsiRequired;
 	bool _checkHandsOnly;
 	ScriptValues<RuleSkill> _scriptValues;
+	ModScript::BattleUnitScripts::Container _battleUnitScripts;
 public:
 	/// Default constructor.
 	RuleSkill(const std::string &type);
@@ -57,6 +58,12 @@ public:
 	static constexpr const char *ScriptName = "RuleSkill";
 	/// Register all useful function used by script.
 	static void ScriptRegister(ScriptParserBase* parser);
+
+	/// Gets script.
+	template<typename Script>
+	const typename Script::Container &getScript() const { return _battleUnitScripts.get<Script>(); }
+	const ScriptValues<RuleSkill> &getScriptValuesRaw() const { return _scriptValues; }
+
 };
 
 }

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -190,8 +190,16 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod, int listOrder, const Mo
 	{
 		if (n)
 		{
-			RuleSkill *skill = new RuleSkill(offset);
-			
+			RuleSkill *skill;
+			if (offset < (int)_skills.size())
+			{
+				skill = _skills.at(offset);
+			}
+			else
+			{
+				skill = new RuleSkill(offset);
+			}
+
 			loadCost(skill->Cost, n, "Use");
 			loadPercent(skill->Flat, n, "Use");
 			
@@ -362,7 +370,7 @@ bool RuleSoldier::isSkillMenuDefined() const
  * Gets the list of defined skills.
  * @return The list of defined skills.
  */
-const std::vector<const RuleSkill*> RuleSoldier::getSkills() const
+const std::vector<RuleSkill*> &RuleSoldier::getSkills() const
 {
 	return _skills;
 }

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -59,10 +59,6 @@ RuleSoldier::~RuleSoldier()
 	{
 		delete *i;
 	}
-	for (auto i = _skills.begin(); i != _skills.end(); ++i)
-	{
-		delete *i;
-	}
 }
 
 /**

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include "RuleSoldier.h"
+#include "RuleSkill.h"
 #include "Mod.h"
 #include "ModScript.h"
 #include "RuleItem.h"
@@ -186,44 +187,7 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod, int listOrder, const Mo
 		_listOrder = listOrder;
 	}
 	
-	auto loadSkillActionConf = [&](int offset, const YAML::Node &n)
-	{
-		if (n)
-		{
-			RuleSkill *skill;
-			if (offset < (int)_skills.size())
-			{
-				skill = _skills.at(offset);
-			}
-			else
-			{
-				skill = new RuleSkill(offset);
-			}
-
-			loadCost(skill->Cost, n, "Use");
-			loadPercent(skill->Flat, n, "Use");
-			
-			skill->Name = n["name"].as<std::string>(skill->Name);
-			skill->RequiredBonus = node["requiredBonus"].as<std::vector<std::string>>(skill->RequiredBonus);
-			int targetMode = n["targetMode"].as<int>(skill->TargetMode);
-			targetMode = targetMode < 0 ? 0 : targetMode;
-			targetMode = targetMode > BA_CQB ? 0 : targetMode;
-			skill->TargetMode = static_cast<BattleActionType>(targetMode);
-			skill->IsPsiRequired = n["isPsiRequired"].as<bool>(skill->IsPsiRequired);
-			skill->CheckHandsOnly = n["checkHandsOnly"].as<bool>(skill->CheckHandsOnly);
-			skill->CompatibleWeapons = n["compatibleWeapons"].as<std::vector<std::string>>(skill->CompatibleWeapons);
-			_skills.push_back(skill);
-		}
-	};
-	
-	if (const YAML::Node &nodeSkills = node["skills"])
-	{
-		for (int slot = 0; slot < 5; ++slot)
-		{
-			const YAML::Node currentNode = nodeSkills[std::to_string(slot)];
-			loadSkillActionConf(slot, currentNode);
-		}
-	}
+	_skillNames = node["skills"].as<std::vector<std::string>>(_skillNames);
 
 	_scriptValues.load(node, parsers.getShared());
 }
@@ -244,6 +208,17 @@ void RuleSoldier::afterLoad(const Mod* mod)
 			if ((_specWeapon->getBattleType() == BT_FIREARM || _specWeapon->getBattleType() == BT_MELEE) && !_specWeapon->getClipSize())
 			{
 				throw Exception("Weapon " + _specWeaponName + " is used as a special weapon, but doesn't have its own ammo - give it a clipSize!");
+			}
+		}
+	}
+	if (_skillNames.size() > 0)
+	{
+		for (auto skillName : _skillNames)
+		{
+			auto skill = mod->getSkill(skillName, true);
+			if (skill)
+			{
+				_skills.push_back(skill);
 			}
 		}
 	}
@@ -650,91 +625,6 @@ std::string debugDisplayScript(const RuleSoldier* rs)
 	}
 }
 
-}
-
-/**
- * Load item use cost.
- * @param a Item use cost.
- * @param node YAML node.
- * @param name Name of action type.
- */
-void RuleSoldier::loadCost(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const
-{
-	loadInt(a.Time, node["tu" + name]);
-	if (const YAML::Node& cost = node["cost" + name])
-	{
-		loadInt(a.Time, cost["time"]);
-		loadInt(a.Energy, cost["energy"]);
-		loadInt(a.Morale, cost["morale"]);
-		loadInt(a.Health, cost["health"]);
-		loadInt(a.Stun, cost["stun"]);
-		loadInt(a.Mana, cost["mana"]);
-	}
-}
-
-/**
- * Load skill use cost type (flat or percent).
- * @param a Item use type.
- * @param node YAML node.
- * @param name Name of action type.
- */
-void RuleSoldier::loadPercent(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const
-{
-	if (const YAML::Node& cost = node["flat" + name])
-	{
-		if (cost.IsScalar())
-		{
-			loadTriBool(a.Time, cost);
-		}
-		else
-		{
-			loadTriBool(a.Time, cost["time"]);
-			loadTriBool(a.Energy, cost["energy"]);
-			loadTriBool(a.Morale, cost["morale"]);
-			loadTriBool(a.Health, cost["health"]);
-			loadTriBool(a.Stun, cost["stun"]);
-			loadTriBool(a.Mana, cost["mana"]);
-		}
-	}
-}
-
-/**
- * Load nullable bool value and store it in int (with null as -1).
- * @param a value to set.
- * @param node YAML node.
- */
-void RuleSoldier::loadTriBool(int& a, const YAML::Node& node) const
-{
-	if (node)
-	{
-		if (node.IsNull())
-		{
-			a = -1;
-		}
-		else
-		{
-			a = node.as<bool>();
-		}
-	}
-}
-/**
- * Load nullable int (with null as -1).
- * @param a value to set.
- * @param node YAML node.
- */
-void RuleSoldier::loadInt(int& a, const YAML::Node& node) const
-{
-	if (node)
-	{
-		if (node.IsNull())
-		{
-			a = -1;
-		}
-		else
-		{
-			a = node.as<int>();
-		}
-	}
 }
 
 /**

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -59,6 +59,10 @@ RuleSoldier::~RuleSoldier()
 	{
 		delete *i;
 	}
+	for (auto i = _skills.begin(); i != _skills.end(); ++i)
+	{
+		delete *i;
+	}
 }
 
 /**
@@ -221,6 +225,7 @@ void RuleSoldier::afterLoad(const Mod* mod)
 				_skills.push_back(skill);
 			}
 		}
+		_skillNames.clear();
 	}
 }
 
@@ -345,7 +350,7 @@ bool RuleSoldier::isSkillMenuDefined() const
  * Gets the list of defined skills.
  * @return The list of defined skills.
  */
-const std::vector<RuleSkill*> &RuleSoldier::getSkills() const
+const std::vector<const RuleSkill*> &RuleSoldier::getSkills() const
 {
 	return _skills;
 }

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -89,7 +89,7 @@ private:
 	int _rankSprite, _rankSpriteBattlescape, _rankSpriteTiny, _skillIconSprite;
 	ScriptValues<RuleSoldier> _scriptValues;
 	std::vector<std::string> _skillNames;
-	std::vector<RuleSkill*> _skills;
+	std::vector<const RuleSkill*> _skills;
 	void addSoldierNamePool(const std::string &namFile);
 public:
 	/// Creates a blank soldier ruleset.
@@ -127,7 +127,7 @@ public:
 	/// Has the soldier type a skill menu defined?
 	bool isSkillMenuDefined() const;
 	/// Returns the skill definition at the specified index
-	const std::vector<RuleSkill*> &getSkills() const;
+	const std::vector<const RuleSkill*> &getSkills() const;
 	/// Return the sprite index for the skill icon sprite.
 	int getSkillIconSprite() const;
 	/// Gets the monthly salary of the soldier (for a given rank).

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -110,7 +110,7 @@ private:
 	int _rankSprite, _rankSpriteBattlescape, _rankSpriteTiny, _skillIconSprite;
 	ScriptValues<RuleSoldier> _scriptValues;
 	
-	std::vector<const RuleSkill*> _skills;
+	std::vector<RuleSkill*> _skills;
 	void addSoldierNamePool(const std::string &namFile);
 public:
 	/// Creates a blank soldier ruleset.
@@ -148,7 +148,7 @@ public:
 	/// Has the soldier type a skill menu defined?
 	bool isSkillMenuDefined() const;
 	/// Returns the skill definition at the specified index
-	const std::vector<const RuleSkill*> getSkills() const;
+	const std::vector<RuleSkill*> &getSkills() const;
 	/// Return the sprite index for the skill icon sprite.
 	int getSkillIconSprite() const;
 	/// Gets the monthly salary of the soldier (for a given rank).

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -33,27 +33,6 @@ class ModScript;
 class SoldierNamePool;
 class StatString;
 
-struct RuleSkill
-{
-	std::string Name;
-	RuleItemUseCost Cost;
-	RuleItemUseCost Flat;
-	BattleActionType TargetMode;
-	std::vector<std::string> CompatibleWeapons;
-	std::vector<std::string> RequiredBonus;
-	bool IsPsiRequired;
-	
-	bool CheckHandsOnly;
-	const int Id;
-	
-	/// Default constructor.
-	RuleSkill(int index) : Name("STR_SKILL_USE"), TargetMode(BA_NONE), IsPsiRequired(false), CheckHandsOnly(true), Id(index)
-	{
-		CompatibleWeapons = {};
-		RequiredBonus = {};
-	}
-};
-
 /**
  * Represents the creation data for an X-COM unit.
  * This info is copied to either Soldier for Geoscape or BattleUnit for Battlescape.
@@ -109,7 +88,7 @@ private:
 	std::vector<std::string> _rankStrings;
 	int _rankSprite, _rankSpriteBattlescape, _rankSpriteTiny, _skillIconSprite;
 	ScriptValues<RuleSoldier> _scriptValues;
-	
+	std::vector<std::string> _skillNames;
 	std::vector<RuleSkill*> _skills;
 	void addSoldierNamePool(const std::string &namFile);
 public:
@@ -223,14 +202,6 @@ public:
 	int getRankSpriteBattlescape() const;
 	/// Gets the offset of the rank sprite in TinyRanks.
 	int getRankSpriteTiny() const;
-	/// Load int from yaml.
-	void loadInt(int& a, const YAML::Node& node) const;
-	/// Load RuleItemUseCost from yaml.
-	void loadCost(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const;
-	/// Load extended cost definition from yaml.
-	void loadPercent(RuleItemUseCost& a, const YAML::Node& node, const std::string& name) const;
-	/// Load a nullable bool from yaml.
-	void loadTriBool(int& a, const YAML::Node& node) const;
 };
 
 }

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -1778,14 +1778,14 @@ RuleItemUseCost BattleUnit::getActionTUs(BattleActionType actionType, const Rule
 			default:
 				break;
 		}
-		
 		// if it's a percentage, apply it to unit TUs
 		applyPercentages(cost, flat);
 	}
 	return cost;
 }
-	
-void BattleUnit::applyPercentages(RuleItemUseCost &cost, const RuleItemUseCost &flat) const {
+
+void BattleUnit::applyPercentages(RuleItemUseCost &cost, const RuleItemUseCost &flat) const
+{
 	if (!flat.Time && cost.Time)
 	{
 		cost.Time = std::max(1, (int)floor(getBaseStats()->tu * cost.Time / 100.0f));

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -37,6 +37,7 @@
 #include "../Mod/Unit.h"
 #include "../Mod/RuleEnviroEffects.h"
 #include "../Mod/RuleInventory.h"
+#include "../Mod/RuleSkill.h"
 #include "../Mod/RuleSoldier.h"
 #include "../Mod/RuleSoldierBonus.h"
 #include "../Mod/Mod.h"
@@ -1448,7 +1449,7 @@ int BattleUnit::damage(Position relative, int damage, const RuleDamageType *type
 	const int orgDamage = damage;
 	const int overKillMinimum = type->IgnoreOverKill ? 0 : -4 * _stats.health;
 
-	const int skillId = attack.skill_rules ? attack.skill_rules->Id : -1;
+	const int skillId = attack.skill_rules ? attack.skill_rules->getScriptId() : -1;
 	
 	{
 		ModScript::HitUnit::Output args { damage, bodypart, side, };
@@ -1717,8 +1718,8 @@ RuleItemUseCost BattleUnit::getActionTUs(BattleActionType actionType, const Rule
 	{
 		return 0;
 	}
-	RuleItemUseCost cost(skillRules->Cost);
-	applyPercentages(cost, skillRules->Flat);
+	RuleItemUseCost cost(skillRules->getCost());
+	applyPercentages(cost, skillRules->getFlat());
 	
 	return cost;
 }

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -175,6 +175,8 @@ private:
 	void prepareUnitSounds();
 	/// Helper function preparing unit response sounds.
 	void prepareUnitResponseSounds(const Mod *mod);
+	/// Applies percentual and/or flat adjustments to the use costs.
+	void applyPercentages(RuleItemUseCost &cost, const RuleItemUseCost &flat) const;
 public:
 	static const int MAX_SOLDIER_ID = 1000000;
 	/// Name of class used in script.
@@ -301,6 +303,8 @@ public:
 	RuleItemUseCost getActionTUs(BattleActionType actionType, const BattleItem *item) const;
 	/// Get the number of time units a certain action takes.
 	RuleItemUseCost getActionTUs(BattleActionType actionType, const RuleItem *item) const;
+	/// Get the number of time units a certain skill action takes.
+	RuleItemUseCost getActionTUs(BattleActionType actionType, const RuleSkill *skillRules) const;
 	/// Spend time units if it can.
 	bool spendTimeUnits(int tu);
 	/// Spend energy if it can.
@@ -607,8 +611,10 @@ public:
 	MovementType getMovementType() const;
 	/// Create special weapon for unit.
 	void setSpecialWeapon(SavedBattleGame *save);
-	/// Get special weapon.
+	/// Get special weapon by battle type.
 	BattleItem *getSpecialWeapon(BattleType type) const;
+	/// Get special weapon by weapon type.
+	BattleItem *getSpecialWeapon(std::string weaponType) const;
 	/// Gets special weapon that uses an icon, if any.
 	BattleItem *getSpecialIconWeapon(BattleType &type) const;
 	/// Checks if this unit is in hiding for a turn.


### PR DESCRIPTION
This adds a skill menu for soldiers.
It will be displayed as an icon at the location of the special weapon icon in the battlescape.
Clicking it will open a moddable action menu. Each action can use an item or be completely scripted.
Skill actions can override weapon action costs. Item based actions can use items from the hand, the inventory or a special weapon.

features for skill menu
 - skill menu actions via ruleset definition
 - support of untargeted actions (scriptable)
 - support of item actions (with item references taken from hands/inventory/specialweapon by type)
 - allow for 0 TU abilities that cost Mana instead
 - allow psi targeting modes: friendly, enemy, both
 - allow for thrown targeting modes (with instant priming)
 - allow firearm targeting mode
 - allow melee targeting mode
 - allow waypoint targeting mode (BA_LAUNCH)
 - allow all item types to be used (incl. medikit, etc.)
 - added skill_id parameter to hitUnit script hook

Here is a small mod which showcases the main features:

[ReportMod.zip](https://github.com/MeridianOXC/OpenXcom/files/4175973/ReportMod.zip)