### PR TITLE
Load layout from next decade by repeating key press. …

### DIFF
--- a/src/Battlescape/InventoryState.cpp
+++ b/src/Battlescape/InventoryState.cpp
@@ -914,15 +914,34 @@ void InventoryState::btnGlobalEquipmentLayoutClick(Action *action)
 		return;
 	}
 
-	// SDLK_1 = 49, SDLK_9 = 57
-	const int index = action->getDetails()->key.keysym.sym - 49;
-	if (index < 0 || index > 8)
+	// SDLK_0 = 48, SDLK_1 = 49, SDLK_9 = 57
+	// SDLK_0 selects 10-th inventory layout
+	// by repeating a key you can load a layout from next decade
+	const int sym = action->getDetails()->key.keysym.sym;
+	const int layout_no = (sym == 48) ? 10 : sym - 48;
+
+	if (!_game->isCtrlPressed() && sym == _prev_key)
 	{
-		return; // just in case
+		_key_repeats++;
+	}
+	else
+	{
+		_key_repeats = 0;
+	}
+	_prev_key = sym;
+
+	int index = 10 * _key_repeats + layout_no - 1;
+
+	if (index < 0 || index >= SavedGame::MAX_EQUIPMENT_LAYOUT_TEMPLATES)
+	{
+		// do nothing if layout is out of bonds
+		return;
 	}
 
 	if (_game->isCtrlPressed())
 	{
+		// can't save layout >10 this way
+		_prev_key = 0, _key_repeats = 0;
 		saveGlobalLayout(index, false);
 
 		// give audio feedback
@@ -1583,6 +1602,7 @@ void InventoryState::onAutoequip(Action *)
 void InventoryState::invClick(Action *act)
 {
 	updateStats();
+	_prev_key = 0, _key_repeats = 0;
 }
 
 /**
@@ -1919,13 +1939,18 @@ void InventoryState::handle(Action *action)
 	{
 		// "ctrl+1..9" - save equipment
 		// "1..9" - load equipment
-		if (action->getDetails()->key.keysym.sym >= SDLK_1 && action->getDetails()->key.keysym.sym <= SDLK_9)
+		if (action->getDetails()->key.keysym.sym >= SDLK_0 && action->getDetails()->key.keysym.sym <= SDLK_9)
 		{
 			if (!_btnQuickSearch->isFocused())
 			{
 				btnGlobalEquipmentLayoutClick(action);
 			}
 		}
+		else
+		{
+			_prev_key = 0, _key_repeats = 0;
+		}
+
 		if (action->getDetails()->key.keysym.sym == Options::keyInvClear)
 		{
 			if (_game->isCtrlPressed() && _game->isAltPressed())

--- a/src/Battlescape/InventoryState.h
+++ b/src/Battlescape/InventoryState.h
@@ -64,6 +64,7 @@ private:
 	BattleItem *_currentDamageTooltipItem = nullptr;
 	bool _reloadUnit;
 	int _globalLayoutIndex;
+	int _prev_key = 0, _key_repeats = 0;
 	/// Helper method for Create Template button
 	void _createInventoryTemplate(std::vector<EquipmentLayoutItem*> &inventoryTemplate);
 	/// Helper method for Apply Template button

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -122,7 +122,7 @@ public:
 	static void ScriptRegister(ScriptParserBase* parser);
 
 
-	static const int MAX_EQUIPMENT_LAYOUT_TEMPLATES = 20;
+	static const int MAX_EQUIPMENT_LAYOUT_TEMPLATES = 200;
 	static const int MAX_CRAFT_LOADOUT_TEMPLATES = 10;
 
 private:


### PR DESCRIPTION
…Set MAX_EQUIPMENT_LAYOUT_TEMPLATES to 200.

I am playing X-Com Files mod and there is a tons of weapons! I haven't even researched laser weaponry yet :)
Equipment templates are very useful in this mod. So 20 templates is not enough.

This commit increases MAX_EQUIPMENT_LAYOUT_TEMPLATES to 200 and adds a way to load them quickly.

There is a hotkeys for loading slots 1..9 already.
First I added a hotkey (0) for slot 10.
Second I added a way to load all other 190 slots. If user presses the hotkey again the game loads template with number +10.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->