### PR TITLE
TTV cost to buy

### DIFF
--- a/src/Basescape/TechTreeViewerState.cpp
+++ b/src/Basescape/TechTreeViewerState.cpp
@@ -1676,6 +1676,31 @@ void TechTreeViewerState::initLists()
 				++row;
 			}
 		}
+
+		// empty line
+		_lstFull->addRow(1, "");
+		_leftTopics.push_back("-");
+		_leftFlags.push_back(TTV_NONE);
+		++row;
+
+		// cost to buy
+		if (rule->getBuyCost() > 0)
+		{
+			_lstFull->addRow(1, tr("STR_TTV_COST_PER_UNIT").c_str());
+			_lstFull->setRowColor(row, _blue);
+			_leftTopics.push_back("-");
+			_leftFlags.push_back(TTV_NONE);
+			++row;
+
+			std::ostringstream txt;
+			txt << "  ";
+			txt << Unicode::formatFunding(rule->getBuyCost());
+			_lstFull->addRow(1, txt.str().c_str());
+			_lstFull->setRowColor(row, _white);
+			_leftTopics.push_back("-");
+			_leftFlags.push_back(TTV_NONE);
+			++row;
+		}
 	}
 }
 


### PR DESCRIPTION
A small addition which allows you to see the item price in the TTV. The same code as for the manufacturing price in the TTV.

![image](https://user-images.githubusercontent.com/20323032/147552166-8fdf84b1-fd84-4cda-9f81-5ab710fcf81b.png)
