### PR TITLE
Removed Quit option and Win self update code

### DIFF
--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -40,7 +40,7 @@
 namespace OpenXcom
 {
 
-GoToMainMenuState::GoToMainMenuState(bool updateCheck) : _updateCheck(updateCheck)
+GoToMainMenuState::GoToMainMenuState()
 {
 	// empty
 }
@@ -54,28 +54,22 @@ void GoToMainMenuState::init()
 {
 	Screen::updateScale(Options::geoscapeScale, Options::baseXGeoscape, Options::baseYGeoscape, true);
 	_game->getScreen()->resetDisplay(false);
-	_game->setState(new MainMenuState(_updateCheck));
+	_game->setState(new MainMenuState());
 }
 
 /**
  * Initializes all the elements in the Main Menu window.
  * @param updateCheck Perform update check?
  */
-MainMenuState::MainMenuState(bool updateCheck)
+MainMenuState::MainMenuState()
 {
-#ifdef _WIN32
-	_debugInVisualStudio = false;
-#endif
-
 	// Create objects
 	_window = new Window(this, 256, 160, 32, 20, POPUP_BOTH);
 	_btnNewGame = new TextButton(92, 20, 64, 90);
 	_btnNewBattle = new TextButton(92, 20, 164, 90);
 	_btnLoad = new TextButton(92, 20, 64, 118);
 	_btnOptions = new TextButton(92, 20, 164, 118);
-	_btnMods = new TextButton(92, 20, 64, 146);
-	_btnQuit = new TextButton(92, 20, 164, 146);
-	_btnUpdate = new TextButton(72, 16, 209, 27);
+	_btnMods = new TextButton(92, 20, 114, 146);
 	_txtUpdateInfo = new Text(320, 17, 0, 11);
 	_txtTitle = new Text(256, 30, 32, 45);
 
@@ -88,8 +82,6 @@ MainMenuState::MainMenuState(bool updateCheck)
 	add(_btnLoad, "button", "mainMenu");
 	add(_btnOptions, "button", "mainMenu");
 	add(_btnMods, "button", "mainMenu");
-	add(_btnQuit, "button", "mainMenu");
-	add(_btnUpdate, "button", "mainMenu");
 	add(_txtUpdateInfo, "text", "mainMenu");
 	add(_txtTitle, "text", "mainMenu");
 
@@ -113,80 +105,10 @@ MainMenuState::MainMenuState(bool updateCheck)
 	_btnMods->setText(tr("STR_MODS"));
 	_btnMods->onMouseClick((ActionHandler)&MainMenuState::btnModsClick);
 
-	_btnQuit->setText(tr("STR_QUIT"));
-	_btnQuit->onMouseClick((ActionHandler)&MainMenuState::btnQuitClick);
-
-	_btnUpdate->setText(tr("STR_UPDATE"));
-	_btnUpdate->onMouseClick((ActionHandler)& MainMenuState::btnUpdateClick);
-	_btnUpdate->setVisible(false);
-
 	_txtUpdateInfo->setAlign(ALIGN_CENTER);
 	_txtUpdateInfo->setWordWrap(true);
 	_txtUpdateInfo->setText(tr("STR_LATEST_VERSION_INFO"));
 	_txtUpdateInfo->setVisible(false);
-
-#ifdef _WIN32
-	//_debugInVisualStudio = true; // uncomment when debugging in Visual Studio (working dir and exe dir are not the same)
-
-	// delete (old) update batch file
-	if (updateCheck && CrossPlatform::fileExists("oxce-upd.bat"))
-	{
-		CrossPlatform::deleteFile("oxce-upd.bat");
-	}
-
-	if (updateCheck && Options::oxceUpdateCheck)
-	{
-		int checkProgress = 0;
-		const std::string relativeExeFilename = (_debugInVisualStudio ? "Debug/" + CrossPlatform::getExeFilename(false) : CrossPlatform::getExeFilename(false));
-		// (naive) check if working directory and exe directory are the same
-		if (!relativeExeFilename.empty() && CrossPlatform::fileExists(relativeExeFilename))
-		{
-			checkProgress = 1;
-			const std::string internetConnectionCheckUrl = "https://openxcom.org/";
-			if (CrossPlatform::testInternetConnection(internetConnectionCheckUrl))
-			{
-				checkProgress = 2;
-				const std::string updateMetadataUrl = "https://openxcom.org/oxce/update.txt";
-				const std::string updateMetadataFilename = Options::getUserFolder() + "oxce-update.txt";
-				if (CrossPlatform::downloadFile(updateMetadataUrl, updateMetadataFilename))
-				{
-					checkProgress = 3;
-					if (CrossPlatform::fileExists(updateMetadataFilename))
-					{
-						checkProgress = 4;
-						try
-						{
-							YAML::Node doc = YAML::Load(*CrossPlatform::readFile(updateMetadataFilename));
-							checkProgress = 5;
-							if (doc["updateInfo"])
-							{
-								checkProgress = 6;
-								std::string msg = doc["updateInfo"].as<std::string>();
-								_txtUpdateInfo->setText(msg);
-								_txtUpdateInfo->setVisible(true);
-							}
-							else if (doc["newVersion"])
-							{
-								checkProgress = 7;
-								_newVersion = doc["newVersion"].as<std::string>();
-								if (CrossPlatform::isHigherThanCurrentVersion(_newVersion))
-									_btnUpdate->setVisible(true);
-								else
-									_txtUpdateInfo->setVisible(true);
-							}
-							CrossPlatform::deleteFile(updateMetadataFilename);
-						}
-						catch (YAML::Exception &e)
-						{
-							Log(LOG_ERROR) << e.what();
-						}
-					}
-				}
-			}
-		}
-		Log(LOG_INFO) << "Update check status: " << checkProgress << "; newVersion: v" << _newVersion << "; ";
-	}
-#endif
 
 	_txtTitle->setAlign(ALIGN_CENTER);
 	_txtTitle->setBig();
@@ -258,222 +180,6 @@ void MainMenuState::btnOptionsClick(Action *)
 void MainMenuState::btnModsClick(Action *)
 {
 	_game->pushState(new OptionsModsState);
-}
-
-/**
- * Quits the game.
- * @param action Pointer to an action.
- */
-void MainMenuState::btnQuitClick(Action *)
-{
-	_game->quit();
-}
-
-/**
- * Updates OpenXcom to the newest version.
- * @param action Pointer to an action.
- */
-void MainMenuState::btnUpdateClick(Action*)
-{
-#ifdef _WIN32
-	const std::string subdir = "v" + _newVersion + "/";
-
-#ifdef _WIN64
-	const std::string relativeExeZipFileName = _debugInVisualStudio ? "Debug/exe64.zip" : "exe64.zip";
-#else
-	const std::string relativeExeZipFileName = _debugInVisualStudio ? "Debug/exe.zip" : "exe.zip";
-#endif
-	const std::string relativeExeNewFileName = _debugInVisualStudio ? "Debug/OpenXcomEx.exe.new" : "OpenXcomEx.exe.new";
-
-	const std::string commonDirFilename = Options::getDataFolder() + "common";
-	const std::string commonZipFilename = Options::getDataFolder() + "common.zip";
-	const std::string commonZipUrl = "https://openxcom.org/oxce/" + subdir + "common.zip";
-
-	const std::string standardDirFilename = Options::getDataFolder() + "standard";
-	const std::string standardZipFilename = Options::getDataFolder() + "standard.zip";
-	const std::string standardZipUrl = "https://openxcom.org/oxce/" + subdir + "standard.zip";
-
-	const std::string now = CrossPlatform::now();
-
-	const std::string exePath = CrossPlatform::getExeFolder();
-	const std::string exeFilenameOnly = CrossPlatform::getExeFilename(false);
-	const std::string exeFilenameFullPath = CrossPlatform::getExeFilename(true);
-
-#ifdef _WIN64
-	const std::string exeZipFilename = exePath + "exe64.zip";
-#else
-	const std::string exeZipFilename = exePath + "exe.zip";
-#endif
-	const std::string exeNewFilename = exePath + "OpenXcomEx.exe.new";
-#ifdef _WIN64
-	const std::string exeZipUrl = "https://openxcom.org/oxce/" + subdir + "exe64.zip";
-#else
-	const std::string exeZipUrl = "https://openxcom.org/oxce/" + subdir + "exe.zip";
-#endif
-
-	// stop using the common/standard zip files, so that we can back them up
-	FileMap::clear(true, false);
-
-	// 0. backup the exe
-	if (CrossPlatform::fileExists(exeFilenameFullPath))
-	{
-		if (CrossPlatform::copyFile(exeFilenameFullPath, exeFilenameFullPath + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 0 done.";
-		else return;
-	}
-
-	// 1. backup common dir
-	if (CrossPlatform::fileExists(commonDirFilename))
-	{
-		if (CrossPlatform::moveFile(commonDirFilename, commonDirFilename + "-" + now))
-			Log(LOG_INFO) << "Update step 1 done.";
-		else return;
-	}
-
-	// 2. backup common zip
-	if (CrossPlatform::fileExists(commonZipFilename))
-	{
-		if (CrossPlatform::moveFile(commonZipFilename, commonZipFilename + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 2 done.";
-		else return;
-	}
-
-	// 3. backup standard dir
-	if (CrossPlatform::fileExists(standardDirFilename))
-	{
-		if (CrossPlatform::moveFile(standardDirFilename, standardDirFilename + "-" + now))
-			Log(LOG_INFO) << "Update step 3 done.";
-		else return;
-	}
-
-	// 4. backup standard zip
-	if (CrossPlatform::fileExists(standardZipFilename))
-	{
-		if (CrossPlatform::moveFile(standardZipFilename, standardZipFilename + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 4 done.";
-		else return;
-	}
-
-	// 5. delete exe zip
-	if (CrossPlatform::fileExists(exeZipFilename))
-	{
-		if (CrossPlatform::deleteFile(exeZipFilename))
-			Log(LOG_INFO) << "Update step 5 done.";
-		else return;
-	}
-
-	// 6. delete unpacked exe zip
-	if (CrossPlatform::fileExists(exeNewFilename))
-	{
-		if (CrossPlatform::deleteFile(exeNewFilename))
-			Log(LOG_INFO) << "Update step 6 done.";
-		else return;
-	}
-
-	// 7. download common zip
-	if (CrossPlatform::downloadFile(commonZipUrl, commonZipFilename))
-	{
-		Log(LOG_INFO) << "Update step 7 done.";
-	}
-	else return;
-
-	// 8. download standard zip
-	if (CrossPlatform::downloadFile(standardZipUrl, standardZipFilename))
-	{
-		Log(LOG_INFO) << "Update step 8 done.";
-	}
-	else return;
-
-	// 9. download exe zip
-	if (CrossPlatform::downloadFile(exeZipUrl, exeZipFilename))
-	{
-		Log(LOG_INFO) << "Update step 9 done.";
-	}
-	else return;
-
-	// 10. extract exe zip
-	if (CrossPlatform::fileExists(exeZipFilename) && CrossPlatform::fileExists(relativeExeZipFileName))
-	{
-		const std::string file_to_extract = "OpenXcomEx.exe.new";
-		SDL_RWops *rwo_read = FileMap::zipGetFileByName(relativeExeZipFileName, file_to_extract);
-		if (!rwo_read) {
-			Log(LOG_ERROR) << "Step 10a: failed to unzip file.";
-			return;
-		}
-		size_t size = 0;
-		auto data = SDL_LoadFile_RW(rwo_read, &size, SDL_TRUE);
-		if (!data) {
-			Log(LOG_ERROR) << "Step 10b: failed to unzip file." << SDL_GetError(); // out of memory for a copy ?
-			return;
-		}
-		SDL_RWops *rwo_write = SDL_RWFromFile(relativeExeNewFileName.c_str(), "wb");
-		if (!rwo_write) {
-			Log(LOG_ERROR) << "Step 10c: failed to open exe.new file for writing." << SDL_GetError();
-			return;
-		}
-		auto wsize = SDL_RWwrite(rwo_write, data, size, 1);
-		if (wsize != 1) {
-			Log(LOG_ERROR) << "Step 10d: failed to write exe.new file." << SDL_GetError();
-			return;
-		}
-		if (SDL_RWclose(rwo_write)) {
-			Log(LOG_ERROR) << "Step 10e: failed to write exe.new file." << SDL_GetError();
-			return;
-		}
-	} else {
-		Log(LOG_ERROR) << "Update step 10 failed."; // exe dir and working dir not the same
-		return;
-	}
-
-	// 11. check if extracted exe exists
-	if (!CrossPlatform::fileExists(exeNewFilename))
-	{
-		Log(LOG_ERROR) << "Update step 11 failed.";
-		return;
-	}
-
-	// 12. delete exe zip (again)
-	if (CrossPlatform::fileExists(exeZipFilename))
-	{
-		if (CrossPlatform::deleteFile(exeZipFilename))
-			Log(LOG_INFO) << "Update step 12 done.";
-		else return;
-	}
-
-	// 13. create the update batch file
-	{
-		std::ofstream batch;
-		batch.open("oxce-upd.bat", std::ios::out);
-
-		batch << "@echo OFF\n";
-		batch << "echo OpenXcom is updating, please wait...\n";
-		batch << "timeout 5\n";
-		if (!_debugInVisualStudio)
-		{
-			batch << "echo Removing the old version...\n";
-			batch << "del " << exeFilenameOnly << "\n";
-			batch << "echo Preparing the new version...\n";
-			batch << "ren OpenXcomEx.exe.new " << exeFilenameOnly << "\n";
-			batch << "echo Starting the new version...\n";
-			batch << "timeout 2\n";
-			batch << "start " << exeFilenameOnly << "\n"; // asynchronous
-			batch << "exit\n";
-		}
-
-		batch.close();
-	}
-
-	// 14. Clear the SDL event queue (i.e. ignore input from impatient users)
-	SDL_Event e;
-	while (SDL_PollEvent(&e))
-	{
-		// do nothing
-	}
-
-	Log(LOG_INFO) << "Update prepared, restarting.";
-	_game->setUpdateFlag(true);
-	_game->quit();
-#endif
 }
 
 /**

--- a/src/Menu/MainMenuState.h
+++ b/src/Menu/MainMenuState.h
@@ -29,10 +29,8 @@ class Text;
 // Utility class for enqueuing a state in the stack that goes to the main menu
 class GoToMainMenuState : public State
 {
-private:
-	bool _updateCheck;
 public:
-	GoToMainMenuState(bool updateCheck = false);
+	GoToMainMenuState();
 	~GoToMainMenuState();
 	void init() override;
 };
@@ -44,16 +42,12 @@ public:
 class MainMenuState : public State
 {
 private:
-	TextButton *_btnNewGame, *_btnNewBattle, *_btnLoad, *_btnOptions, *_btnMods, *_btnQuit, *_btnUpdate;
+	TextButton *_btnNewGame, *_btnNewBattle, *_btnLoad, *_btnOptions, *_btnMods;
 	Window *_window;
 	Text *_txtTitle, *_txtUpdateInfo;
-#ifdef _WIN32
-	bool _debugInVisualStudio;
-	std::string _newVersion;
-#endif
 public:
 	/// Creates the Main Menu state.
-	MainMenuState(bool updateCheck = false);
+	MainMenuState();
 	/// Cleans up the Main Menu state.
 	~MainMenuState();
 	/// Handler for clicking the New Game button.
@@ -66,10 +60,6 @@ public:
 	void btnOptionsClick(Action *action);
 	/// Handler for clicking the Mods button.
 	void btnModsClick(Action *action);
-	/// Handler for clicking the Quit button.
-	void btnQuitClick(Action *action);
-	/// Handler for clicking the Update button.
-	void btnUpdateClick(Action* action);
 	/// Update the resolution settings, we just resized the window.
 	void resize(int &dX, int &dY) override;
 	void init() override;

--- a/src/Menu/StartState.cpp
+++ b/src/Menu/StartState.cpp
@@ -205,7 +205,7 @@ void StartState::think()
 	case LOADING_SUCCESSFUL:
 		CrossPlatform::flashWindow(_game->getScreen()->getWindow());
 		Log(LOG_INFO) << "OpenXcom started successfully!";
-		_game->setState(new GoToMainMenuState(true));
+		_game->setState(new GoToMainMenuState());
 		if (_oldMaster != Options::getActiveMaster() && Options::playIntro)
 		{
 			_game->pushState(new CutsceneState("intro"));


### PR DESCRIPTION
Removed the Quit button as iOS apps don't really quit, against the ethos blah, blah. There is a quit function but that closes the app and leaves it in a crashed like state with the app window still front and centre.

Stripped out update code, probably shouldn't have, didn't seem to belong there really.