### PR TITLE
Added Energy Display to Path Review + Toggle

### DIFF
--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -1500,11 +1500,42 @@ void Map::drawTerrain(Surface *surface)
 							_numWaypid->draw();
 							if ( !(_previewSetting & PATH_ARROWS) )
 							{
+								// TU only
 								_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (29-adjustment), 0, false, tile->getMarkerColor() );
 							}
 							else
 							{
-								_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (22-adjustment), 0);
+								// Arrows + TUs
+								if (Options::oxceShowEnergyInPathReview)
+								{
+									if (tile->getTUMarker() == 0)
+									{
+										// 3 = red
+										_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (22-adjustment), 0, false, 3);
+									}
+									else
+									{
+										// 5 = lime green
+										_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (22-adjustment), 0, false, 5);
+									}
+
+									_numWaypid->setValue(tile->getEnergyMarker());
+									_numWaypid->draw();
+									if (tile->getEnergyMarker() == 0)
+									{
+										// 3 = red
+										_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (29-adjustment), 0, false, 3);
+									}
+									else
+									{
+										// 10 = yellow
+										_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (29-adjustment), 0, false, 10);
+									}
+								}
+								else
+								{
+									_numWaypid->blitNShade(surface, screenPosition.x + 16 - off, screenPosition.y + (22-adjustment), 0);
+								}
 							}
 						}
 					}

--- a/src/Battlescape/Pathfinding.cpp
+++ b/src/Battlescape/Pathfinding.cpp
@@ -971,6 +971,7 @@ bool Pathfinding::previewPath(bool bRemove)
 					if ((x && y) || size == 0)
 					{
 						tile->setTUMarker(std::max(0,tus));
+						tile->setEnergyMarker(std::max(0,energy));
 					}
 					if (tileAbove && tileAbove->getPreview() == 0 && tu == 0 && _movementType != MT_FLY) //unit fell down, retroactively make the tile above's direction marker to DOWN
 					{
@@ -981,6 +982,7 @@ bool Pathfinding::previewPath(bool bRemove)
 				{
 					tile->setPreview(-1);
 					tile->setTUMarker(-1);
+					tile->setEnergyMarker(-1);
 				}
 				tile->setMarkerColor(bRemove?0:((tus>=0 && energy>=0)?(reserve?Pathfinding::green : Pathfinding::yellow) : Pathfinding::red));
 			}

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -224,6 +224,7 @@ void create()
 	_info.push_back(OptionInfo("oxceAutoSell", &oxceAutoSell, false, "STR_AUTO_SELL", "STR_OXCE"));
 	_info.push_back(OptionInfo("oxceRememberDisabledCraftWeapons", &oxceRememberDisabledCraftWeapons, false, "STR_REMEMBER_DISABLED_CRAFT_WEAPONS", "STR_OXCE"));
 	_info.push_back(OptionInfo("oxceEnableOffCentreShooting", &oxceEnableOffCentreShooting, false, "STR_OFF_CENTRE_SHOOTING", "STR_OXCE"));
+	_info.push_back(OptionInfo("oxceShowEnergyInPathReview", &oxceShowEnergyInPathReview, false, "STR_SHOW_ENERGY_PATH_REVIEW", "STR_OXCE"));
 
 	// OXCE hidden
 #ifdef __MOBILE__

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -74,6 +74,7 @@ OPT bool oxceAutoSell;
 OPT int oxceAutoNightVisionThreshold;
 OPT bool oxceRememberDisabledCraftWeapons;
 OPT bool oxceEnableOffCentreShooting;
+OPT bool oxceShowEnergyInPathReview;
 
 // OXCE hidden, accessible only via options.cfg
 OPT bool oxceFatFingerLinks;

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -1009,6 +1009,25 @@ int Tile::getTUMarker() const
 }
 
 /**
+ * set the number to be displayed for pathfinding preview.
+ * @param energy
+ */
+void Tile::setEnergyMarker(int energy)
+{
+       _EnergyMarker = energy;
+}
+
+/**
+ * get the number to be displayed for pathfinding preview.
+ * @return marker
+ */
+int Tile::getEnergyMarker() const
+{
+       return _EnergyMarker;
+}
+
+
+/**
  * get the overlap value of this tile.
  * @return overlap
  */

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -127,6 +127,7 @@ protected:
 	Sint16 _explosive = 0;
 	Sint16 _visible = 0;
 	Sint16 _TUMarker = -1;
+	Sint16 _EnergyMarker = -1;
 	Sint8 _preview = -1;
 	Uint8 _overlaps = 0;
 
@@ -380,6 +381,10 @@ public:
 	void setTUMarker(int tu);
 	/// get the number to be displayed for pathfinding preview.
 	int getTUMarker() const;
+    /// set the number to be displayed for pathfinding preview.
+    void setEnergyMarker(int tu);
+    /// get the number to be displayed for pathfinding preview.
+    int getEnergyMarker() const;
 	/// how many times has this tile been overlapped with smoke/fire (runtime only)
 	int getOverlaps() const;
 	/// increment the overlap value on this tile.


### PR DESCRIPTION
This commit adds an indicator of remaining energy next to remaining TUs when pathing for your own soldiers. This is useful for mods which have an energy cost for attacks (melee) and abilities (restoring TUs, etc.). This way the player does not have to figure out the energy use by theirselves but see it in the path review.

This is the solution to my request back then: https://openxcom.org/forum/index.php/topic,9556.0.html

What it does is to use the way TUs are shown and added similar parts so it displays energy for the path review with Arrows and TUs. I have added an extra toggle in the advanced options. For any player not enabling this toggle the game will behave like it did before.