### PR TITLE
ufos and alien bases handling fakeUnderwater

### DIFF
--- a/bin/standard/xcom1/Language/OXCE/en-US.yml
+++ b/bin/standard/xcom1/Language/OXCE/en-US.yml
@@ -15,6 +15,8 @@ en-US:
 #=================== Geoscape ===================
 #DogfightState.cpp
   STR_EVASIVE_MANEUVERS: "EVASIVE MANEUVERS"
+  STR_UFO_DESTROED_BY_SPLASHDOWN: "UFO DESTROED BY SPLASHDOWN!"
+  STR_UFO_SURVIVE_IN_SPLASHDOWN : "UFO SURVIVES SPLASHDOWN!"
 #GeoscapeState.cpp
   STR_UFO_HAS_LANDED: "UFO has landed at{NEWLINE}{0}"
 #SelectMusicTrackState.cpp

--- a/src/Geoscape/BuildNewBaseState.cpp
+++ b/src/Geoscape/BuildNewBaseState.cpp
@@ -236,19 +236,7 @@ void BuildNewBaseState::globeClick(Action *action)
 	{
 		if (_globe->insideLand(lon, lat))
 		{
-			// look up polygons texture
-			bool fakeUnderwaterTexture = false;
-			int texture, shade;
-			_globe->getPolygonTextureAndShade(lon, lat, &texture, &shade);
-			if (texture >= 0)
-			{
-				Texture *textureRule = _game->getMod()->getGlobe()->getTexture(texture);
-				if (textureRule && textureRule->isFakeUnderwater())
-				{
-					fakeUnderwaterTexture = true;
-				}
-			}
-
+			bool fakeUnderwaterTexture = _globe->insideFakeUnderwater(lon, lat);
 			if (_first && fakeUnderwaterTexture)
 			{
 				// first (starting) base can't be fake underwater base

--- a/src/Geoscape/DogfightState.h
+++ b/src/Geoscape/DogfightState.h
@@ -161,6 +161,8 @@ public:
 	void setWaitForAltitude(bool wait);
 	/// Waits until the UFO reaches the right altitude.
 	bool getWaitForAltitude() const;
+	/// Check if ufo survive crashing on water.
+	bool getSurviveSplash(Ufo* ufo) const;
 	/// Award experience to the pilots.
 	void awardExperienceToPilots();
 };

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -2708,6 +2708,7 @@ void GeoscapeState::globeClick(Action *action)
 		ss << "rad: " << lon << ", " << lat << std::endl;
 		ss << "deg: " << lonDeg << ", " << latDeg << std::endl;
 		ss << "texture: " << texture << ", shade: " << shade << std::endl;
+		ss << "fakeUnderwater: " << _globe->insideFakeUnderwater(lon, lat) << std::endl;
 
 		_txtDebug->setText(ss.str());
 	}

--- a/src/Geoscape/Globe.cpp
+++ b/src/Geoscape/Globe.cpp
@@ -52,6 +52,7 @@
 #include "../Mod/RuleBaseFacility.h"
 #include "../Mod/RuleCraft.h"
 #include "../Mod/RuleGlobe.h"
+#include "../Mod/Texture.h"
 #include "../Interface/Cursor.h"
 #include "../Engine/Screen.h"
 
@@ -716,6 +717,24 @@ void Globe::center(double lon, double lat)
 bool Globe::insideLand(double lon, double lat) const
 {
 	return (getPolygonFromLonLat(lon,lat))!=NULL;
+}
+
+/**
+ * Checks if a polar point is inside the fakeUnderwater texture.
+ * @param lon Longitude of the point.
+ * @param lat Latitude of the point.
+ * @return True if it's inside, False if it's outside.
+ */
+bool Globe::insideFakeUnderwater(double lon, double lat) const
+{
+	Polygon* t = getPolygonFromLonLat(lon, lat);
+	int texture = (t == NULL) ? -1 : t->getTexture();
+	Texture* textureRule = _game->getMod()->getGlobe()->getTexture(texture);
+	if (textureRule && textureRule->isFakeUnderwater())
+	{
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/src/Geoscape/Globe.h
+++ b/src/Geoscape/Globe.h
@@ -157,6 +157,8 @@ public:
 	void center(double lon, double lat);
 	/// Checks if a point is inside land.
 	bool insideLand(double lon, double lat) const;
+	/// Checks if a point is inside fakeUnderwater texture.
+	bool insideFakeUnderwater(double lon, double lat) const;
 	/// Turns on/off the globe detail.
 	void toggleDetail();
 	/// Gets all the targets near a point on the globe.

--- a/src/Mod/AlienDeployment.cpp
+++ b/src/Mod/AlienDeployment.cpp
@@ -119,7 +119,7 @@ namespace OpenXcom
  */
 AlienDeployment::AlienDeployment(const std::string &type) :
 	_type(type), _bughuntMinTurn(0), _width(0), _length(0), _height(0), _civilians(0), _civilianSpawnNodeRank(0),
-	_shade(-1), _minShade(-1), _maxShade(-1), _finalDestination(false), _isAlienBase(false), _isHidden(false),
+	_shade(-1), _minShade(-1), _maxShade(-1), _finalDestination(false), _isAlienBase(false), _fakeUnderwater(-1), _isHidden(false),
 	_alert("STR_ALIENS_TERRORISE"), _alertBackground("BACK03.SCR"), _alertDescription(""), _alertSound(-1),
 	_markerName("STR_TERROR_SITE"), _markerIcon(-1), _durationMin(0), _durationMax(0), _minDepth(0), _maxDepth(0),
 	_genMissionFrequency(0), _genMissionLimit(1000),
@@ -224,6 +224,7 @@ void AlienDeployment::load(const YAML::Node &node, Mod *mod)
 	_chronoTrigger = ChronoTrigger(node["chronoTrigger"].as<int>(_chronoTrigger));
 	_isAlienBase = node["alienBase"].as<bool>(_isAlienBase);
 	_isHidden = node["isHidden"].as<bool>(_isHidden);
+	_fakeUnderwater = node["fakeUnderwater"].as<int>(_fakeUnderwater);
 	_keepCraftAfterFailedMission = node["keepCraftAfterFailedMission"].as<bool>(_keepCraftAfterFailedMission);
 	_allowObjectiveRecovery = node["allowObjectiveRecovery"].as<bool>(_allowObjectiveRecovery);
 	_escapeType = EscapeType(node["escapeType"].as<int>(_escapeType));
@@ -666,6 +667,21 @@ int AlienDeployment::getCheatTurn() const
 bool AlienDeployment::isAlienBase() const
 {
 	return _isAlienBase;
+}
+/**
+ * Checks if deployment can be placed on texture
+ * @param if texture is fakeUnderwater
+ * @return tr if can be placed.
+ */
+bool AlienDeployment::isAllowedForTexture(bool fakeUnderwaterTexture) const
+{
+	if (_fakeUnderwater == -1)
+		return true;
+	else if (_fakeUnderwater == 0 && !fakeUnderwaterTexture)
+		return true;
+	else if (_fakeUnderwater == 1 && fakeUnderwaterTexture)
+		return true;
+	return false;
 }
 
 std::string AlienDeployment::chooseGenMissionType() const

--- a/src/Mod/AlienDeployment.h
+++ b/src/Mod/AlienDeployment.h
@@ -79,6 +79,7 @@ private:
 	std::string _nextStage, _race, _script;
 	std::vector<std::string> _randomRaces;
 	bool _finalDestination, _isAlienBase, _isHidden;
+	int _fakeUnderwater;
 	std::string _winCutscene, _loseCutscene, _abortCutscene;
 	std::string _alert, _alertBackground, _alertDescription;
 	int _alertSound;
@@ -197,6 +198,8 @@ public:
 	bool isAlienBase() const;
 	/// Gets whether or not this mission should be hidden (purely for new battle mode)
 	bool isHidden() const { return _isHidden; }
+	/// Checks if deployment can be placed on fakeUnderwater texture
+	bool isAllowedForTexture(bool fakeUnderwaterTexture) const;
 
 	std::string chooseGenMissionType() const;
 

--- a/src/Mod/RuleUfo.cpp
+++ b/src/Mod/RuleUfo.cpp
@@ -35,7 +35,8 @@ RuleUfo::RuleUfo(const std::string &type) :
 	_hunterKillerPercentage(0), _huntMode(0), _huntSpeed(100), _huntBehavior(2),
 	_missilePower(0),
 	_fireSound(-1), _alertSound(-1), _huntAlertSound(-1),
-	_battlescapeTerrainData(0), _stats(), _statsRaceBonus()
+	_battlescapeTerrainData(0), _stats(), _statsRaceBonus(),
+	_seaCrashSurvivalPercentage(100)
 {
 	_stats.sightRange = 268;
 	_stats.radarRange = 672; // same default as in RuleCraft (used by hunter-killers)
@@ -92,6 +93,7 @@ void RuleUfo::load(const YAML::Node &node, const ModScript &parsers, Mod *mod)
 	_huntSpeed = node["huntSpeed"].as<int>(_huntSpeed);
 	_huntBehavior = node["huntBehavior"].as<int>(_huntBehavior);
 	_missilePower = node["missilePower"].as<int>(_missilePower);
+	_seaCrashSurvivalPercentage = node["seaCrashSurvivalPercentage"].as<int>(_seaCrashSurvivalPercentage);
 
 	_stats.load(node);
 

--- a/src/Mod/RuleUfo.h
+++ b/src/Mod/RuleUfo.h
@@ -74,6 +74,7 @@ private:
 	int _fireSound;
 	int _alertSound;
 	int _huntAlertSound;
+	int _seaCrashSurvivalPercentage;
 	RuleTerrain *_battlescapeTerrainData;
 	RuleUfoStats _stats;
 	std::map<std::string, RuleUfoStats> _statsRaceBonus;
@@ -145,6 +146,8 @@ public:
 	int getHuntBehavior() const;
 	/// Gets the missile power (of a UFO that represents one or more missiles).
 	int getMissilePower() const { return _missilePower; }
+	/// Gets the chance of surviving landing on fakeUnderwater.
+	int getSeaCrashSurvivalPercentage() const { return _seaCrashSurvivalPercentage; }
 	/// Gets script.
 	template<typename Script>
 	const typename Script::Container &getScript() const { return _ufoScripts.get<Script>(); }

--- a/src/Savegame/AlienMission.h
+++ b/src/Savegame/AlienMission.h
@@ -85,6 +85,8 @@ public:
 	void setId(int id);
 	/// Gets the unique ID for this mission.
 	int getId() const;
+	/// Gets valid position to spawn mission.
+	//std::pair<double, double> getSpawnPosition(const Mod& mod);
 	/// Gets the alien base for this mission.
 	const AlienBase *getAlienBase() const;
 	/// Sets the alien base for this mission.
@@ -120,9 +122,9 @@ private:
 	/// Spawn an alien base
 	AlienBase *spawnAlienBase(Country *pactCountry, Game &engine, const MissionArea &area, std::pair<double, double> pos, AlienDeployment *deploymentOverride);
 	/// Select a destination (lon/lat) based on the criteria of our trajectory and desired waypoint.
-	std::pair<double, double> getWaypoint(const MissionWave &wave, const UfoTrajectory &trajectory, const size_t nextWaypoint, const Globe &globe, const RuleRegion &region);
+	std::pair<double, double> getWaypoint(const MissionWave &wave, const UfoTrajectory &trajectory, const size_t nextWaypoint, const Globe &globe, const RuleRegion &region, Ufo* ufo);
 	/// Get a random landing point inside the given region zone.
-	std::pair<double, double> getLandPoint(const Globe &globe, const RuleRegion &region, size_t zone);
+	std::pair<double, double> getLandPoint(const Globe &globe, const RuleRegion &region, Ufo* ufo, size_t zone);
 	/// Spawns a MissionSite at a specific location.
 	MissionSite *spawnMissionSite(SavedGame &game, const Mod &mod, const MissionArea &area, const Ufo *ufo = 0, AlienDeployment *missionOveride = 0);
 	/// Provides some error information for bad mission definitions


### PR DESCRIPTION
additional behavior for UFOs and alien bases for textures with fakeUnderwater: true
* ufos: seaCrashSurvivalPercentage - the chance of UFO to survive splashdown to produce a crash site on fakeUnderwater texture. Default value 100 means UFO can always survive to support the current work of Hybrid globe projects; 0 means UFO will always be destroyed if it's going to crash down over fakeUnderwater texture. 2 new status added for Doghight stat that will be displayed only if ufo was shot down over fakeUnderwater for the player could better understand what is going on (default behavior stays for purists).
UFOs can land by itself on fakeUnderwater only if it has seaCrashSurvivalPercentage >= 100

* alienDeployments: fakeUnderwater. Works exactly like the same property for base facilities (default value -1 means both textures fit, 0 means only true land, 1 means only fakeUnderwater). Used to define if the base can be spawned on texture. I advance a little spawning process, and it goes through all missionZones, in the region to see if any could fit conditions, previously it chooses one random are to get spawn point. So if the chosen area has no valid points process just gave up and placed the base on an invalid spot. Now it tries the best and if no missionsZones can reveal valid points after 100 tries for each zone I assume that its a modder fault that he or she defines the wrong system and I do not spawn the base. Such a case can happen on vanilla hybrid globe mode because, for example, its STR_NORTH_ATLANTIC region has no mission spots for bases on true land, and if this region was chosen with the script and we choose its base to be only on true land, it would fail to spawn the base and make log output. IMO it's better to just spawn base on the wrong location and modder should pay attention to missionScripts regions, and thir mission zones textures if he or she dared to get involved in all this. I thought a lot at this and discussed with Scorch, he agrees with that concept. 
However, I don't understand well code for the case where the area is defined with the country, so it's not changed to go through all its areas. I think it's fine that if aliens fail to spawn their base, they should go to another country.
