### PR TITLE
Added scanning for mods in installation directory

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -660,6 +660,8 @@ void refreshMods()
 	}
 	Log(LOG_INFO) << "Scanning user mods in '" << getUserFolder() << "'...";
 	FileMap::scanModDir(getUserFolder(), "mods", false);
+	Log(LOG_INFO) << "Scanning system mods in '" << getDataFolder() << "'...";
+	FileMap::scanModDir(getDataFolder(), "mods", false);
 #ifdef __MOBILE__
 	if (getDataFolder() == getUserFolder())
 	{


### PR DESCRIPTION
Those two lines of code load mods from DataFolder, "mods" subdirectory. With it system administrator can install mods for all users. Also this allows installing mods from distribution repositories with system tools like APT or pacman. For now it's complicated, because those programs often don't want to make mess in user's $HOME directory. With this patch they would install mods in eg. /usr/share/openxcom/mods without need to edit user's files.
<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->