### PR TITLE
getHaveCategory y-script method for RuleItem

### DIFF
--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -2625,6 +2625,10 @@ void getHaveCategory(const RuleItem* ri, int& val, const std::string& cat)
 		{
 			val = 1;
 		}
+		else
+		{
+			val = 0;
+		}
 		return;
 	}
 	val = 0;

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -2616,6 +2616,20 @@ std::string debugDisplayScript(const RuleItem* ri)
 	}
 }
 
+void getHaveCategory(const RuleItem* ri, int& val, const std::string& cat)
+{
+	if (ri)
+	{
+		auto it = std::find(ri->getCategories().begin(), ri->getCategories().end(), cat);
+		if (it != ri->getCategories().end())
+		{
+			val = 1;
+		}
+		return;
+	}
+	val = 0;
+}
+
 }
 
 
@@ -2664,6 +2678,7 @@ void RuleItem::ScriptRegister(ScriptParserBase* parser)
 	ri.add<&RuleItem::isTwoHanded>("isTwoHanded");
 	ri.add<&RuleItem::isBlockingBothHands>("isBlockingBothHands");
 	ri.add<&isSingleTargetScript>("isSingleTarget");
+	ri.add<&getHaveCategory>("getHaveCategory");
 
 	ri.addScriptValue<BindBase::OnlyGet, &RuleItem::_scriptValues>();
 	ri.addDebugDisplay<&debugDisplayScript>();

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -2616,7 +2616,7 @@ std::string debugDisplayScript(const RuleItem* ri)
 	}
 }
 
-void getHaveCategory(const RuleItem* ri, int& val, const std::string& cat)
+void hasCategoryScript(const RuleItem* ri, int& val, const std::string& cat)
 {
 	if (ri)
 	{
@@ -2624,12 +2624,8 @@ void getHaveCategory(const RuleItem* ri, int& val, const std::string& cat)
 		if (it != ri->getCategories().end())
 		{
 			val = 1;
+			return;
 		}
-		else
-		{
-			val = 0;
-		}
-		return;
 	}
 	val = 0;
 }
@@ -2682,7 +2678,7 @@ void RuleItem::ScriptRegister(ScriptParserBase* parser)
 	ri.add<&RuleItem::isTwoHanded>("isTwoHanded");
 	ri.add<&RuleItem::isBlockingBothHands>("isBlockingBothHands");
 	ri.add<&isSingleTargetScript>("isSingleTarget");
-	ri.add<&getHaveCategory>("getHaveCategory");
+	ri.add<&hasCategoryScript>("hasCategory");
 
 	ri.addScriptValue<BindBase::OnlyGet, &RuleItem::_scriptValues>();
 	ri.addDebugDisplay<&debugDisplayScript>();


### PR DESCRIPTION
Enables y-scripts to check if the item we are pointing has a particular item category in its categories vector.

Example of usage:
RuleItem.getHaveCategory value "STR_SNIPER_RIFLES";
returs 1 if "STR_SNIPER_RIFLES" string was found in item's `category` vector; else returns 0.