### PR TITLE
Implemented Toggle to Keep Craft Commands after Dogfight

### DIFF
--- a/bin/common/Language/OXCE/en-GB.yml
+++ b/bin/common/Language/OXCE/en-GB.yml
@@ -292,6 +292,8 @@ en-GB:
   STR_REMEMBER_DISABLED_CRAFT_WEAPONS_DESC: "Craft weapons disabled during a dogfight will stay disabled. They will also not be rearmed at the base."
   STR_OFF_CENTRE_SHOOTING: "Off-centre shooting"
   STR_OFF_CENTRE_SHOOTING_DESC: "Soldiers will automatically try to adjust the firing angle slightly in case there is no line of fire."
+  STR_KEEP_CRAFT_COMMANDS_AFTER_DOGFIGHT: "Keep Craft Commands after Dogfight"
+  STR_KEEP_CRAFT_COMMANDS_AFTER_DOGFIGHT_DESC: "Crafts will keep their commands despite having been engaged by a Hunter-Killer/UFO. Usually crafts will return to base once they have been in a dogfight."
 #===================
   STR_GRAPHS_ZOOM_IN: "Zoom In (Graphs)"
   STR_GRAPHS_ZOOM_OUT: "Zoom Out (Graphs)"

--- a/bin/common/Language/OXCE/en-US.yml
+++ b/bin/common/Language/OXCE/en-US.yml
@@ -292,6 +292,8 @@ en-US:
   STR_REMEMBER_DISABLED_CRAFT_WEAPONS_DESC: "Craft weapons disabled during a dogfight will stay disabled. They will also not be rearmed at the base."
   STR_OFF_CENTRE_SHOOTING: "Off-center shooting"
   STR_OFF_CENTRE_SHOOTING_DESC: "Soldiers will automatically try to adjust the firing angle slightly in case there is no line of fire."
+  STR_KEEP_CRAFT_COMMANDS_AFTER_DOGFIGHT: "Keep Craft Commands after Dogfight"
+  STR_KEEP_CRAFT_COMMANDS_AFTER_DOGFIGHT_DESC: "Crafts will keep their commands despite having been engaged by a Hunter-Killer/UFO. Usually crafts will return to base once they have been in a dogfight."
 #===================
   STR_GRAPHS_ZOOM_IN: "Zoom In (Graphs)"
   STR_GRAPHS_ZOOM_OUT: "Zoom Out (Graphs)"

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -224,6 +224,7 @@ void create()
 	_info.push_back(OptionInfo("oxceAutoSell", &oxceAutoSell, false, "STR_AUTO_SELL", "STR_OXCE"));
 	_info.push_back(OptionInfo("oxceRememberDisabledCraftWeapons", &oxceRememberDisabledCraftWeapons, false, "STR_REMEMBER_DISABLED_CRAFT_WEAPONS", "STR_OXCE"));
 	_info.push_back(OptionInfo("oxceEnableOffCentreShooting", &oxceEnableOffCentreShooting, false, "STR_OFF_CENTRE_SHOOTING", "STR_OXCE"));
+	_info.push_back(OptionInfo("oxceKeepCraftCommandsAfterDogfight", &oxceKeepCraftCommandsAfterDogfight, false, "STR_KEEP_CRAFT_COMMANDS_AFTER_DOGFIGHT", "STR_OXCE"));
 
 	// OXCE hidden
 #ifdef __MOBILE__

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -74,6 +74,7 @@ OPT bool oxceAutoSell;
 OPT int oxceAutoNightVisionThreshold;
 OPT bool oxceRememberDisabledCraftWeapons;
 OPT bool oxceEnableOffCentreShooting;
+OPT bool oxceKeepCraftCommandsAfterDogfight;
 
 // OXCE hidden, accessible only via options.cfg
 OPT bool oxceFatFingerLinks;

--- a/src/Geoscape/DogfightState.cpp
+++ b/src/Geoscape/DogfightState.cpp
@@ -1382,7 +1382,12 @@ void DogfightState::update()
 		}
 		if (!_destroyCraft && (_destroyUfo || _mode == _btnDisengage))
 		{
-			_craft->returnToBase();
+			// keep original target
+			if (_mode == _btnDisengage || _craft->getDestination() == _ufo || !Options::oxceKeepCraftCommandsAfterDogfight)
+			{
+				_craft->returnToBase();
+			}
+			
 			// Need to give the craft at least one step advantage over the hunter-killer (to be able to escape)
 			if (_ufoIsAttacking)
 			{
@@ -1398,7 +1403,9 @@ void DogfightState::update()
 			std::vector<Craft*> followers = _ufo->getCraftFollowers();
 			for (std::vector<Craft*>::iterator i = followers.begin(); i != followers.end(); ++i)
 			{
-				if (((*i)->getNumSoldiers() == 0 && (*i)->getNumVehicles() == 0) || !(*i)->getRules()->getAllowLanding())
+				if (((*i)->getNumSoldiers() == 0 && (*i)->getNumVehicles() == 0) ||
+					!(*i)->getRules()->getAllowLanding() ||
+					((*i)->getDestination() != _ufo && Options::oxceKeepCraftCommandsAfterDogfight))
 				{
 					(*i)->returnToBase();
 				}


### PR DESCRIPTION
Currently when a patrolling/escorting/chasing craft is being engaged by a hunter-killer/UFO
the craft will return to base after the successfully crashing/destroying the hunter-killer/UFO.
This means that the original command has to be issued to the craft by the player again.
This implementation adds a toggle, so the craft will not return to base unless it has achieved its final mission.
