### PR TITLE
Show research progress in percents

### DIFF
--- a/bin/common/Language/en-US.yml
+++ b/bin/common/Language/en-US.yml
@@ -133,6 +133,8 @@ en-US:
   STR_ALLOWPSIONICCAPTURE_DESC: "Mind-controlling all remaining aliens results in victory, and they count as live captures."
   STR_ANYTIMEPSITRAINING: "Psionic training at any time"
   STR_ANYTIMEPSITRAINING_DESC: "Allows assigning soldiers to psionic training at any time of the month. Remember, initial training takes from 30 to 60 days."
+  STR_SHOWRESEARCHPERCENTS: "Show research progress"
+  STR_SHOWRESEARCHPERCENTS_DESC: "Show research progress in percents"
   STR_SKIPNEXTTURNSCREEN: "Skip \"Next Turn\" screen"
   STR_SKIPNEXTTURNSCREEN_DESC: "\"Next Turn\" screens during battle are advanced automatically after a short delay."
   STR_NOT_ENOUGH_SPACE: "Not Enough Space!"

--- a/src/Basescape/GlobalResearchState.cpp
+++ b/src/Basescape/GlobalResearchState.cpp
@@ -187,14 +187,25 @@ void GlobalResearchState::fillProjectList()
 			_bases.push_back(0);
 			_topics.push_back(0);
 		}
-		for (std::vector<ResearchProject *>::const_iterator iter = baseProjects.begin(); iter != baseProjects.end(); ++iter)
+		for (const auto& project: baseProjects)
 		{
 			std::ostringstream sstr;
-			sstr << (*iter)->getAssigned();
-			const RuleResearch *r = (*iter)->getRules();
+			sstr << project->getAssigned();
+			const RuleResearch *r = project->getRules();
 
 			std::string wstr = tr(r->getName());
-			_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), tr((*iter)->getResearchProgress()).c_str());
+
+			std::ostringstream progress;
+			auto [progressTag, percents] = project->getResearchProgress();
+			progress << tr(progressTag);
+			if (Options::showResearchPertcents)
+			{
+				progress << " (" << percents << "%)";
+			}
+
+			auto progressString = progress.str();
+
+			_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), progressString.c_str());
 
 			_bases.push_back(base);
 			_topics.push_back(_game->getMod()->getResearch(r->getName()));

