### PR TITLE
check for allowLanding before showing craft preview button

### DIFF
--- a/src/Basescape/CraftSoldiersState.cpp
+++ b/src/Basescape/CraftSoldiersState.cpp
@@ -38,6 +38,7 @@
 #include "SoldierInfoState.h"
 #include "../Mod/Armor.h"
 #include "../Mod/RuleInterface.h"
+#include "../Mod/RuleCraft.h"
 #include "../Engine/Unicode.h"
 #include "../Battlescape/BattlescapeGenerator.h"
 #include "../Battlescape/BriefingState.h"
@@ -55,11 +56,12 @@ namespace OpenXcom
 CraftSoldiersState::CraftSoldiersState(Base *base, size_t craft)
 		:  _base(base), _craft(craft), _otherCraftColor(0), _origSoldierOrder(*_base->getSoldiers()), _dynGetter(NULL)
 {
-	bool isNewBattle = _game->getSavedGame()->getMonthsPassed() == -1;
+	Craft *c = _base->getCrafts()->at(_craft);
+	bool hidePreview = _game->getSavedGame()->getMonthsPassed() == -1 || !c->getRules()->getAllowLanding();
 
 	// Create objects
 	_window = new Window(this, 320, 200, 0, 0);
-	_btnOk = new TextButton(isNewBattle ? 148 : 30, 16, isNewBattle ? 164 : 274, 176);
+	_btnOk = new TextButton(hidePreview ? 148 : 30, 16, hidePreview ? 164 : 274, 176);
 	_btnPreview = new TextButton(102, 16, 164, 176);
 	_txtTitle = new Text(300, 17, 16, 7);
 	_txtName = new Text(114, 9, 16, 32);
@@ -99,11 +101,10 @@ CraftSoldiersState::CraftSoldiersState(Base *base, size_t craft)
 	_btnOk->onKeyboardPress((ActionHandler)&CraftSoldiersState::btnDeassignCraftSoldiersClick, Options::keyRemoveSoldiersFromCraft);
 
 	_btnPreview->setText(tr("STR_CRAFT_DEPLOYMENT_PREVIEW"));
-	_btnPreview->setVisible(!isNewBattle);
+	_btnPreview->setVisible(!hidePreview);
 	_btnPreview->onMouseClick((ActionHandler)&CraftSoldiersState::btnPreviewClick);
 
 	_txtTitle->setBig();
-	Craft *c = _base->getCrafts()->at(_craft);
 	_txtTitle->setText(tr("STR_SELECT_SQUAD_FOR_CRAFT").arg(c->getName(_game->getLanguage())));
 
 	_txtName->setText(tr("STR_NAME_UC"));


### PR DESCRIPTION
AFAIK, some mods do have pilots, but were not meant to have any battlescape, so they indicate it with allowLanding. I would suggest adding extra check for that before showing preview button

