### PR TITLE
PromotionsState screen now includes in-transit soldiers if promoted

### DIFF
--- a/src/Battlescape/PromotionsState.cpp
+++ b/src/Battlescape/PromotionsState.cpp
@@ -27,6 +27,7 @@
 #include "../Savegame/SavedGame.h"
 #include "../Savegame/Base.h"
 #include "../Savegame/Soldier.h"
+#include "../Savegame/Transfer.h"
 #include "../Engine/Options.h"
 
 namespace OpenXcom
@@ -90,6 +91,16 @@ PromotionsState::PromotionsState()
 			if ((*j)->isPromoted())
 			{
 				_lstSoldiers->addRow(3, (*j)->getName().c_str(), tr((*j)->getRankString()).c_str(), (*i)->getName().c_str());
+			}
+		}
+		for (std::vector<Transfer*>::iterator j = (*i)->getTransfers()->begin(); j != (*i)->getTransfers()->end(); ++j)
+		{
+			if ((*j)->getType() == TRANSFER_SOLDIER)
+			{
+				if ((*j)->getSoldier()->isPromoted())
+				{
+					_lstSoldiers->addRow(3, (*j)->getSoldier()->getName().c_str(), tr((*j)->getSoldier()->getRankString()).c_str(), (*i)->getName().c_str());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously, soldiers that are currently being transferred could be promoted, but they would not appear on the recent promotions screen. This could result in a completely empty promotion screen at the end of a mission.

This patch looks for recently promoted soldiers that are currently being transferred in the same way they are looked for when promotions are being granted.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->