### PR TITLE
Fixing getReactionScoreScript not to always return ret = 0

### DIFF
--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -5183,6 +5183,7 @@ void getReactionScoreScript(const BattleUnit *bu, int &ret)
 	if (bu)
 	{
 		ret = (int)bu->getReactionScore();
+		return;
 	}
 	ret = 0;
 }


### PR DESCRIPTION
This fixes a bug in the Y-script function getReactionScoreScript. Previously the value ret was always set to 0 instead of the return value of getReactionScore.