--- a/src/Basescape/ResearchState.cpp
+++ b/src/Basescape/ResearchState.cpp
@@ -232,14 +232,25 @@ void ResearchState::fillProjectList(size_t scrl)
 {
 	const std::vector<ResearchProject *> & baseProjects(_base->getResearch());
 	_lstResearch->clearList();
-	for (std::vector<ResearchProject *>::const_iterator iter = baseProjects.begin(); iter != baseProjects.end(); ++iter)
+	for (const auto& project : baseProjects)
 	{
 		std::ostringstream sstr;
-		sstr << (*iter)->getAssigned();
-		const RuleResearch *r = (*iter)->getRules();
+		sstr << project->getAssigned();
+		const RuleResearch *r = project->getRules();
 
 		std::string wstr = tr(r->getName());
-		_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), tr((*iter)->getResearchProgress()).c_str());
+
+		std::ostringstream progress;
+		auto [progressTag, percents] = project->getResearchProgress();
+		progress << tr(progressTag);
+		if (Options::showResearchPertcents)
+		{
+			progress << " (" << percents << "%)";
+		}
+
+		auto progressString = progress.str();
+
+		_lstResearch->addRow(3, wstr.c_str(), sstr.str().c_str(), progressString.c_str());
 	}
 	_txtAvailable->setText(tr("STR_SCIENTISTS_AVAILABLE").arg(_base->getAvailableScientists()));
 	_txtAllocated->setText(tr("STR_SCIENTISTS_ALLOCATED").arg(_base->getAllocatedScientists()));

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -185,6 +185,7 @@ void create()
 	_info.push_back(OptionInfo("storageLimitsEnforced", &storageLimitsEnforced, false, "STR_STORAGELIMITSENFORCED", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("canSellLiveAliens", &canSellLiveAliens, false, "STR_CANSELLLIVEALIENS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("anytimePsiTraining", &anytimePsiTraining, false, "STR_ANYTIMEPSITRAINING", "STR_GEOSCAPE"));
+	_info.push_back(OptionInfo("showResearchPertcents", &showResearchPertcents, false, "STR_SHOWRESEARCHPERCENTS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("globeSeasons", &globeSeasons, false, "STR_GLOBESEASONS", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("psiStrengthEval", &psiStrengthEval, false, "STR_PSISTRENGTHEVAL", "STR_GEOSCAPE"));
 	_info.push_back(OptionInfo("canTransferCraftsWhileAirborne", &canTransferCraftsWhileAirborne, false, "STR_CANTRANSFERCRAFTSWHILEAIRBORNE", "STR_GEOSCAPE")); // When the craft can reach the destination base with its fuel

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -22,7 +22,7 @@ OPT SDLKey keyOk, keyCancel, keyScreenshot, keyFps, keyQuickLoad, keyQuickSave;
 OPT int geoClockSpeed, dogfightSpeed, geoScrollSpeed, geoDragScrollButton, geoscapeScale;
 OPT bool includePrimeStateInSavedLayout, anytimePsiTraining, weaponSelfDestruction, retainCorpses, craftLaunchAlways, globeSeasons, globeDetail, globeRadarLines, globeFlightPaths, globeAllRadarsOnBaseBuild,
 	storageLimitsEnforced, canSellLiveAliens, canTransferCraftsWhileAirborne, customInitialBase, aggressiveRetaliation, geoDragScrollInvert,
-	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, allowPsiStrengthImprovement, fieldPromotions, meetingPoint;
+	allowBuildingQueue, showFundsOnGeoscape, psiStrengthEval, allowPsiStrengthImprovement, fieldPromotions, meetingPoint, showResearchPertcents;
 OPT SDLKey keyGeoLeft, keyGeoRight, keyGeoUp, keyGeoDown, keyGeoZoomIn, keyGeoZoomOut, keyGeoSpeed1, keyGeoSpeed2, keyGeoSpeed3, keyGeoSpeed4, keyGeoSpeed5, keyGeoSpeed6,
 	keyGeoIntercept, keyGeoBases, keyGeoGraphs, keyGeoUfopedia, keyGeoOptions, keyGeoFunding, keyGeoToggleDetail, keyGeoToggleRadar,
 	keyBaseSelect1, keyBaseSelect2, keyBaseSelect3, keyBaseSelect4, keyBaseSelect5, keyBaseSelect6, keyBaseSelect7, keyBaseSelect8;

--- a/src/Savegame/ResearchProject.cpp
+++ b/src/Savegame/ResearchProject.cpp
@@ -133,19 +133,21 @@ YAML::Node ResearchProject::save() const
 }
 
 /**
- * Return a string describing Research progress.
- * @return a string describing Research progress.
+ * Return a tuple with string describing current progress and progress in percents.
+ * @return tuple of a string describing research progress and progress in percents.
  */
-std::string ResearchProject::getResearchProgress() const
+std::tuple<std::string, int> ResearchProject::getResearchProgress() const
 {
-	float progress = (float)getSpent() / getRules()->getCost();
+	float progress = static_cast<float>(getSpent()) / static_cast<float>(getCost());
+	int progressInPercents = static_cast<int>(progress * 100.f);
+
 	if (getAssigned() == 0)
 	{
-		return "STR_NONE";
+		return std::make_tuple("STR_NONE", progressInPercents);
 	}
 	else if (progress <= PROGRESS_LIMIT_UNKNOWN)
 	{
-		return "STR_UNKNOWN";
+		return std::make_tuple("STR_UNKNOWN", progressInPercents);
 	}
 	else
 	{
@@ -153,17 +155,17 @@ std::string ResearchProject::getResearchProgress() const
 		rating /= getRules()->getCost();
 		if (rating <= PROGRESS_LIMIT_POOR)
 		{
-			return "STR_POOR";
+			return std::make_tuple("STR_POOR", progressInPercents);
 		}
 		else if (rating <= PROGRESS_LIMIT_AVERAGE)
 		{
-			return "STR_AVERAGE";
+			return std::make_tuple("STR_AVERAGE", progressInPercents);
 		}
 		else if (rating <= PROGRESS_LIMIT_GOOD)
 		{
-			return "STR_GOOD";
+			return std::make_tuple("STR_GOOD", progressInPercents);
 		}
-		return "STR_EXCELLENT";
+		return std::make_tuple("STR_EXCELLENT", progressInPercents);
 	}
 }
 

--- a/src/Savegame/ResearchProject.h
+++ b/src/Savegame/ResearchProject.h
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <tuple>
 #include <yaml-cpp/yaml.h>
 
 namespace OpenXcom
@@ -59,8 +60,8 @@ public:
 	void load(const YAML::Node& node);
 	/// save the ResearchProject to YAML
 	YAML::Node save() const;
-	/// Get a string describing current progress.
-	std::string getResearchProgress() const;
+	/// Get a tuple with string describing current progress and progress in percents
+	std::tuple<std::string, int> getResearchProgress() const;
 };
 
 }


### PR DESCRIPTION
Updates research windows to show progress in percents for active researches. Disabled by default and could be enabled with options flag.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->