### PR TITLE
Fix a few GCC 10.x warnings

### DIFF
--- a/src/Basescape/SellState.cpp
+++ b/src/Basescape/SellState.cpp
@@ -587,7 +587,7 @@ void SellState::btnOkClick(Action *)
 		}
 	};
 
-	auto cleanUpCraft = [&](Craft* craft, const RuleItem* rule, int toRemove) -> int
+	auto cleanUpCraft = [&](Craft* craft2, const RuleItem* rule, int toRemove) -> int
 	{
 		struct S
 		{
@@ -617,7 +617,7 @@ void SellState::btnOkClick(Action *)
 			}
 		};
 
-		for (auto*& w :* craft->getWeapons())
+		for (auto*& w :* craft2->getWeapons())
 		{
 			if (w != nullptr)
 			{
@@ -637,7 +637,7 @@ void SellState::btnOkClick(Action *)
 		}
 
 		Collections::deleteIf(
-			*craft->getVehicles(),
+			*craft2->getVehicles(),
 			[&](Vehicle* v)
 			{
 				auto clipType = v->getRules()->getVehicleClipAmmo();

--- a/src/Battlescape/SkillMenuState.h
+++ b/src/Battlescape/SkillMenuState.h
@@ -41,7 +41,7 @@ public:
 	/// Cleans up the Skill Menu state.
 	~SkillMenuState();
 	/// Handler for clicking a skill menu item.
-	void btnActionMenuItemClick(Action *action);
+	void btnActionMenuItemClick(Action *action) override;
 };
 
 }

--- a/src/Engine/Script.cpp
+++ b/src/Engine/Script.cpp
@@ -3139,7 +3139,7 @@ void ScriptParserBase::logScriptMetadata(bool haveEvents, const std::string& gro
 ScriptParserEventsBase::ScriptParserEventsBase(ScriptGlobal* shared, const std::string& name) : ScriptParserBase(shared, name)
 {
 	_events.reserve(EventsMax);
-	_eventsData.push_back({ 0, {} });
+	_eventsData.push_back({ 0, {}, {} });
 }
 
 /**

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -534,10 +534,10 @@ bool SoldierDiary::manageCommendations(Mod *mod, std::vector<MissionStatistics*>
 							else if ((*j).first == "killsWithCriteriaCareer")
 							{
 								currentTotalCounters = 0;
-								for (std::size_t i = 0; i < currentBlockCounters.size(); i++)
+								for (std::size_t i2 = 0; i2 < currentBlockCounters.size(); i2++)
 								{
-									currentBlockCounters[i] += referenceBlockCounters[i];
-									currentTotalCounters += std::max(currentBlockCounters[i], 0);
+									currentBlockCounters[i2] += referenceBlockCounters[i2];
+									currentTotalCounters += std::max(currentBlockCounters[i2], 0);
 								}
 							}
 						}


### PR DESCRIPTION
Fix these warnings:
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Basescape/SellState.cpp:590:33: warning: declaration of ‘craft’ shadows a previous local [-Wshadow]
  590 |  auto cleanUpCraft = [&](Craft* craft, const RuleItem* rule, int toRemove) -> int
      |                          ~~~~~~~^~~~~
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Basescape/SellState.cpp:573:9: note: shadowed declaration is here
  573 |  Craft *craft;
      |         ^~~~~

In file included from /home/kca/saveme/git/MeridianOXC/OpenXcom/src/Battlescape/BattlescapeState.cpp:29:
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Battlescape/SkillMenuState.h:44:7: warning: ‘virtual void OpenXcom::SkillMenuState::btnActionMenuItemClick(OpenXcom::Action*)’ can be marked override [-Wsuggest-override]
   44 |  void btnActionMenuItemClick(Action *action);
      |       ^~~~~~~~~~~~~~~~~~~~~~

/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Engine/Script.cpp: In constructor ‘OpenXcom::ScriptParserEventsBase::ScriptParserEventsBase(OpenXcom::ScriptGlobal*, const string&)’:
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Engine/Script.cpp:3142:33: warning: missing initializer for member ‘OpenXcom::ScriptParserEventsBase::EventData::script’ [-Wmissing-field-initializers]
 3142 |  _eventsData.push_back({ 0, {} });
      |                                 ^

/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Savegame/SoldierDiary.cpp: In member function ‘bool OpenXcom::SoldierDiary::manageCommendations(OpenXcom::Mod*, std::vector<OpenXcom::MissionStatistics*>*)’:
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Savegame/SoldierDiary.cpp:537:26: warning: declaration of ‘i’ shadows a previous local [-Wshadow]
  537 |         for (std::size_t i = 0; i < currentBlockCounters.size(); i++)
      |                          ^
/home/kca/saveme/git/MeridianOXC/OpenXcom/src/Savegame/SoldierDiary.cpp:282:66: note: shadowed declaration is here
  282 |  for (std::map<std::string, RuleCommendations *>::const_iterator i = commendationsList.begin(); i != commendationsList.end(); )
      |                                                                  ^

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->