### PR TITLE
Macro Log renamed to XComLog.

### DIFF
--- a/src/Battlescape/AIModule.cpp
+++ b/src/Battlescape/AIModule.cpp
@@ -142,7 +142,7 @@ void AIModule::dont_think(BattleAction *action)
 
 	if (_traceAI)
 	{
-		Log(LOG_INFO) << "LEEROY: Unit " << _unit->getId() << " of type " << _unit->getType() << " is Leeroy...";
+		XComLog(LOG_INFO) << "LEEROY: Unit " << _unit->getId() << " of type " << _unit->getType() << " is Leeroy...";
 	}
 	if (action->weapon)
 	{
@@ -163,13 +163,13 @@ void AIModule::dont_think(BattleAction *action)
 	int visibleEnemiesToAttack = selectNearestTargetLeeroy(canRun);
 	if (_traceAI)
 	{
-		Log(LOG_INFO) << "LEEROY: visibleEnemiesToAttack: " << visibleEnemiesToAttack << " _melee: " << _melee << (canRun ? " run" : "");
+		XComLog(LOG_INFO) << "LEEROY: visibleEnemiesToAttack: " << visibleEnemiesToAttack << " _melee: " << _melee << (canRun ? " run" : "");
 	}
 	if ((visibleEnemiesToAttack > 0) && _melee)
 	{
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "LEEROY: LEEROYIN' at someone!";
+			XComLog(LOG_INFO) << "LEEROY: LEEROYIN' at someone!";
 		}
 		meleeActionLeeroy(canRun);
 		action->type = _attackAction.type;
@@ -183,7 +183,7 @@ void AIModule::dont_think(BattleAction *action)
 	{
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "LEEROY: No one to LEEROY!, patrolling...";
+			XComLog(LOG_INFO) << "LEEROY: No one to LEEROY!, patrolling...";
 		}
 		setupPatrol();
 		_unit->setCharging(0);
@@ -227,11 +227,11 @@ void AIModule::think(BattleAction *action)
 	{
 		if (_unit->getFaction() == FACTION_HOSTILE)
 		{
-			Log(LOG_INFO) << "Unit has " << _visibleEnemies << "/" << _knownEnemies << " known enemies visible, " << _spottingEnemies << " of whom are spotting him. ";
+			XComLog(LOG_INFO) << "Unit has " << _visibleEnemies << "/" << _knownEnemies << " known enemies visible, " << _spottingEnemies << " of whom are spotting him. ";
 		}
 		else
 		{
-			Log(LOG_INFO) << "Civilian Unit has " << _visibleEnemies << " enemies visible, " << _spottingEnemies << " of whom are spotting him. ";
+			XComLog(LOG_INFO) << "Civilian Unit has " << _visibleEnemies << " enemies visible, " << _spottingEnemies << " of whom are spotting him. ";
 		}
 		std::string AIMode;
 		switch (_AIMode)
@@ -249,7 +249,7 @@ void AIModule::think(BattleAction *action)
 			AIMode = "Escape";
 			break;
 		}
-		Log(LOG_INFO) << "Currently using " << AIMode << " behaviour";
+		XComLog(LOG_INFO) << "Currently using " << AIMode << " behaviour";
 	}
 
 	if (_unit->isLeeroyJenkins())
@@ -384,7 +384,7 @@ void AIModule::think(BattleAction *action)
 				AIMode = "Escape";
 				break;
 			}
-			Log(LOG_INFO) << "Re-Evaluated, now using " << AIMode << " behaviour";
+			XComLog(LOG_INFO) << "Re-Evaluated, now using " << AIMode << " behaviour";
 		}
 	}
 
@@ -524,7 +524,7 @@ void AIModule::setupPatrol()
 	{
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "Patrol destination reached!";
+			XComLog(LOG_INFO) << "Patrol destination reached!";
 		}
 		// destination reached
 		// head off to next patrol node
@@ -782,14 +782,14 @@ void AIModule::setupAmbush()
 			}
 			if (_traceAI)
 			{
-				Log(LOG_INFO) << "Ambush estimation will move to " << _ambushAction.target;
+				XComLog(LOG_INFO) << "Ambush estimation will move to " << _ambushAction.target;
 			}
 			return;
 		}
 	}
 	if (_traceAI)
 	{
-		Log(LOG_INFO) << "Ambush estimation failed";
+		XComLog(LOG_INFO) << "Ambush estimation failed";
 	}
 }
 
@@ -857,11 +857,11 @@ void AIModule::setupAttack()
 		{
 			if (_attackAction.type != BA_WALK)
 			{
-				Log(LOG_INFO) << "Attack estimation desires to shoot at " << _attackAction.target;
+				XComLog(LOG_INFO) << "Attack estimation desires to shoot at " << _attackAction.target;
 			}
 			else
 			{
-				Log(LOG_INFO) << "Attack estimation desires to move to " << _attackAction.target;
+				XComLog(LOG_INFO) << "Attack estimation desires to move to " << _attackAction.target;
 			}
 		}
 		return;
@@ -873,14 +873,14 @@ void AIModule::setupAttack()
 		{
 			if (_traceAI)
 			{
-				Log(LOG_INFO) << "Attack estimation desires to move to " << _attackAction.target;
+				XComLog(LOG_INFO) << "Attack estimation desires to move to " << _attackAction.target;
 			}
 			return;
 		}
 	}
 	if (_traceAI)
 	{
-		Log(LOG_INFO) << "Attack estimation failed";
+		XComLog(LOG_INFO) << "Attack estimation failed";
 	}
 }
 
@@ -965,7 +965,7 @@ void AIModule::setupEscape()
 			{
 				if (_traceAI)
 				{
-					Log(LOG_INFO) << "best score after systematic search was: " << bestTileScore;
+					XComLog(LOG_INFO) << "best score after systematic search was: " << bestTileScore;
 				}
 			}
 
@@ -1073,7 +1073,7 @@ void AIModule::setupEscape()
 	{
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "Escape estimation failed.";
+			XComLog(LOG_INFO) << "Escape estimation failed.";
 		}
 		_escapeAction.type = BA_RETHINK; // do something, just don't look dumbstruck :P
 		return;
@@ -1082,7 +1082,7 @@ void AIModule::setupEscape()
 	{
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "Escape estimation completed after " << tries << " tries, " << Position::distance2d(_unit->getPosition(), bestTile) << " squares or so away.";
+			XComLog(LOG_INFO) << "Escape estimation completed after " << tries << " tries, " << Position::distance2d(_unit->getPosition(), bestTile) << " squares or so away.";
 		}
 		_escapeAction.type = BA_WALK;
 	}
@@ -1890,13 +1890,13 @@ bool AIModule::findFirePoint()
 		_attackAction.type = BA_WALK;
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "Firepoint found at " << _attackAction.target << ", with a score of: " << bestScore;
+			XComLog(LOG_INFO) << "Firepoint found at " << _attackAction.target << ", with a score of: " << bestScore;
 		}
 		return true;
 	}
 	if (_traceAI)
 	{
-		Log(LOG_INFO) << "Firepoint failed, best estimation was: " << _attackAction.target << ", with a score of: " << bestScore;
+		XComLog(LOG_INFO) << "Firepoint failed, best estimation was: " << _attackAction.target << ", with a score of: " << bestScore;
 	}
 
 	return false;
@@ -2060,8 +2060,8 @@ void AIModule::meleeAction()
 			meleeAttack();
 		}
 	}
-	if (_traceAI && _aggroTarget) { Log(LOG_INFO) << "AIModule::meleeAction:" << " [target]: " << (_aggroTarget->getId()) << " at: "  << _attackAction.target; }
-	if (_traceAI && _aggroTarget) { Log(LOG_INFO) << "CHARGE!"; }
+	if (_traceAI && _aggroTarget) { XComLog(LOG_INFO) << "AIModule::meleeAction:" << " [target]: " << (_aggroTarget->getId()) << " at: "  << _attackAction.target; }
+	if (_traceAI && _aggroTarget) { XComLog(LOG_INFO) << "CHARGE!"; }
 }
 
 /**
@@ -2107,8 +2107,8 @@ void AIModule::meleeActionLeeroy(bool canRun)
 			meleeAttack();
 		}
 	}
-	if (_traceAI && _aggroTarget) { Log(LOG_INFO) << "AIModule::meleeAction:" << " [target]: " << (_aggroTarget->getId()) << " at: " << _attackAction.target; }
-	if (_traceAI && _aggroTarget) { Log(LOG_INFO) << "CHARGE!"; }
+	if (_traceAI && _aggroTarget) { XComLog(LOG_INFO) << "AIModule::meleeAction:" << " [target]: " << (_aggroTarget->getId()) << " at: " << _attackAction.target; }
+	if (_traceAI && _aggroTarget) { XComLog(LOG_INFO) << "CHARGE!"; }
 }
 
 /**
@@ -2202,17 +2202,17 @@ void AIModule::wayPointAction()
  */
 bool AIModule::sniperAction()
 {
-	if (_traceAI) { Log(LOG_INFO) << "Attempting sniper action..."; }
+	if (_traceAI) { XComLog(LOG_INFO) << "Attempting sniper action..."; }
 
 	if (selectSpottedUnitForSniper())
 	{
 		_visibleEnemies = std::max(_visibleEnemies, 1); // Make sure we count at least our target as visible, otherwise we might not shoot!
 
-		if (_traceAI) { Log(LOG_INFO) << "Target for sniper found at (" << _attackAction.target.x << "," << _attackAction.target.y << "," << _attackAction.target.z << ")."; }
+		if (_traceAI) { XComLog(LOG_INFO) << "Target for sniper found at (" << _attackAction.target.x << "," << _attackAction.target.y << "," << _attackAction.target.z << ")."; }
 		return true;
 	}
 
-	if (_traceAI) { Log(LOG_INFO) << "No valid target found or not enough TUs for sniper action."; }
+	if (_traceAI) { XComLog(LOG_INFO) << "No valid target found or not enough TUs for sniper action."; }
 	return false;
 }
 
@@ -2395,7 +2395,7 @@ void AIModule::extendedFireModeChoice(BattleActionCost& costAuto, BattleActionCo
 
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "Evaluate option " << (int)i << ", score = " << newScore;
+			XComLog(LOG_INFO) << "Evaluate option " << (int)i << ", score = " << newScore;
 		}
 	}
 
@@ -2640,7 +2640,7 @@ bool AIModule::psiAction()
 
 		if (_traceAI)
 		{
-			Log(LOG_INFO) << "making a psionic attack this turn";
+			XComLog(LOG_INFO) << "making a psionic attack this turn";
 		}
 
 		_psiAction.type = typeToAttack;
@@ -2659,7 +2659,7 @@ void AIModule::meleeAttack()
 	_unit->lookAt(_aggroTarget->getPosition() + Position(_unit->getArmor()->getSize()-1, _unit->getArmor()->getSize()-1, 0), false);
 	while (_unit->getStatus() == STATUS_TURNING)
 		_unit->turn();
-	if (_traceAI) { Log(LOG_INFO) << "Attack unit: " << _aggroTarget->getId(); }
+	if (_traceAI) { XComLog(LOG_INFO) << "Attack unit: " << _aggroTarget->getId(); }
 	_attackAction.target = _aggroTarget->getPosition();
 	_attackAction.type = BA_HIT;
 	_attackAction.weapon = _unit->getUtilityWeapon(BT_MELEE);

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -335,7 +335,7 @@ void BattlescapeGame::handleAI(BattleUnit *unit)
 	{
 		_playedAggroSound = false;
 		unit->setHiding(false);
-		if (Options::traceAI) { Log(LOG_INFO) << "#" << unit->getId() << "--" << unit->getType(); }
+		if (Options::traceAI) { XComLog(LOG_INFO) << "#" << unit->getId() << "--" << unit->getType(); }
 	}
 
 	BattleAction action;
@@ -1190,7 +1190,7 @@ void BattlescapeGame::popState()
 {
 	if (Options::traceAI)
 	{
-		Log(LOG_INFO) << "BattlescapeGame::popState() #" << _AIActionCounter << " with " << (_save->getSelectedUnit() ? _save->getSelectedUnit()->getTimeUnits() : -9999) << " TU";
+		XComLog(LOG_INFO) << "BattlescapeGame::popState() #" << _AIActionCounter << " with " << (_save->getSelectedUnit() ? _save->getSelectedUnit()->getTimeUnits() : -9999) << " TU";
 	}
 	bool actionFailed = false;
 

--- a/src/Battlescape/BattlescapeGenerator.cpp
+++ b/src/Battlescape/BattlescapeGenerator.cpp
@@ -743,7 +743,7 @@ void BattlescapeGenerator::run()
 			}
 			else // trouble: no texture and no deployment terrain, most likely scenario is a UFO landing on water: use the first available terrain
 			{
-				Log(LOG_WARNING) << "Trouble: no texture and no deployment terrain, most likely scenario is a UFO landing on water: using the first available terrain...";
+				XComLog(LOG_WARNING) << "Trouble: no texture and no deployment terrain, most likely scenario is a UFO landing on water: using the first available terrain...";
 				_terrain = _game->getMod()->getTerrain(_game->getMod()->getTerrainList().front(), true);
 			}
 		}
@@ -2000,8 +2000,8 @@ int BattlescapeGenerator::loadMAP(MapBlock *mapblock, int xoff, int yoff, int zo
 		if (_save->getMissionType() == "STR_BASE_DEFENSE")
 		{
 			// we'll already have gone through _base->isOverlappingOrOverflowing() by the time we hit this, possibly multiple times
-			// let's just throw an exception and tell them to check the log, it'll have all the detail they'll need.
-			throw Exception("Something is wrong with your base, check your log file for additional information.");
+			// let's just throw an exception and tell them to check the XComLog, it'll have all the detail they'll need.
+			throw Exception("Something is wrong with your base, check your XComLog file for additional information.");
 		}
 		throw Exception("Something is wrong in your map definitions, craft/ufo map is too tall?");
 	}
@@ -2191,7 +2191,7 @@ void BattlescapeGenerator::loadRMP(MapBlock *mapblock, int xoff, int yoff, int z
 			// that way, all the connections will still line up properly in the array.
 			node = new Node();
 			node->setDummy(true);
-			Log(LOG_INFO) << "Bad node in RMP file: " << filename << " Node #" << nodesAdded << " is outside map boundaries at X:" << pos_x << " Y:" << pos_y << " Z:" << pos_z << ". Culling Node.";
+			XComLog(LOG_INFO) << "Bad node in RMP file: " << filename << " Node #" << nodesAdded << " is outside map boundaries at X:" << pos_x << " Y:" << pos_y << " Z:" << pos_z << ". Culling Node.";
 			badNodes.push_back(nodesAdded);
 		}
 		_save->getNodes()->push_back(node);
@@ -2209,7 +2209,7 @@ void BattlescapeGenerator::loadRMP(MapBlock *mapblock, int xoff, int yoff, int z
 				{
 					if (*k - nodeOffset == (unsigned)*i)
 					{
-						Log(LOG_INFO) << "RMP file: " << filename << " Node #" << nodeCounter - 1 << " is linked to Node #" << *i << ", which was culled. Terminating Link.";
+						XComLog(LOG_INFO) << "RMP file: " << filename << " Node #" << nodeCounter - 1 << " is linked to Node #" << *i << ", which was culled. Terminating Link.";
 						*k = -1;
 					}
 				}
@@ -2771,7 +2771,7 @@ void BattlescapeGenerator::generateMap(const std::vector<MapScript*> *script, co
 						{
 							if (command->canBeSkipped())
 							{
-								Log(LOG_INFO) << "Map generator encountered a recoverable problem: UFO (MapBlock: " << ufoMap->getName() << ") could not be placed on the map. Command skipped.";
+								XComLog(LOG_INFO) << "Map generator encountered a recoverable problem: UFO (MapBlock: " << ufoMap->getName() << ") could not be placed on the map. Command skipped.";
 								break;
 							}
 							else
@@ -3160,14 +3160,14 @@ void BattlescapeGenerator::generateBaseMap()
 						|| j->y < 0 || j->y / 10 > (*i)->getRules()->getSize()
 						|| j->z < 0 || j->z > _mapsize_z)
 					{
-						Log(LOG_ERROR) << "Tile position " << (*j) << " is outside the facility " << (*i)->getRules()->getType() << ", skipping placing items there.";
+						XComLog(LOG_ERROR) << "Tile position " << (*j) << " is outside the facility " << (*i)->getRules()->getType() << ", skipping placing items there.";
 						continue;
 					}
 
 					Position tilePos = Position((x * 10) + j->x, (y * 10) + j->y, j->z);
 					if (!_save->getTile(tilePos))
 					{
-						Log(LOG_ERROR) << "Tile position " << tilePos << ", from the facility " << (*i)->getRules()->getType() << ", is outside the map; skipping placing items there.";
+						XComLog(LOG_ERROR) << "Tile position " << tilePos << ", from the facility " << (*i)->getRules()->getType() << ", is outside the map; skipping placing items there.";
 						continue;
 					}
 
@@ -3234,7 +3234,7 @@ bool BattlescapeGenerator::populateVerticalLevels(MapScript *command)
 			}
 			else
 			{
-				Log(LOG_WARNING) << "Map generator encountered an error: a 'ground' verticalLevel can only be used once per command.";
+				XComLog(LOG_WARNING) << "Map generator encountered an error: a 'ground' verticalLevel can only be used once per command.";
 			}
 		}
 	}
@@ -3254,11 +3254,11 @@ bool BattlescapeGenerator::populateVerticalLevels(MapScript *command)
 				}
 				else if (command->getType() == MSC_ADDCRAFT || command->getType() == MSC_ADDUFO)
 				{
-					Log(LOG_WARNING) << "Map generator encountered an error: a 'craft' verticalLevel can only be used once per command.";
+					XComLog(LOG_WARNING) << "Map generator encountered an error: a 'craft' verticalLevel can only be used once per command.";
 				}
 				else
 				{
-					Log(LOG_WARNING) << "Map generator encountered an error: a 'craft' verticalLevel is only valid for addCraft and addUFO commands, skipping level.";
+					XComLog(LOG_WARNING) << "Map generator encountered an error: a 'craft' verticalLevel is only valid for addCraft and addUFO commands, skipping level.";
 				}
 
 				break;
@@ -3271,11 +3271,11 @@ bool BattlescapeGenerator::populateVerticalLevels(MapScript *command)
 				}
 				else if (command->getType() == MSC_ADDLINE)
 				{
-					Log(LOG_WARNING) << "Map generator encountered an error: a 'line' verticalLevel can only be used once per command.";
+					XComLog(LOG_WARNING) << "Map generator encountered an error: a 'line' verticalLevel can only be used once per command.";
 				}
 				else
 				{
-					Log(LOG_WARNING) << "Map generator encountered an error: a 'line' verticalLevel is only valid for addLine commands, skipping level.";
+					XComLog(LOG_WARNING) << "Map generator encountered an error: a 'line' verticalLevel is only valid for addLine commands, skipping level.";
 				}
 
 				break;
@@ -3306,7 +3306,7 @@ bool BattlescapeGenerator::populateVerticalLevels(MapScript *command)
 			}
 			else
 			{
-				Log(LOG_WARNING) << "Map generator encountered an error: a 'ceiling' verticalLevel can only be used once per command.";
+				XComLog(LOG_WARNING) << "Map generator encountered an error: a 'ceiling' verticalLevel can only be used once per command.";
 			}
 		}
 	}
@@ -3337,8 +3337,8 @@ RuleTerrain* BattlescapeGenerator::pickTerrain(std::string terrainName)
 		terrain = _game->getMod()->getTerrain(terrainName);
 		if (!terrain)
 		{
-			// make sure we get a terrain, and put an error in the log, continuing with generation
-			Log(LOG_ERROR) << "Map generator could not find alternate terrain " << terrainName << ", proceeding with terrain from alienDeployments or Geoscape texture.";
+			// make sure we get a terrain, and put an error in the XComLog, continuing with generation
+			XComLog(LOG_ERROR) << "Map generator could not find alternate terrain " << terrainName << ", proceeding with terrain from alienDeployments or Geoscape texture.";
 			terrain = _terrain;
 		}
 	}
@@ -3385,8 +3385,8 @@ void BattlescapeGenerator::loadVerticalLevels(MapScript *command, bool repopulat
 		}
 		else if (zLevelsLeft > _mapsize_z)
 		{
-			Log(LOG_WARNING) << "Battlescape Generator has encountered an error: a mapscript command has height " << command->getSizeZ() << " while the map is only " << _mapsize_z << " tiles tall.";
-			Log(LOG_WARNING) << "Reducing command size to map height";
+			XComLog(LOG_WARNING) << "Battlescape Generator has encountered an error: a mapscript command has height " << command->getSizeZ() << " while the map is only " << _mapsize_z << " tiles tall.";
+			XComLog(LOG_WARNING) << "Reducing command size to map height";
 
 			zLevelsLeft = _mapsize_z;
 		}
@@ -3409,7 +3409,7 @@ void BattlescapeGenerator::loadVerticalLevels(MapScript *command, bool repopulat
 			}
 			else
 			{
-				Log(LOG_WARNING) << "Battlescape Generator has encountered an error: an addLine mapscript command has vertical levels but a mapblock for the ground level could not be loaded.";
+				XComLog(LOG_WARNING) << "Battlescape Generator has encountered an error: an addLine mapscript command has vertical levels but a mapblock for the ground level could not be loaded.";
 			}
 		}
 
@@ -3453,7 +3453,7 @@ void BattlescapeGenerator::loadVerticalLevels(MapScript *command, bool repopulat
 		int tries = 0;
 		int maxTries = 20;
 
-		// If a addLine command for some reason can't fit in the line itself, note this in the log for the modder to fix
+		// If a addLine command for some reason can't fit in the line itself, note this in the XComLog for the modder to fix
 		bool lineAdded = false;
 
 		// Loop over the "filling" levels to build up the maps placed at this location
@@ -3561,7 +3561,7 @@ void BattlescapeGenerator::loadVerticalLevels(MapScript *command, bool repopulat
 
 		if (command->getType() == MSC_ADDLINE && !lineAdded)
 		{
-			Log(LOG_WARNING) << "Battlescape Generator has encountered an error: a addLine mapscript command with vertical levels did not load the line itself. The modder may want to reduce the number of levels before the line.";
+			XComLog(LOG_WARNING) << "Battlescape Generator has encountered an error: a addLine mapscript command with vertical levels did not load the line itself. The modder may want to reduce the number of levels before the line.";
 		}
 
 		// Now we can finally load the ceiling level

--- a/src/Battlescape/BattlescapeState.cpp
+++ b/src/Battlescape/BattlescapeState.cpp
@@ -2603,7 +2603,7 @@ inline void BattlescapeState::handle(Action *action)
 				{
 					_game->pushState(new BriefingState(0, 0, true));
 				}
-				// "ctrl-h" - show hit log
+				// "ctrl-h" - show hit XComLog
 				else if (key == SDLK_h && ctrlPressed)
 				{
 					if (_save->getSide() == FACTION_PLAYER)
@@ -2619,7 +2619,7 @@ inline void BattlescapeState::handle(Action *action)
 						}
 						else
 						{
-							// hit log
+							// hit XComLog
 							std::string hitLogText = _save->getHitLog()->getHitLogText();
 							if (!hitLogText.empty())
 								_game->pushState(new InfoboxState(hitLogText));
@@ -2645,7 +2645,7 @@ inline void BattlescapeState::handle(Action *action)
 						Options::oxceEnableUnitResponseSounds = !Options::oxceEnableUnitResponseSounds;
 					}
 				}
-				// "ctrl-e" - experience log
+				// "ctrl-e" - experience XComLog
 				else if (key == SDLK_e && ctrlPressed)
 				{
 					std::ostringstream ss;
@@ -2860,7 +2860,7 @@ void BattlescapeState::saveAIMap()
 	int h = _save->getMapSizeY();
 
 	SDL_Surface *img = SDL_AllocSurface(0, w * 8, h * 8, 24, 0xff, 0xff00, 0xff0000, 0);
-	Log(LOG_INFO) << "unit = " << unit->getId();
+	XComLog(LOG_INFO) << "unit = " << unit->getId();
 	memset(img->pixels, 0, img->pitch * img->h);
 
 	Position tilePos(unit->getPosition());
@@ -2962,13 +2962,13 @@ void BattlescapeState::saveAIMap()
 	unsigned error = lodepng::encode(out, (const unsigned char*)img->pixels, img->w, img->h, LCT_RGB);
 	if (error)
 	{
-		Log(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
+		XComLog(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
 	}
 
 	SDL_FreeSurface(img);
 
 	CrossPlatform::writeFile(ss.str(), out);
-	Log(LOG_INFO) << "saveAIMap() completed in " << SDL_GetTicks() - start << "ms.";
+	XComLog(LOG_INFO) << "saveAIMap() completed in " << SDL_GetTicks() - start << "ms.";
 }
 
 /**
@@ -3091,7 +3091,7 @@ void BattlescapeState::saveVoxelView()
 	unsigned error = lodepng::encode(out, image, 512, 512, LCT_RGB);
 	if (error)
 	{
-		Log(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
+		XComLog(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
 	}
 	CrossPlatform::writeFile(ss.str(), out);
 	return;
@@ -3161,7 +3161,7 @@ void BattlescapeState::saveVoxelMap()
 		unsigned error = lodepng::encode(out, image, _save->getMapSizeX()*16, _save->getMapSizeY()*16, LCT_RGB);
 		if (error)
 		{
-			Log(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
+			XComLog(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
 		}
 		CrossPlatform::writeFile(ss.str(), out);
 	}

--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -53,7 +53,8 @@
 #include "../Interface/Text.h"
 #include "../fmath.h"
 #include "../fallthrough.h"
-
+#include "pbrt/pbrt.h"
+#include "pbrt/options.h"
 
 /*
   1) Map origin is top corner.
@@ -1691,6 +1692,10 @@ void Map::drawTerrain(Surface *surface)
 			}
 		}
 	}
+
+	struct pbrt::PBRTOptions blabla;
+	pbrt::InitPBRT( blabla );
+	pbrt::CleanupPBRT();
 
 	surface->unlock();
 }

--- a/src/Battlescape/Map.h
+++ b/src/Battlescape/Map.h
@@ -24,6 +24,7 @@
 #include "Position.h"
 #include "Particle.h"
 #include <vector>
+#include "pbrt/pbrt.h"
 
 namespace OpenXcom
 {

--- a/src/Battlescape/ProjectileFlyBState.cpp
+++ b/src/Battlescape/ProjectileFlyBState.cpp
@@ -578,7 +578,7 @@ bool ProjectileFlyBState::createNewProjectile()
 	if (_action.type != BA_THROW && _action.type != BA_LAUNCH)
 		_unit->getStatistics()->shotsFiredCounter++;
 
-	// hit log - new bullet
+	// hit XComLog - new bullet
 	if (_action.actor)
 	{
 		_parent->getSave()->appendToHitLog(HITLOG_NEW_SHOT, _action.actor->getFaction());

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -2372,7 +2372,7 @@ bool TileEngine::hitUnit(BattleActionAttack attack, BattleUnit *target, const Po
 	const int healthDamage = healthOrig - target->getHealth();
 	const int stunDamage = target->getStunlevel() - stunLevelOrig;
 
-	// hit log
+	// hit XComLog
 	if (attack.attacker)
 	{
 		if (healthDamage > 0 || stunDamage > 0)
@@ -4098,7 +4098,7 @@ bool TileEngine::meleeAttack(BattleActionAttack attack, BattleUnit *victim, int 
 	}
 	if (attack.type != BA_CQB)
 	{
-		// hit log - new melee attack
+		// hit XComLog - new melee attack
 		_save->appendToHitLog(HITLOG_NEW_SHOT, attack.attacker->getFaction());
 
 		// to allow melee reactions when attacked from any side, not just from the front

--- a/src/Battlescape/TurnDiaryState.h
+++ b/src/Battlescape/TurnDiaryState.h
@@ -29,7 +29,7 @@ class TextList;
 class HitLog;
 
 /**
- * Turn Diary window that displays the hit log history (for the current turn).
+ * Turn Diary window that displays the hit XComLog history (for the current turn).
  */
 class TurnDiaryState : public State
 {

--- a/src/Battlescape/UnitWalkBState.cpp
+++ b/src/Battlescape/UnitWalkBState.cpp
@@ -66,7 +66,7 @@ void UnitWalkBState::init()
 	_pf = _parent->getPathfinding();
 	_terrain = _parent->getTileEngine();
 	_target = _action.target;
-	if (Options::traceAI) { Log(LOG_INFO) << "Walking from: " << _unit->getPosition() << "," << " to " << _target;}
+	if (Options::traceAI) { XComLog(LOG_INFO) << "Walking from: " << _unit->getPosition() << "," << " to " << _target;}
 	int dir = _pf->getStartDirection();
 	if (!_action.strafe && dir != -1 && dir != _unit->getDirection())
 	{
@@ -245,7 +245,7 @@ void UnitWalkBState::think()
 		// check if we did spot new units
 		if (unitSpotted && !_action.desperate && _unit->getCharging() == 0 && !_falling)
 		{
-			if (Options::traceAI) { Log(LOG_INFO) << "Uh-oh! Company!"; }
+			if (Options::traceAI) { XComLog(LOG_INFO) << "Uh-oh! Company!"; }
 			_unit->setHiding(false); // clearly we're not hidden now
 			postPathProcedures();
 			return;
@@ -429,7 +429,7 @@ void UnitWalkBState::think()
 				_preMovementCost = _preMovementCost * _unit->getTurnCost();
 				_unit->spendTimeUnits(_preMovementCost);
 			}
-			if (Options::traceAI) { Log(LOG_INFO) << "Egads! A turn reveals new units! I must pause!"; }
+			if (Options::traceAI) { XComLog(LOG_INFO) << "Egads! A turn reveals new units! I must pause!"; }
 			_unit->setHiding(false); // not hidden, are we...
 			_pf->abortPath();
 			_unit->abortTurn(); //revert to a standing state.

--- a/src/Engine/Adlib/fmopl.cpp
+++ b/src/Engine/Adlib/fmopl.cpp
@@ -235,7 +235,7 @@ static INT32 amsIncr;
 static INT32 vibIncr;
 static INT32 feedback2;		/* connect for SLOT 2 */
 
-/* log output level */
+/* XComLog output level */
 #define LOG_ERR  3      /* ERROR       */
 #define LOG_WAR  2      /* WARNING     */
 #define LOG_INF  1      /* INFORMATION */
@@ -243,8 +243,8 @@ static INT32 feedback2;		/* connect for SLOT 2 */
 //#define LOG_LEVEL LOG_INF
 #define LOG_LEVEL	LOG_ERR
 
-//#define LOG(n,x) if( (n)>=LOG_LEVEL ) logerror x
-#define LOG(n,x)
+//#define XComLog(n,x) if( (n)>=LOG_LEVEL ) logerror x
+#define XComLog(n,x)
 
 /* --------------------- subroutines  --------------------- */
 
@@ -607,7 +607,7 @@ static void init_timetables( FM_OPL *OPL , int ARRATE , int DRRATE )
 	}
 #if 0
 	for (i = 0;i < 64 ;i++){	/* make for overflow area */
-		LOG(LOG_WAR,("rate %2d , ar %f ms , dr %f ms \n",i,
+		XComLog(LOG_WAR,("rate %2d , ar %f ms , dr %f ms \n",i,
 			((double)(EG_ENT<<ENV_BITS) / OPL->AR_TABLE[i]) * (1000.0 / OPL->rate),
 			((double)(EG_ENT<<ENV_BITS) / OPL->DR_TABLE[i]) * (1000.0 / OPL->rate) ));
 	}
@@ -648,7 +648,7 @@ static int OPLOpenTable( void )
 		rate = ((1<<TL_BITS)-1)/pow(10,EG_STEP*t/20);	/* dB -> voltage */
 		TL_TABLE[       t] =  (int)rate;
 		TL_TABLE[TL_MAX+t] = -TL_TABLE[t];
-/*		LOG(LOG_INF,("TotalLevel(%3d) = %x\n",t,TL_TABLE[t]));*/
+/*		XComLog(LOG_INF,("TotalLevel(%3d) = %x\n",t,TL_TABLE[t]));*/
 	}
 	/* fill volume off area */
 	for ( t = EG_ENT-1; t < TL_MAX ;t++){
@@ -667,7 +667,7 @@ static int OPLOpenTable( void )
 		SIN_TABLE[          s] = SIN_TABLE[SIN_ENT/2-s] = &TL_TABLE[j];
         /* degree 180 - 270    , degree 360 - 270 : minus section */
 		SIN_TABLE[SIN_ENT/2+s] = SIN_TABLE[SIN_ENT  -s] = &TL_TABLE[TL_MAX+j];
-/*		LOG(LOG_INF,("sin(%3d) = %f:%f db\n",s,pom,(double)j * EG_STEP));*/
+/*		XComLog(LOG_INF,("sin(%3d) = %f:%f db\n",s,pom,(double)j * EG_STEP));*/
 	}
 	for (s = 0;s < SIN_ENT;s++)
 	{
@@ -702,7 +702,7 @@ static int OPLOpenTable( void )
 		pom = (double)VIB_RATE*0.06*sin(2*PI*i/VIB_ENT); /* +-100sect step */
 		VIB_TABLE[i]         = VIB_RATE + (pom*0.07); /* +- 7cent */
 		VIB_TABLE[VIB_ENT+i] = VIB_RATE + (pom*0.14); /* +-14cent */
-		/* LOG(LOG_INF,("vib %d=%d\n",i,VIB_TABLE[VIB_ENT+i])); */
+		/* XComLog(LOG_INF,("vib %d=%d\n",i,VIB_TABLE[VIB_ENT+i])); */
 	}
 	return 1;
 }
@@ -824,7 +824,7 @@ static void OPLWriteReg(FM_OPL *OPL, int r, int v)
 				if(OPL->keyboardhandler_w)
 					OPL->keyboardhandler_w(OPL->keyboard_param,v);
 				else
-					LOG(LOG_WAR,("OPL:write unmapped KEYBOARD port\n"));
+					XComLog(LOG_WAR,("OPL:write unmapped KEYBOARD port\n"));
 			}
 			return;
 		case 0x07:	/* DELTA-T control : START,REC,MEMDATA,REPT,SPOFF,x,x,RST */
@@ -1005,7 +1005,7 @@ static void OPLWriteReg(FM_OPL *OPL, int r, int v)
 		CH = &OPL->P_CH[slot/2];
 		if(OPL->wavesel)
 		{
-			/* LOG(LOG_INF,("OPL SLOT %d wave select %d\n",slot,v&3)); */
+			/* XComLog(LOG_INF,("OPL SLOT %d wave select %d\n",slot,v&3)); */
 			CH->SLOT[slot&1].wavetable = &SIN_TABLE[(v&0x03)*SIN_ENT];
 		}
 		return;
@@ -1356,7 +1356,7 @@ unsigned char OPLRead(FM_OPL *OPL,int a)
 			}
 			else
 			{
-				LOG(LOG_WAR,("OPL:read unmapped KEYBOARD port\n"));
+				XComLog(LOG_WAR,("OPL:read unmapped KEYBOARD port\n"));
 			}
 		}
 		return 0;
@@ -1373,7 +1373,7 @@ unsigned char OPLRead(FM_OPL *OPL,int a)
 			}
 			else
 			{
-				LOG(LOG_WAR,("OPL:read unmapped I/O port\n"));
+				XComLog(LOG_WAR,("OPL:read unmapped I/O port\n"));
 			}
 		}
 		return 0;

--- a/src/Engine/CatFile.cpp
+++ b/src/Engine/CatFile.cpp
@@ -75,7 +75,7 @@ CatFile::CatFile(const std::string& filename) : _data(0), _items()
 	SDL_RWseek(rwops, 0, RW_SEEK_SET);  // and again reset the rwops pointer back
 
 	if (offset0 >= filesize) {
-		Log(LOG_WARNING) << "Catfile(" << filename << "): first offset " << offset0 << ">= file size " << filesize << ", not parsing.";
+		XComLog(LOG_WARNING) << "Catfile(" << filename << "): first offset " << offset0 << ">= file size " << filesize << ", not parsing.";
 		SDL_RWclose(rwops);
 		return;
 	}
@@ -84,7 +84,7 @@ CatFile::CatFile(const std::string& filename) : _data(0), _items()
 		SDL_ReadLE32(rwops); // ignore size;
 		// reject bad data
 		if (offset >= filesize) {
-			Log(LOG_WARNING) << "Catfile("<<filename<<"): item "<<i<<" outside of the file: offset="<<offset<<" "<<" filesize="<<filesize;
+			XComLog(LOG_WARNING) << "Catfile("<<filename<<"): item "<<i<<" outside of the file: offset="<<offset<<" "<<" filesize="<<filesize;
 			continue;
 		}
 		_items.push_back(std::make_tuple(_data + offset, offset));
@@ -114,7 +114,7 @@ CatFile::~CatFile()
  */
 SDL_RWops *CatFile::getRWops(Uint32 i) {
 	if (i >= _items.size()) {
-		Log(LOG_ERROR) << "Catfile<" << _filename << ">::getRWops("<<i<<"): >= size " << _items.size();
+		XComLog(LOG_ERROR) << "Catfile<" << _filename << ">::getRWops("<<i<<"): >= size " << _items.size();
 		return NULL;
 	}
 	return SDL_RWFromConstMem(std::get<0>(_items[i]), std::get<1>(_items[i]));

--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -201,7 +201,7 @@ void showError(const std::string &error)
 			std::cerr << error << std::endl;
 	}
 #endif
-	Log(LOG_FATAL) << error;
+	XComLog(LOG_FATAL) << error;
 }
 
 #ifndef _WIN32
@@ -243,7 +243,7 @@ std::vector<std::string> findDataFolders()
 	{
 		PathAppendW(pathW, oxconst.c_str());
 		auto path = pathFromWindows(pathW);
-		Log(LOG_DEBUG) << "findDataFolders(): SHGetSpecialFolderPathW: " << path;
+		XComLog(LOG_DEBUG) << "findDataFolders(): SHGetSpecialFolderPathW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 
@@ -253,7 +253,7 @@ std::vector<std::string> findDataFolders()
 		PathRemoveFileSpecW(pathW);
 		auto path = pathFromWindows(pathW);
 		path.push_back('/');
-		Log(LOG_DEBUG) << "findDataFolders(): GetModuleFileNameW/PathRemoveFileSpecW: " << path;
+		XComLog(LOG_DEBUG) << "findDataFolders(): GetModuleFileNameW/PathRemoveFileSpecW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 
@@ -262,7 +262,7 @@ std::vector<std::string> findDataFolders()
 	{
 		auto path = pathFromWindows(pathW);
 		path.push_back('/');
-		Log(LOG_DEBUG) << "findDataFolders(): GetCurrentDirectoryW: " << path;
+		XComLog(LOG_DEBUG) << "findDataFolders(): GetCurrentDirectoryW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 #else
@@ -346,7 +346,7 @@ std::vector<std::string> findUserFolders()
 	{
 		PathAppendW(pathW, oxconst.c_str());
 		auto path = pathFromWindows(pathW);
-		Log(LOG_DEBUG) << "findUserFolders(): SHGetSpecialFolderPathW: " << path;
+		XComLog(LOG_DEBUG) << "findUserFolders(): SHGetSpecialFolderPathW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 
@@ -356,7 +356,7 @@ std::vector<std::string> findUserFolders()
 		PathRemoveFileSpecW(pathW);
 		PathAppendW(pathW, usconst.c_str());
 		auto path = pathFromWindows(pathW);
-		Log(LOG_DEBUG) << "findUserFolders(): GetModuleFileNameW/PathRemoveFileSpecW: " << path;
+		XComLog(LOG_DEBUG) << "findUserFolders(): GetModuleFileNameW/PathRemoveFileSpecW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 
@@ -365,7 +365,7 @@ std::vector<std::string> findUserFolders()
 	{
 		PathAppendW(pathW, usconst.c_str());
 		auto path = pathFromWindows(pathW);
-		Log(LOG_DEBUG) << "findUserFolders(): GetCurrentDirectoryW: " << path;
+		XComLog(LOG_DEBUG) << "findUserFolders(): GetCurrentDirectoryW: " << path;
 		if (seen.end() == seen.find(path)) { seen.insert(path); list.push_back(path); }
 	}
 #else
@@ -555,12 +555,12 @@ std::vector<std::tuple<std::string, bool, time_t>> getFolderContents(const std::
 #ifdef _WIN32
 	auto search_path = path + "/*";
 	if (!ext.empty()) { search_path += "." + ext; }
-	Log(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<") -> " << search_path;
+	XComLog(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<") -> " << search_path;
 	auto pathW = pathToWindows(search_path);
 	WIN32_FIND_DATAW ffd;
 	auto handle = FindFirstFileW(pathW.c_str(), &ffd);
 	if (handle == INVALID_HANDLE_VALUE) {
-		Log(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): fail outright.";
+		XComLog(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): fail outright.";
 		return files;
 	}
 	do  {
@@ -569,10 +569,10 @@ std::vector<std::tuple<std::string, bool, time_t>> getFolderContents(const std::
 		time_t mtime = FILETIME2mtime(ffd.ftLastWriteTime);
 		bool is_folder = ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;
 		files.push_back(std::make_tuple(filename, is_folder, mtime));
-		Log(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): got '"<<filename<<"'";
+		XComLog(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): got '"<<filename<<"'";
 	} while (FindNextFileW(handle, &ffd) != 0);
 	FindClose(handle);
-	Log(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): total "<<files.size();
+	XComLog(LOG_VERBOSE) << "getFolderContents("<<path<<", "<<ext<<"): total "<<files.size();
 #else
 	DIR *dp = opendir(path.c_str());
 
@@ -620,7 +620,7 @@ bool folderExists(const std::string &path)
 #ifdef _WIN32
 	auto pathW = pathToWindows(path);
 	bool rv = (PathIsDirectoryW(pathW.c_str()) != FALSE);
-	Log(LOG_VERBOSE) << "folderExists("<<path<<")? " << (rv ? "yeah" : "nope");
+	XComLog(LOG_VERBOSE) << "folderExists("<<path<<")? " << (rv ? "yeah" : "nope");
 	return rv;
 #elif __MORPHOS__
 	BPTR l = Lock( path.c_str(), SHARED_LOCK );
@@ -646,7 +646,7 @@ bool fileExists(const std::string &path)
 #ifdef _WIN32
 	auto pathW = pathToWindows(path);
 	bool rv = (PathFileExistsW(pathW.c_str()) != FALSE);
-	Log(LOG_VERBOSE) << "fileExists("<<path<<")? " << (rv?"yeah":"nope");
+	XComLog(LOG_VERBOSE) << "fileExists("<<path<<")? " << (rv?"yeah":"nope");
 	return rv;
 #elif __MORPHOS__
 	BPTR l = Lock( path.c_str(), SHARED_LOCK );
@@ -977,11 +977,11 @@ bool writeFile(const std::string& filename, const std::string& data) {
 	// Even SDL1 file IO accepts UTF-8 file names on windows.
 	SDL_RWops *rwops = SDL_RWFromFile(filename.c_str(), "w");
 	if (!rwops) {
-		Log(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
+		XComLog(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
 		return false;
 	}
 	if (1 != SDL_RWwrite(rwops, data.c_str(), data.size(), 1)) {
-		Log(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
+		XComLog(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
 		SDL_RWclose(rwops);
 		return false;
 	}
@@ -999,11 +999,11 @@ bool writeFile(const std::string& filename, const std::vector<unsigned char>& da
 	// Even SDL1 file IO accepts UTF-8 file names on windows.
 	SDL_RWops *rwops = SDL_RWFromFile(filename.c_str(), "wb");
 	if (!rwops) {
-		Log(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
+		XComLog(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
 		return false;
 	}
 	if (1 != SDL_RWwrite(rwops, data.data(), data.size(), 1)) {
-		Log(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
+		XComLog(LOG_ERROR) << "Failed to write " << filename << ": " << SDL_GetError();
 		SDL_RWclose(rwops);
 		return false;
 	}
@@ -1020,14 +1020,14 @@ std::unique_ptr<std::istream> readFile(const std::string& filename) {
 	SDL_RWops *rwops = SDL_RWFromFile(filename.c_str(), "r");
 	if (!rwops) {
 		std::string err = "Failed to read " + filename + ": " + SDL_GetError();
-		Log(LOG_ERROR) << err;
+		XComLog(LOG_ERROR) << err;
 		throw Exception(err);
 	}
 	size_t size;
 	char *data = (char *)SDL_LoadFile_RW(rwops, &size, SDL_TRUE);
 	if (data == NULL) {
 		std::string err = "Failed to read " + filename + ": " + SDL_GetError();
-		Log(LOG_ERROR) << err;
+		XComLog(LOG_ERROR) << err;
 		throw Exception(err);
 	}
 	std::string datastr(data, size);
@@ -1045,7 +1045,7 @@ std::unique_ptr<std::istream> getYamlSaveHeader(const std::string& filename) {
 	SDL_RWops *rwops = SDL_RWFromFile(filename.c_str(), "r");
 	if (!rwops) {
 		std::string err = "Failed to read " + filename + ": " + SDL_GetError();
-		Log(LOG_ERROR) << err;
+		XComLog(LOG_ERROR) << err;
 		throw Exception(err);
 	}
 	const size_t chunksize = 4096;
@@ -1054,7 +1054,7 @@ std::unique_ptr<std::istream> getYamlSaveHeader(const std::string& filename) {
 	char *data = (char *)SDL_malloc(chunksize + 1);
 	if (data == NULL) {
 		std::string err(SDL_GetError());
-		Log(LOG_ERROR) << err;
+		XComLog(LOG_ERROR) << err;
 		throw Exception(err);
 	}
 	while(true) {
@@ -1071,7 +1071,7 @@ std::unique_ptr<std::istream> getYamlSaveHeader(const std::string& filename) {
 		char *newdata = (char *)SDL_realloc(data, size+chunksize+1);
 		if (newdata == NULL) {
 			std::string err(SDL_GetError());
-			Log(LOG_ERROR) << err;
+			XComLog(LOG_ERROR) << err;
 			throw Exception(err);
 		}
 		data = newdata;
@@ -1251,7 +1251,7 @@ void stackTrace(void *ctx)
 	frame.AddrStack.Offset = context.IntSp;
 	frame.AddrStack.Mode = AddrModeFlat;
 #  else
-	Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
+	XComLog(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 	return;
 #  endif
 	SYMBOL_INFO *symbol = (SYMBOL_INFO *)malloc(sizeof(SYMBOL_INFO) + (MAX_SYMBOL_LENGTH - 1) * sizeof(TCHAR));
@@ -1290,29 +1290,29 @@ void stackTrace(void *ctx)
 				{
 					filename = filename.substr(n + 1);
 				}
-				Log(LOG_FATAL) << "0x" << std::hex << symbol->Address << std::dec << " " << symname << " (" << filename << ":" << line->LineNumber << ")";
+				XComLog(LOG_FATAL) << "0x" << std::hex << symbol->Address << std::dec << " " << symname << " (" << filename << ":" << line->LineNumber << ")";
 			}
 			else
 			{
-				Log(LOG_FATAL) << "0x" << std::hex << symbol->Address << std::dec << " " << symname;
+				XComLog(LOG_FATAL) << "0x" << std::hex << symbol->Address << std::dec << " " << symname;
 			}
 		}
 		else
 		{
-			Log(LOG_FATAL) << "??";
+			XComLog(LOG_FATAL) << "??";
 		}
 	}
 	DWORD err = GetLastError();
 	if (err)
 	{
-		Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
+		XComLog(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 	}
 	SymCleanup(process);
 # else /* __NO_DBGHELP */
-	Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
+	XComLog(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 # endif
 #elif __CYGWIN__
-	Log(LOG_FATAL) << "Unfortunately, no stack trace information is available";
+	XComLog(LOG_FATAL) << "Unfortunately, no stack trace information is available";
 #else    /* not _WIN32 or __CYGWIN__ */
 	void *frames[32];
 	char buf[1024];
@@ -1339,10 +1339,10 @@ void stackTrace(void *ctx)
 				snprintf(buf, sizeof(buf), "%s(+0x%zx) [%p]", dl_info.dli_fname, sym_offset, frames[i]);
 			}
 			free(demangled);
-			Log(LOG_FATAL) << buf;
+			XComLog(LOG_FATAL) << buf;
 		} else { // object not found
 			snprintf(buf, sizeof(buf), "? ? [%p]", frames[i]);
-			Log(LOG_FATAL) << buf;
+			XComLog(LOG_FATAL) << buf;
 		}
 	}
 #endif
@@ -1400,7 +1400,7 @@ void crashDump(void *ex, const std::string &err)
 		error << "code 0x" << std::hex << exception->ExceptionRecord->ExceptionCode;
 		break;
 	}
-	Log(LOG_FATAL) << "A fatal error has occurred: " << error.str();
+	XComLog(LOG_FATAL) << "A fatal error has occurred: " << error.str();
 	if (ex)
 	{
 		stackTrace(exception->ContextRecord);
@@ -1414,11 +1414,11 @@ void crashDump(void *ex, const std::string &err)
 	exceptionInformation.ClientPointers = FALSE;
 	if (MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), dumpFile, MiniDumpNormal, exception ? &exceptionInformation : NULL, NULL, NULL))
 	{
-		Log(LOG_FATAL) << "Crash dump generated at " << dumpName;
+		XComLog(LOG_FATAL) << "Crash dump generated at " << dumpName;
 	}
 	else
 	{
-		Log(LOG_FATAL) << "No crash dump generated: " << GetLastError();
+		XComLog(LOG_FATAL) << "No crash dump generated: " << GetLastError();
 	}
 #else
 	if (ex == 0)
@@ -1438,17 +1438,17 @@ void crashDump(void *ex, const std::string &err)
 			break;
 		}
 	}
-	Log(LOG_FATAL) << "A fatal error has occurred: " << error.str();
+	XComLog(LOG_FATAL) << "A fatal error has occurred: " << error.str();
 	stackTrace(0);
 #endif
 	std::ostringstream msg;
 	msg << "OpenXcom has crashed: " << error.str() << std::endl;
-	msg << "Log file: " << getLogFileName() << std::endl;
+	msg << "XComLog file: " << getLogFileName() << std::endl;
 	msg << "If this error was unexpected, please report it on OpenXcom forum or discord." << std::endl;
 	msg << "The following can help us solve the problem:" << std::endl;
 	msg << "1. a saved game from just before the crash (helps 98%)" << std::endl;
 	msg << "2. a detailed description how to reproduce the crash (helps 80%)" << std::endl;
-	msg << "3. a log file (helps 10%)" << std::endl;
+	msg << "3. a XComLog file (helps 10%)" << std::endl;
 	msg << "4. a screenshot of this error message (helps 5%)";
 	showError(msg.str());
 }
@@ -1497,17 +1497,17 @@ static std::string logFileName;
 const std::string& getLogFileName() { return logFileName; }
 
 /**
- * Setting the log file name and setting the effective reportingLevel
- * to not LOG_UNCENSORED turns off buffering of the log messages,
- * and turns on writing them to the actual log (and flushes the buffer).
+ * Setting the XComLog file name and setting the effective reportingLevel
+ * to not LOG_UNCENSORED turns off buffering of the XComLog messages,
+ * and turns on writing them to the actual XComLog (and flushes the buffer).
  */
 void setLogFileName(const std::string& name) {
 	deleteFile(name);
 	size_t sz = logBuffer.size();
-	Log(LOG_DEBUG) << "setLogFileName("<<name<<") was '"<<logFileName<<"'; "<<sz<<" in buffer";
+	XComLog(LOG_DEBUG) << "setLogFileName("<<name<<") was '"<<logFileName<<"'; "<<sz<<" in buffer";
 	logFileName = name;
 }
-void log(int level, const std::ostringstream& baremsgstream) {
+void Log(int level, const std::ostringstream& baremsgstream) {
 	std::ostringstream msgstream;
 	msgstream << "[" << CrossPlatform::now() << "]" << "\t"
 			  << "[" << Logger::toString(level) << "]" << "\t"
@@ -1522,7 +1522,7 @@ void log(int level, const std::ostringstream& baremsgstream) {
 	if (logBuffer.size() > LOG_BUFFER_LIMIT) { // drop earliest message so as to not eat all memory
 		logBuffer.pop_front();
 	}
-	if (logFileName.empty() || effectiveLevel == LOG_UNCENSORED) { // no log file; accumulate.
+	if (logFileName.empty() || effectiveLevel == LOG_UNCENSORED) { // no XComLog file; accumulate.
 		logBuffer.push_back(std::make_pair(level, msg));
 		return;
 	}
@@ -1575,7 +1575,7 @@ extern "C" {
 SDL_RWops *getEmbeddedAsset(const std::string& assetName) {
 	std::string log_ctx = "getEmbeddedAsset('" + assetName + "'): ";
 	if (assetName.size() == 0 || assetName[0] == '/') {
-		Log(LOG_WARNING) << log_ctx << "ignoring bogus asset name";
+		XComLog(LOG_WARNING) << log_ctx << "ignoring bogus asset name";
 		return NULL;
 	}
 #if defined(EMBED_ASSETS)
@@ -1606,12 +1606,12 @@ SDL_RWops *getEmbeddedAsset(const std::string& assetName) {
 	}
 # endif
 	if (rv == NULL) {
-		Log(LOG_ERROR) << log_ctx << "embedded asset not found: "<< SDL_GetError();
+		XComLog(LOG_ERROR) << log_ctx << "embedded asset not found: "<< SDL_GetError();
 	}
 	return rv;
 #else
 	/* Asset embedding disabled. */
-	Log(LOG_DEBUG) << log_ctx << "assets were not embedded.";
+	XComLog(LOG_DEBUG) << log_ctx << "assets were not embedded.";
 	return NULL;
 #endif
 }

--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -111,8 +111,8 @@ namespace CrossPlatform
 	/// Opens a URL.
 	bool openExplorer(const std::string &url);
 	/// Log something.
-	void log(int, const std::ostringstream& msg);
-	/// The log file name
+	void Log(int, const std::ostringstream& msg);
+	/// The Log file name
 	void setLogFileName(const std::string &path);
 	const std::string& getLogFileName();
 	/// Get an SDL_RWops to an embedded asset. NULL if not there.

--- a/src/Engine/FlcPlayer.cpp
+++ b/src/Engine/FlcPlayer.cpp
@@ -102,7 +102,7 @@ bool FlcPlayer::init(const char *filename, void(*frameCallBack)(), Game *game, b
 {
 	if (_fileBuf != 0)
 	{
-		Log(LOG_ERROR) << "Trying to init a video player that is already initialized";
+		XComLog(LOG_ERROR) << "Trying to init a video player that is already initialized";
 		return false;
 	}
 
@@ -141,11 +141,11 @@ bool FlcPlayer::init(const char *filename, void(*frameCallBack)(), Game *game, b
 		_screenHeight = _headerHeight;
 		_screenDepth = 8;
 
-		Log(LOG_INFO) << "Playing flx, " << _screenWidth << "x" << _screenHeight << ", " << _headerFrames << " frames";
+		XComLog(LOG_INFO) << "Playing flx, " << _screenWidth << "x" << _screenHeight << ", " << _headerFrames << " frames";
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Flx file failed header check.";
+		XComLog(LOG_ERROR) << "Flx file failed header check.";
 		return false;
 	}
 	if (_screenWidth > _realScreen->getSurface()->w && Options::displayWidth >= _screenWidth)
@@ -425,7 +425,7 @@ void FlcPlayer::playVideoFrame()
 			case 18:
 				break;
 			default:
-				Log(LOG_WARNING) << "Ieek an non implemented chunk type:" << _chunkType;
+				XComLog(LOG_WARNING) << "Ieek an non implemented chunk type:" << _chunkType;
 				break;
 		}
 
@@ -813,8 +813,8 @@ void FlcPlayer::initAudio(Uint16 format, Uint8 channels)
 		{
 			if (Mix_OpenAudio(_audioData.sampleRate, format, channels, _audioFrameSize * 2) != 0)
 			{
-				Log(LOG_ERROR) << Mix_GetError();
-				Log(LOG_WARNING) << "Failed to init cutscene audio";
+				XComLog(LOG_ERROR) << Mix_GetError();
+				XComLog(LOG_WARNING) << "Failed to init cutscene audio";
 				Options::mute = true;
 			}
 		}

--- a/src/Engine/GMCat.cpp
+++ b/src/Engine/GMCat.cpp
@@ -375,7 +375,7 @@ Music *GMCatFile::loadMIDI(unsigned int i)
 	SDL_RWseek(cat_rwops, RW_SEEK_SET, 0);
 	auto data = (unsigned char *)SDL_LoadFile_RW(cat_rwops, &size, SDL_TRUE);
 	if (gmext_read_stream(&stream, size - nameskip, data + nameskip) == -1) {
-		Log(LOG_ERROR) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): Error reading MIDI stream";
+		XComLog(LOG_ERROR) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): Error reading MIDI stream";
 		return music;
 	}
 
@@ -383,11 +383,11 @@ Music *GMCatFile::loadMIDI(unsigned int i)
 	midi.reserve(65536);	// FIXME: well... what is this
 
 	if (gmext_write_midi(&stream, midi) == -1) {
-		Log(LOG_ERROR) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): Error writing MIDI stream";
+		XComLog(LOG_ERROR) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): Error writing MIDI stream";
 	} else {
 		music->load(SDL_RWFromConstMem(midi.data(), midi.size()));
 	}
-	Log(LOG_VERBOSE) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): loaded ok.";
+	XComLog(LOG_VERBOSE) << "GMCatFile::loadMIDI("<<fileName()<<", "<<i<<"): loaded ok.";
 	SDL_free(data);
 	return music;
 }

--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -64,11 +64,11 @@ Game::Game(const std::string &title) : _screen(0), _cursor(0), _lang(0), _save(0
 	// Initialize SDL
 	if (SDL_Init(SDL_INIT_VIDEO) < 0)
 	{
-		Log(LOG_ERROR) << SDL_GetError();
-		Log(LOG_WARNING) << "No video detected, quit.";
+		XComLog(LOG_ERROR) << SDL_GetError();
+		XComLog(LOG_WARNING) << "No video detected, quit.";
 		throw Exception(SDL_GetError());
 	}
-	Log(LOG_INFO) << "SDL initialized successfully.";
+	XComLog(LOG_INFO) << "SDL initialized successfully.";
 
 	// Initialize SDL_mixer
 	initAudio();
@@ -647,8 +647,8 @@ void Game::initAudio()
 {
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
 	{
-		Log(LOG_ERROR) << SDL_GetError();
-		Log(LOG_WARNING) << "No sound device detected, audio disabled.";
+		XComLog(LOG_ERROR) << SDL_GetError();
+		XComLog(LOG_WARNING) << "No sound device detected, audio disabled.";
 		Options::mute = true;
 		return;
 	}
@@ -659,16 +659,16 @@ void Game::initAudio()
 
 	if (Options::audioSampleRate % 11025 != 0)
 	{
-		Log(LOG_WARNING) << "Custom sample rate " << Options::audioSampleRate << "Hz, audio that doesn't match will be distorted!";
-		Log(LOG_WARNING) << "SDL_mixer only supports multiples of 11025Hz.";
+		XComLog(LOG_WARNING) << "Custom sample rate " << Options::audioSampleRate << "Hz, audio that doesn't match will be distorted!";
+		XComLog(LOG_WARNING) << "SDL_mixer only supports multiples of 11025Hz.";
 	}
 	int minChunk = Options::audioSampleRate / 11025 * 512;
 	Options::audioChunkSize = std::max(minChunk, Options::audioChunkSize);
 
 	if (Mix_OpenAudio(Options::audioSampleRate, format, MIX_DEFAULT_CHANNELS, Options::audioChunkSize) != 0)
 	{
-		Log(LOG_ERROR) << Mix_GetError();
-		Log(LOG_WARNING) << "Sound device failed, audio disabled.";
+		XComLog(LOG_ERROR) << Mix_GetError();
+		XComLog(LOG_WARNING) << "Sound device failed, audio disabled.";
 		Options::mute = true;
 	}
 	else
@@ -681,7 +681,7 @@ void Game::initAudio()
 		// 4 = unit responses (OXCE only)
 		Mix_ReserveChannels(5);
 		Mix_GroupChannels(1, 2, 0);
-		Log(LOG_INFO) << "SDL_mixer initialized successfully.";
+		XComLog(LOG_INFO) << "SDL_mixer initialized successfully.";
 		setVolume(Options::soundVolume, Options::musicVolume, Options::uiVolume);
 	}
 }

--- a/src/Engine/Language.cpp
+++ b/src/Engine/Language.cpp
@@ -315,7 +315,7 @@ LocalizedText Language::getString(const std::string &id, unsigned n) const
 		if (notFoundIds.end() == notFoundIds.find(id))
 		{
 			notFoundIds.insert(id);
-			Log(LOG_WARNING) << id << " not found in " << Options::language;
+			XComLog(LOG_WARNING) << id << " not found in " << Options::language;
 		}
 		return id;
 	}
@@ -324,7 +324,7 @@ LocalizedText Language::getString(const std::string &id, unsigned n) const
 		if (notFoundIds.end() == notFoundIds.find(id))
 		{
 			notFoundIds.insert(id);
-			Log(LOG_WARNING) << id << " has plural format in ``" << Options::language << "``. Code assumes singular format.";
+			XComLog(LOG_WARNING) << id << " has plural format in ``" << Options::language << "``. Code assumes singular format.";
 //		Hint: Change ``getstring(ID).arg(value)`` to ``getString(ID, value)`` in appropriate files.
 		}
 		return s->second;

--- a/src/Engine/Logger.h
+++ b/src/Engine/Logger.h
@@ -37,7 +37,7 @@ enum SeverityLevel
 	LOG_DEBUG,		/**< Purely test stuff to help developers implement, not really relevant to users. */
 	LOG_VERBOSE,	/**< Extra details that even developers won't really need 90% of the time. */
 
-	LOG_UNCENSORED  /**< Makes sure everything makes it into log buffer until there's a logfile set up */
+	LOG_UNCENSORED  /**< Makes sure everything makes it into XComLog buffer until there's a logfile set up */
 };
 
 /**
@@ -49,7 +49,7 @@ class Logger
 {
 public:
 	Logger() : _level(LOG_INFO) { };
-	virtual ~Logger() { CrossPlatform::log(_level, os); };
+	virtual ~Logger() { CrossPlatform::Log(_level, os); };
 	std::ostringstream& get(SeverityLevel level = LOG_INFO) { _level = level; return os; };
 
 	static SeverityLevel& reportingLevel() {
@@ -66,6 +66,6 @@ private:
 	std::ostringstream os;
 };
 
-#define Log(level) if (level > Logger::reportingLevel()) { } else Logger().get(level)
+#define XComLog(level) if (level > Logger::reportingLevel()) { } else Logger().get(level)
 
 }

--- a/src/Engine/Music.cpp
+++ b/src/Engine/Music.cpp
@@ -56,7 +56,7 @@ void Music::load(const std::string &filename)
 {
 #ifndef __NO_MUSIC
 	load(FileMap::getRWops(filename));
-	Log(LOG_VERBOSE)<<"Music::load('" << filename << "')";
+	XComLog(LOG_VERBOSE)<<"Music::load('" << filename << "')";
 #endif
 }
 
@@ -91,7 +91,7 @@ void Music::play(int loop) const
 			stop();
 			if (Mix_PlayMusic(_music, loop) == -1)
 			{
-				Log(LOG_WARNING) << Mix_GetError();
+				XComLog(LOG_WARNING) << Mix_GetError();
 			}
 		}
 	}

--- a/src/Engine/OpenGL.cpp
+++ b/src/Engine/OpenGL.cpp
@@ -258,7 +258,7 @@ bool OpenGL::set_shader(const char *source_yaml_filename)
 		glprogram = glCreateProgram();
 		if (glprogram == 0)
 		{
-			Log(LOG_ERROR) << "Failed to create GLSL shader program";
+			XComLog(LOG_ERROR) << "Failed to create GLSL shader program";
 			return false;
 		}
 		{
@@ -280,7 +280,7 @@ bool OpenGL::set_shader(const char *source_yaml_filename)
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Unexpected shader language \"" <<
+				XComLog(LOG_ERROR) << "Unexpected shader language \"" <<
 					document["language"].as<std::string>() << "\"";
 			}
 		}
@@ -296,7 +296,7 @@ bool OpenGL::set_shader(const char *source_yaml_filename)
 			glErrorCheck();
 			if (infoLogLength == 0)
 			{
-				Log(LOG_ERROR) << "OpenGL shader link failed: No log returned from driver";
+				XComLog(LOG_ERROR) << "OpenGL shader link failed: No XComLog returned from driver";
 			}
 			else
 			{
@@ -304,7 +304,7 @@ bool OpenGL::set_shader(const char *source_yaml_filename)
 				glGetProgramInfoLog(glprogram, infoLogLength, NULL, infoLog);
 				glErrorCheck();
 
-				Log(LOG_ERROR) << "OpenGL shader link failed \"" << infoLog << "\"";
+				XComLog(LOG_ERROR) << "OpenGL shader link failed \"" << infoLog << "\"";
 
 				delete[] infoLog;
 			}
@@ -335,7 +335,7 @@ static GLuint createShader(GLenum type, const char *source)
 		glErrorCheck();
 		if (infoLogLength == 0)
 		{
-			Log(LOG_ERROR) << "OpenGL shader compilation failed: No log returned from driver";
+			XComLog(LOG_ERROR) << "OpenGL shader compilation failed: No XComLog returned from driver";
 		}
 		else
 		{
@@ -343,7 +343,7 @@ static GLuint createShader(GLenum type, const char *source)
 			glGetShaderInfoLog(shader, infoLogLength, NULL, infoLog);
 			glErrorCheck();
 
-			Log(LOG_ERROR) << "OpenGL shader compilation failed: \"" << infoLog << "\"";
+			XComLog(LOG_ERROR) << "OpenGL shader compilation failed: \"" << infoLog << "\"";
 
 			delete[] infoLog;
 		}
@@ -460,13 +460,13 @@ void OpenGL::setVSync(bool sync)
 		if (drawable) {
 			glXSwapIntervalEXT(dpy, drawable, interval);
 			glErrorCheck();
-			// Log(LOG_INFO) << "Made an attempt to set vsync via GLX.";
+			// XComLog(LOG_INFO) << "Made an attempt to set vsync via GLX.";
 		}
 	} else if (wglSwapIntervalEXT)
 	{
 		wglSwapIntervalEXT(interval);
 		glErrorCheck();
-		// Log(LOG_INFO) << "Made an attempt to set vsync via WGL.";
+		// XComLog(LOG_INFO) << "Made an attempt to set vsync via WGL.";
 	}
 }
 

--- a/src/Engine/OpenGL.h
+++ b/src/Engine/OpenGL.h
@@ -36,7 +36,7 @@ std::string strGLError(GLenum glErr);
 		\
 		do \
 		{ \
-			Log(LOG_WARNING) << __FILE__ << ":" << __LINE__ << ": glGetError() complaint: " << strGLError(glErr);\
+			XComLog(LOG_WARNING) << __FILE__ << ":" << __LINE__ << ": glGetError() complaint: " << strGLError(glErr);\
 		} while (((glErr = glGetError()) != GL_NO_ERROR));\
 	}\
 }

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -498,7 +498,7 @@ static void loadArgs()
 			if (argv.size() > i + 1)
 			{
 				++i; // we'll be consuming the next argument too
-				Log(LOG_DEBUG) << "loadArgs(): "<< argname <<" -> " << argv[i];
+				XComLog(LOG_DEBUG) << "loadArgs(): "<< argname <<" -> " << argv[i];
 				if (argname == "data")
 				{
 					_dataFolder = argv[i];
@@ -532,7 +532,7 @@ static void loadArgs()
 			}
 			else
 			{
-				Log(LOG_WARNING) << "Unknown option: " << argname;
+				XComLog(LOG_WARNING) << "Unknown option: " << argname;
 			}
 		}
 	}
@@ -629,33 +629,33 @@ bool init()
 	if (Options::verboseLogging)
 		Logger::reportingLevel() = LOG_VERBOSE;
 
-	// this enables writes to the log file and filters already emitted messages
-	CrossPlatform::setLogFileName(getUserFolder() + "openxcom.log");
+	// this enables writes to the XComLog file and filters already emitted messages
+	CrossPlatform::setLogFileName(getUserFolder() + "openxcom.XComLog");
 
-	Log(LOG_INFO) << "OpenXcom Version: " << OPENXCOM_VERSION_SHORT << OPENXCOM_VERSION_GIT;
+	XComLog(LOG_INFO) << "OpenXcom Version: " << OPENXCOM_VERSION_SHORT << OPENXCOM_VERSION_GIT;
 #ifdef _WIN64
-	Log(LOG_INFO) << "Platform: Windows 64 bit";
+	XComLog(LOG_INFO) << "Platform: Windows 64 bit";
 #elif _WIN32
-	Log(LOG_INFO) << "Platform: Windows 32 bit";
+	XComLog(LOG_INFO) << "Platform: Windows 32 bit";
 #elif __APPLE__
-	Log(LOG_INFO) << "Platform: OSX";
+	XComLog(LOG_INFO) << "Platform: OSX";
 #elif  __ANDROID_API__
-	Log(LOG_INFO) << "Platform: Android";
+	XComLog(LOG_INFO) << "Platform: Android";
 #elif __linux__
-	Log(LOG_INFO) << "Platform: Linux";
+	XComLog(LOG_INFO) << "Platform: Linux";
 #else
-	Log(LOG_INFO) << "Platform: Unix-like";
+	XComLog(LOG_INFO) << "Platform: Unix-like";
 #endif
 
-	Log(LOG_INFO) << "Data folder is: " << _dataFolder;
-	Log(LOG_INFO) << "Data search is: ";
+	XComLog(LOG_INFO) << "Data folder is: " << _dataFolder;
+	XComLog(LOG_INFO) << "Data search is: ";
 	for (std::vector<std::string>::iterator i = _dataList.begin(); i != _dataList.end(); ++i)
 	{
-		Log(LOG_INFO) << "- " << *i;
+		XComLog(LOG_INFO) << "- " << *i;
 	}
-	Log(LOG_INFO) << "User folder is: " << _userFolder;
-	Log(LOG_INFO) << "Config folder is: " << _configFolder;
-	Log(LOG_INFO) << "Options loaded successfully.";
+	XComLog(LOG_INFO) << "User folder is: " << _userFolder;
+	XComLog(LOG_INFO) << "Config folder is: " << _configFolder;
+	XComLog(LOG_INFO) << "Options loaded successfully.";
 
 	FileMap::clear(false, Options::oxceEmbeddedOnly);
 	return true;
@@ -672,25 +672,25 @@ void refreshMods()
 	_modInfos.clear();
 	SDL_RWops *rwops = CrossPlatform::getEmbeddedAsset("standard.zip");
 	if (rwops) {
-		Log(LOG_INFO) << "Scanning embedded standard mods...";
+		XComLog(LOG_INFO) << "Scanning embedded standard mods...";
 		FileMap::scanModZipRW(rwops, "exe:standard.zip");
 	}
 	if (Options::oxceEmbeddedOnly && rwops) {
-		Log(LOG_INFO) << "Modding embedded resources is disabled, set 'oxceEmbeddedOnly: false' in options.cfg to enable.";
+		XComLog(LOG_INFO) << "Modding embedded resources is disabled, set 'oxceEmbeddedOnly: false' in options.cfg to enable.";
 	} else {
-		Log(LOG_INFO) << "Scanning standard mods in '" << getDataFolder() << "'...";
+		XComLog(LOG_INFO) << "Scanning standard mods in '" << getDataFolder() << "'...";
 		FileMap::scanModDir(getDataFolder(), "standard", true);
 	}
-	Log(LOG_INFO) << "Scanning user mods in '" << getUserFolder() << "'...";
+	XComLog(LOG_INFO) << "Scanning user mods in '" << getUserFolder() << "'...";
 	FileMap::scanModDir(getUserFolder(), "mods", false);
 #ifdef __MOBILE__
 	if (getDataFolder() == getUserFolder())
 	{
-		Log(LOG_INFO) << "Skipped scanning user mods in the data folder, because it's the same folder as the user folder.";
+		XComLog(LOG_INFO) << "Skipped scanning user mods in the data folder, because it's the same folder as the user folder.";
 	}
 	else
 	{
-		Log(LOG_INFO) << "Scanning user mods in '" << getDataFolder() << "'...";
+		XComLog(LOG_INFO) << "Scanning user mods in '" << getDataFolder() << "'...";
 		FileMap::scanModDir(getDataFolder(), "mods", false);
 	}
 #endif
@@ -711,7 +711,7 @@ void refreshMods()
 		auto modIt = _modInfos.find(i->first);
 		if (_modInfos.end() == modIt)
 		{
-			Log(LOG_VERBOSE) << "removing references to missing mod: " << i->first;
+			XComLog(LOG_VERBOSE) << "removing references to missing mod: " << i->first;
 			i = mods.erase(i);
 			continue;
 		}
@@ -721,7 +721,7 @@ void refreshMods()
 			{
 				if (nonMasterModFound)
 				{
-					Log(LOG_ERROR) << "Removing master mod '" << i->first << "' from the list, because it is on a wrong position. It will be re-added automatically.";
+					XComLog(LOG_ERROR) << "Removing master mod '" << i->first << "' from the list, because it is on a wrong position. It will be re-added automatically.";
 					corruptedMasters[i->first] = i->second;
 					i = mods.erase(i);
 					continue;
@@ -763,7 +763,7 @@ void refreshMods()
 					{
 						if (!activeMaster.empty())
 						{
-							Log(LOG_WARNING) << "Too many active masters detected; turning off " << j->first;
+							XComLog(LOG_WARNING) << "Too many active masters detected; turning off " << j->first;
 							j->second = false;
 						}
 						else
@@ -813,12 +813,12 @@ void refreshMods()
 	{
 		if (inactiveMaster.empty())
 		{
-			Log(LOG_ERROR) << "no mod masters available";
+			XComLog(LOG_ERROR) << "no mod masters available";
 			throw Exception("No X-COM installations found");
 		}
 		else
 		{
-			Log(LOG_INFO) << "no master already active; activating " << inactiveMaster;
+			XComLog(LOG_INFO) << "no master already active; activating " << inactiveMaster;
 			std::find(mods.begin(), mods.end(), std::pair<std::string, bool>(inactiveMaster, false))->second = true;
 			_masterMod = inactiveMaster;
 		}
@@ -845,14 +845,14 @@ void updateMods()
 		if (!modInf->isEngineOk())
 		{
 			forceQuit = true;
-			Log(LOG_ERROR) << "- " << modInf->getId() << " v" << modInf->getVersion();
+			XComLog(LOG_ERROR) << "- " << modInf->getId() << " v" << modInf->getVersion();
 			if (modInf->getRequiredExtendedEngine() != OPENXCOM_VERSION_ENGINE)
 			{
-				Log(LOG_ERROR) << "Mod '" << modInf->getName() << "' require OXC " << modInf->getRequiredExtendedEngine() << " engine to run";
+				XComLog(LOG_ERROR) << "Mod '" << modInf->getName() << "' require OXC " << modInf->getRequiredExtendedEngine() << " engine to run";
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Mod '" << modInf->getName() << "' enforces at least OXC " << OPENXCOM_VERSION_ENGINE << " v" << modInf->getRequiredExtendedVersion();
+				XComLog(LOG_ERROR) << "Mod '" << modInf->getName() << "' enforces at least OXC " << OPENXCOM_VERSION_ENGINE << " v" << modInf->getRequiredExtendedVersion();
 			}
 		}
 	}
@@ -864,11 +864,11 @@ void updateMods()
 	FileMap::setup(activeModsList, Options::oxceEmbeddedOnly);
 	userSplitMasters();
 
-	Log(LOG_INFO) << "Active mods:";
+	XComLog(LOG_INFO) << "Active mods:";
 	auto activeMods = getActiveMods();
 	for (auto modInf : activeMods)
 	{
-		Log(LOG_INFO) << "- " << modInf->getId() << " v" << modInf->getVersion();
+		XComLog(LOG_INFO) << "- " << modInf->getId() << " v" << modInf->getVersion();
 	}
 }
 
@@ -920,7 +920,7 @@ void setFolders()
 	if (!_dataFolder.empty())
 	{
 		_dataList.insert(_dataList.begin(), _dataFolder);
-		Log(LOG_DEBUG) << "setFolders(): inserting " << _dataFolder;
+		XComLog(LOG_DEBUG) << "setFolders(): inserting " << _dataFolder;
 	}
 	if (_userFolder.empty())
 	{
@@ -1037,7 +1037,7 @@ bool load(const std::string &filename)
 	}
 	catch (YAML::Exception &e)
 	{
-		Log(LOG_WARNING) << e.what();
+		XComLog(LOG_WARNING) << e.what();
 		return false;
 	}
 	return true;
@@ -1118,7 +1118,7 @@ bool save(const std::string &filename)
 	}
 	catch (YAML::Exception &e)
 	{
-		Log(LOG_WARNING) << e.what();
+		XComLog(LOG_WARNING) << e.what();
 		return false;
 	}
 	std::string filepath = _configFolder + filename + ".cfg";
@@ -1126,7 +1126,7 @@ bool save(const std::string &filename)
 
 	if (!CrossPlatform::writeFile(filepath, data + "\n" ))
 	{
-		Log(LOG_WARNING) << "Failed to save " << filepath;
+		XComLog(LOG_WARNING) << "Failed to save " << filepath;
 		return false;
 	}
 	return true;
@@ -1150,7 +1150,7 @@ std::string getDataFolder()
 void setDataFolder(const std::string &folder)
 {
 	_dataFolder = folder;
-	Log(LOG_DEBUG) << "setDataFolder(" << folder <<");";
+	XComLog(LOG_DEBUG) << "setDataFolder(" << folder <<");";
 }
 
 /**

--- a/src/Engine/Screen.cpp
+++ b/src/Engine/Screen.cpp
@@ -195,7 +195,7 @@ void Screen::flip()
 	{
 		if (_screen->format->BitsPerPixel == 8 && SDL_SetColors(_screen, &(deferredPalette[_firstColor]), _firstColor, _numColors) == 0)
 		{
-			Log(LOG_DEBUG) << "Display palette doesn't match requested palette";
+			XComLog(LOG_DEBUG) << "Display palette doesn't match requested palette";
 		}
 		_numColors = 0;
 		_pushPalette = false;
@@ -215,7 +215,7 @@ void Screen::flip()
 	{
 		if (_screen->format->BitsPerPixel == 8 && SDL_SetColors(_screen, &(deferredPalette[_firstColor]), _firstColor, _numColors) == 0)
 		{
-			Log(LOG_DEBUG) << "Display palette doesn't match requested palette";
+			XComLog(LOG_DEBUG) << "Display palette doesn't match requested palette";
 		}
 		_numColors = 0;
 		_pushPalette = false;
@@ -267,7 +267,7 @@ void Screen::setPalette(const SDL_Color* colors, int firstcolor, int ncolors, bo
 	// defer actual update of screen until SDL_Flip()
 	if (immediately && _screen->format->BitsPerPixel == 8 && SDL_SetColors(_screen, const_cast<SDL_Color *>(colors), firstcolor, ncolors) == 0)
 	{
-		Log(LOG_DEBUG) << "Display palette doesn't match requested palette";
+		XComLog(LOG_DEBUG) << "Display palette doesn't match requested palette";
 	}
 
 	// Sanity check
@@ -275,13 +275,13 @@ void Screen::setPalette(const SDL_Color* colors, int firstcolor, int ncolors, bo
 	SDL_Color *newcolors = _screen->format->palette->colors;
 	for (int i = firstcolor, j = 0; i < firstcolor + ncolors; i++, j++)
 	{
-		Log(LOG_DEBUG) << (int)newcolors[i].r << " - " << (int)newcolors[i].g << " - " << (int)newcolors[i].b;
-		Log(LOG_DEBUG) << (int)colors[j].r << " + " << (int)colors[j].g << " + " << (int)colors[j].b;
+		XComLog(LOG_DEBUG) << (int)newcolors[i].r << " - " << (int)newcolors[i].g << " - " << (int)newcolors[i].b;
+		XComLog(LOG_DEBUG) << (int)colors[j].r << " + " << (int)colors[j].g << " + " << (int)colors[j].b;
 		if (newcolors[i].r != colors[j].r ||
 			newcolors[i].g != colors[j].g ||
 			newcolors[i].b != colors[j].b)
 		{
-			Log(LOG_ERROR) << "Display palette doesn't match requested palette";
+			XComLog(LOG_ERROR) << "Display palette doesn't match requested palette";
 			break;
 		}
 	}
@@ -367,12 +367,12 @@ void Screen::resetDisplay(bool resetVideo, bool noShaders)
 			SDL_SetCursor(SDL_CreateCursor(&cursor, &cursor, 1,1,0,0));
 		}
 #endif
-		Log(LOG_INFO) << "Attempting to set display to " << width << "x" << height << "x" << _bpp << "...";
+		XComLog(LOG_INFO) << "Attempting to set display to " << width << "x" << height << "x" << _bpp << "...";
 		_screen = SDL_SetVideoMode(width, height, _bpp, _flags);
 		if (_screen == 0)
 		{
-			Log(LOG_ERROR) << SDL_GetError();
-			Log(LOG_INFO) << "Attempting to set display to default resolution...";
+			XComLog(LOG_ERROR) << SDL_GetError();
+			XComLog(LOG_INFO) << "Attempting to set display to default resolution...";
 			_screen = SDL_SetVideoMode(640, 400, _bpp, _flags);
 			if (_screen == 0)
 			{
@@ -383,7 +383,7 @@ void Screen::resetDisplay(bool resetVideo, bool noShaders)
 				throw Exception(SDL_GetError());
 			}
 		}
-		Log(LOG_INFO) << "Display set to " << getWidth() << "x" << getHeight() << "x" << (int)_screen->format->BitsPerPixel << ".";
+		XComLog(LOG_INFO) << "Display set to " << getWidth() << "x" << getHeight() << "x" << (int)_screen->format->BitsPerPixel << ".";
 	}
 	else
 	{
@@ -573,7 +573,7 @@ void Screen::screenshot(const std::string &filename) const
 		unsigned error = lodepng::encode(out, (const unsigned char *)(_surface->pixels), _surface->w, _surface->h, state);
 		if (error)
 		{
-			Log(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
+			XComLog(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
 		}
 	}
 	else
@@ -581,7 +581,7 @@ void Screen::screenshot(const std::string &filename) const
 		unsigned error = lodepng::encode(out, (const unsigned char *)(screenshot->pixels), getWidth() - getWidth()%4, getHeight(), LCT_RGB);
 		if (error)
 		{
-			Log(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
+			XComLog(LOG_ERROR) << "Saving to PNG failed: " << lodepng_error_text(error);
 		}
 	}
 

--- a/src/Engine/Script.cpp
+++ b/src/Engine/Script.cpp
@@ -435,7 +435,7 @@ static inline void scriptExe(ScriptWorkerBase& data, const Uint8* proc)
 	static int bugCount = 0;
 	if (++bugCount < 100)
 	{
-		Log(LOG_ERROR) << "Invalid script operation for OpId: " << std::hex << std::showbase << (int)proc[(int)curr] <<" at "<< (int)curr;
+		XComLog(LOG_ERROR) << "Invalid script operation for OpId: " << std::hex << std::showbase << (int)proc[(int)curr] <<" at "<< (int)curr;
 	}
 
 	endLabel:
@@ -545,7 +545,7 @@ constexpr int log_buffer_limit_max = 500;
 static int log_buffer_limit_count = 0;
 
 /**
- * Add text to log buffer.
+ * Add text to XComLog buffer.
  */
 void ScriptWorkerBase::log_buffer_add(FuncRef<std::string()> func)
 {
@@ -561,20 +561,20 @@ void ScriptWorkerBase::log_buffer_add(FuncRef<std::string()> func)
 }
 
 /**
- * Flush buffer to log file.
+ * Flush buffer to XComLog file.
  */
 void ScriptWorkerBase::log_buffer_flush(ProgPos& p)
 {
 	if (++log_buffer_limit_count < log_buffer_limit_max)
 	{
-		Logger log;
-		log.get(LOG_DEBUG) << "Script debug log: " << log_buffer;
+		Logger XComLog;
+		XComLog.get(LOG_DEBUG) << "Script debug XComLog: " << log_buffer;
 		log_buffer.clear();
 	}
 	else if (log_buffer_limit_count == log_buffer_limit_max)
 	{
-		Logger log;
-		log.get(LOG_DEBUG) << "Script debug log limit reach";
+		Logger XComLog;
+		XComLog.get(LOG_DEBUG) << "Script debug XComLog limit reach";
 		log_buffer.clear();
 	}
 }
@@ -741,7 +741,7 @@ bool callOverloadProc(ParserWriter& ph, const ScriptRange<ScriptProcData>& proc,
 		{
 			if ((*bestValue)(ph, begin, end) == false)
 			{
-				Log(LOG_ERROR) << "Error in matching arguments for operator '" + proc.begin()->name.toString() + "'";
+				XComLog(LOG_ERROR) << "Error in matching arguments for operator '" + proc.begin()->name.toString() + "'";
 				return false;
 			}
 			else
@@ -751,14 +751,14 @@ bool callOverloadProc(ParserWriter& ph, const ScriptRange<ScriptProcData>& proc,
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Conflicting overloads for operator '" + proc.begin()->name.toString() + "' for:";
-			Log(LOG_ERROR) << "  " << displayArgs(&ph.parser, ScriptRange<ScriptRefData>{ begin, end }, [](const ScriptRefData& r){ return r.type; });
-			Log(LOG_ERROR) << "Expected:";
+			XComLog(LOG_ERROR) << "Conflicting overloads for operator '" + proc.begin()->name.toString() + "' for:";
+			XComLog(LOG_ERROR) << "  " << displayArgs(&ph.parser, ScriptRange<ScriptRefData>{ begin, end }, [](const ScriptRefData& r){ return r.type; });
+			XComLog(LOG_ERROR) << "Expected:";
 			for (auto& p : proc)
 			{
 				if (p.parserArg != nullptr && p.overloadArg)
 				{
-					Log(LOG_ERROR) << "  " << displayOverloadProc(&ph.parser, p.overloadArg);
+					XComLog(LOG_ERROR) << "  " << displayOverloadProc(&ph.parser, p.overloadArg);
 				}
 			}
 			return false;
@@ -766,14 +766,14 @@ bool callOverloadProc(ParserWriter& ph, const ScriptRange<ScriptProcData>& proc,
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Can't match overload for operator '" + proc.begin()->name.toString() + "' for:";
-		Log(LOG_ERROR) << "  " << displayArgs(&ph.parser, ScriptRange<ScriptRefData>{ begin, end }, [](const ScriptRefData& r){ return r.type; });
-		Log(LOG_ERROR) << "Expected:";
+		XComLog(LOG_ERROR) << "Can't match overload for operator '" + proc.begin()->name.toString() + "' for:";
+		XComLog(LOG_ERROR) << "  " << displayArgs(&ph.parser, ScriptRange<ScriptRefData>{ begin, end }, [](const ScriptRefData& r){ return r.type; });
+		XComLog(LOG_ERROR) << "Expected:";
 		for (auto& p : proc)
 		{
 			if (p.parserArg != nullptr && p.overloadArg)
 			{
-				Log(LOG_ERROR) << "  " << displayOverloadProc(&ph.parser, p.overloadArg);
+				XComLog(LOG_ERROR) << "  " << displayOverloadProc(&ph.parser, p.overloadArg);
 			}
 		}
 		return false;
@@ -877,7 +877,7 @@ bool parseConditionImpl(ParserWriter& ph, ScriptRefData truePos, ScriptRefData f
 
 	if (std::distance(begin, end) != 3)
 	{
-		Log(LOG_ERROR) << "Invalid length of condition arguments";
+		XComLog(LOG_ERROR) << "Invalid length of condition arguments";
 		return false;
 	}
 
@@ -903,14 +903,14 @@ bool parseConditionImpl(ParserWriter& ph, ScriptRefData truePos, ScriptRefData f
 	}
 	if (i == ConditionSize)
 	{
-		Log(LOG_ERROR) << "Unknown condition: '" + begin[0].name.toString() + "'";
+		XComLog(LOG_ERROR) << "Unknown condition: '" + begin[0].name.toString() + "'";
 		return false;
 	}
 
 	const auto proc = ph.parser.getProc(ScriptRef{ equalFunc ? "test_eq" : "test_le" });
 	if (callOverloadProc(ph, proc, std::begin(conditionArgs), std::end(conditionArgs)) == false)
 	{
-		Log(LOG_ERROR) << "Unsupported operator: '" + begin[0].name.toString() + "'";
+		XComLog(LOG_ERROR) << "Unsupported operator: '" + begin[0].name.toString() + "'";
 		return false;
 	}
 
@@ -924,7 +924,7 @@ bool parseFullConditionImpl(ParserWriter& ph, ScriptRefData falsePos, const Scri
 {
 	if (std::distance(begin, end) <= 1)
 	{
-		Log(LOG_ERROR) << "Invalid length of condition arguments";
+		XComLog(LOG_ERROR) << "Invalid length of condition arguments";
 		return false;
 	}
 
@@ -964,7 +964,7 @@ bool parseVariableImpl(ParserWriter& ph, ScriptRefData reg, ScriptRefData val = 
 {
 	if (!ArgIsReg(reg.type))
 	{
-		Log(LOG_ERROR) << "Invalid register";
+		XComLog(LOG_ERROR) << "Invalid register";
 		return false;
 	}
 
@@ -1008,7 +1008,7 @@ bool parseElse(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData*
 {
 	if (ph.codeBlocks.back().type != BlockIf)
 	{
-		Log(LOG_ERROR) << "Unexpected 'else'";
+		XComLog(LOG_ERROR) << "Unexpected 'else'";
 		return false;
 	}
 
@@ -1039,7 +1039,7 @@ bool parseElse(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData*
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'else'";
+		XComLog(LOG_ERROR) << "Error in processing 'else'";
 		return false;
 	}
 }
@@ -1051,7 +1051,7 @@ bool parseBegin(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData
 {
 	if (std::distance(begin, end) != 0)
 	{
-		Log(LOG_ERROR) << "Unexpected symbols after 'begin'";
+		XComLog(LOG_ERROR) << "Unexpected symbols after 'begin'";
 		return false;
 	}
 
@@ -1067,12 +1067,12 @@ bool parseLoop(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData*
 {
 	if (std::distance(begin, end) != 3)
 	{
-		Log(LOG_ERROR) << "Unexpected symbols after 'loop'";
+		XComLog(LOG_ERROR) << "Unexpected symbols after 'loop'";
 		return false;
 	}
 	if (begin[0].name != ScriptRef{ "var" })
 	{
-		Log(LOG_ERROR) << "After 'loop' should be 'var'";
+		XComLog(LOG_ERROR) << "After 'loop' should be 'var'";
 		return false;
 	}
 
@@ -1120,7 +1120,7 @@ bool parseLoop(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData*
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'loop'";
+		XComLog(LOG_ERROR) << "Error in processing 'loop'";
 		return false;
 	}
 }
@@ -1150,14 +1150,14 @@ bool parseBreak(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData
 {
 	if (std::distance(begin, end) != 0)
 	{
-		Log(LOG_ERROR) << "Unexpected symbols after 'break'";
+		XComLog(LOG_ERROR) << "Unexpected symbols after 'break'";
 		return false;
 	}
 
 	auto* loopBlock = getTopBlockOfType(ph, BlockLoop);
 	if (!loopBlock)
 	{
-		Log(LOG_ERROR) << "Operation 'break' outside 'loop'";
+		XComLog(LOG_ERROR) << "Operation 'break' outside 'loop'";
 		return false;
 	}
 
@@ -1176,7 +1176,7 @@ bool parseBreak(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'break'";
+		XComLog(LOG_ERROR) << "Error in processing 'break'";
 		return false;
 	}
 }
@@ -1188,14 +1188,14 @@ bool parseContinue(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefD
 {
 	if (std::distance(begin, end) != 0)
 	{
-		Log(LOG_ERROR) << "Unexpected symbols after 'continue'";
+		XComLog(LOG_ERROR) << "Unexpected symbols after 'continue'";
 		return false;
 	}
 
 	auto* loopBlock = getTopBlockOfType(ph, BlockLoop);
 	if (!loopBlock)
 	{
-		Log(LOG_ERROR) << "Operation 'continue' outside 'loop'";
+		XComLog(LOG_ERROR) << "Operation 'continue' outside 'loop'";
 		return false;
 	}
 
@@ -1214,7 +1214,7 @@ bool parseContinue(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefD
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'continue'";
+		XComLog(LOG_ERROR) << "Error in processing 'continue'";
 		return false;
 	}
 }
@@ -1226,12 +1226,12 @@ bool parseEnd(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* 
 {
 	if (ph.codeBlocks.back().type == BlockMain)
 	{
-		Log(LOG_ERROR) << "Unexpected 'end'";
+		XComLog(LOG_ERROR) << "Unexpected 'end'";
 		return false;
 	}
 	if (std::distance(begin, end) != 0)
 	{
-		Log(LOG_ERROR) << "Unexpected symbols after 'end'";
+		XComLog(LOG_ERROR) << "Unexpected symbols after 'end'";
 		return false;
 	}
 
@@ -1273,7 +1273,7 @@ bool parseEnd(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* 
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'end'";
+		XComLog(LOG_ERROR) << "Error in processing 'end'";
 		return false;
 	}
 }
@@ -1300,7 +1300,7 @@ bool parseVar(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* 
 	auto size = std::distance(begin, end);
 	if (size < 2 || 3 < size)
 	{
-		Log(LOG_ERROR) << "Invalid length of 'var' definition";
+		XComLog(LOG_ERROR) << "Invalid length of 'var' definition";
 		return false;
 	}
 
@@ -1308,27 +1308,27 @@ bool parseVar(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* 
 	auto type_curr = ph.parser.getType(begin[0].name);
 	if (!type_curr)
 	{
-		Log(LOG_ERROR) << "Invalid type '" << begin[0].name.toString() << "'";
+		XComLog(LOG_ERROR) << "Invalid type '" << begin[0].name.toString() << "'";
 		return false;
 	}
 
 	if (type_curr->meta.size == 0 && !(spec & ArgSpecPtr))
 	{
-		Log(LOG_ERROR) << "Can't create variable of type '" << begin[0].name.toString() << "'";
+		XComLog(LOG_ERROR) << "Can't create variable of type '" << begin[0].name.toString() << "'";
 		return false;
 	}
 
 	++begin;
 	if (begin[0].type != ArgInvalid || !begin[0].name || begin[0].name.find('.') != std::string::npos)
 	{
-		Log(LOG_ERROR) << "Invalid variable name '" << begin[0].name.toString() << "'";
+		XComLog(LOG_ERROR) << "Invalid variable name '" << begin[0].name.toString() << "'";
 		return false;
 	}
 
 	auto reg = ph.addReg(begin[0].name, ArgSpecAdd(type_curr->type, spec));
 	if (!reg)
 	{
-		Log(LOG_ERROR) << "Invalid type for variable '" << begin[0].name.toString() << "'";
+		XComLog(LOG_ERROR) << "Invalid type for variable '" << begin[0].name.toString() << "'";
 		return false;
 	}
 
@@ -1351,7 +1351,7 @@ bool parseVar(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* 
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Error in processing 'end'";
+		XComLog(LOG_ERROR) << "Error in processing 'end'";
 		return false;
 	}
 }
@@ -1365,7 +1365,7 @@ bool parseReturn(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefDat
 	const auto returnSize = ph.parser.haveEmptyReturn() ? 0 : ph.parser.getParamSize();
 	if (returnSize != size)
 	{
-		Log(LOG_ERROR) << "Invalid length of returns arguments";
+		XComLog(LOG_ERROR) << "Invalid length of returns arguments";
 		return false;
 	}
 
@@ -1378,7 +1378,7 @@ bool parseReturn(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefDat
 		outputRegsData[i] = *ph.parser.getParamData(i);
 		if (begin[i].isValueType<RegEnum>() && !ArgCompatible(outputRegsData[i].type, begin[i].type, 1))
 		{
-			Log(LOG_ERROR) << "Invalid return argument '" + begin[i].name.toString() + "'";
+			XComLog(LOG_ERROR) << "Invalid return argument '" + begin[i].name.toString() + "'";
 			return false;
 		}
 		currValueIndex[i] = outputRegsData[i].getValue<RegEnum>();
@@ -1422,7 +1422,7 @@ bool parseReturn(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefDat
 				const auto proc = ph.parser.getProc(ScriptRef{ "set" });
 				if (!callOverloadProc(ph, proc, std::begin(temp), std::end(temp)))
 				{
-					Log(LOG_ERROR) << "Invalid return argument '" + begin[i].name.toString() + "'";
+					XComLog(LOG_ERROR) << "Invalid return argument '" + begin[i].name.toString() + "'";
 					return false;
 				}
 			}
@@ -1485,7 +1485,7 @@ bool parseDebugLog(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefD
 		const auto proc = ph.parser.getProc(ScriptRef{ "debug_impl" });
 		if (!callOverloadProc(ph, proc, i, std::next(i)))
 		{
-			Log(LOG_ERROR) << "Invalid debug argument '" + i->name.toString() + "'";
+			XComLog(LOG_ERROR) << "Invalid debug argument '" + i->name.toString() + "'";
 			return false;
 		}
 	}
@@ -1499,7 +1499,7 @@ bool parseDebugLog(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefD
  */
 bool parseDummy(const ScriptProcData& spd, ParserWriter& ph, const ScriptRefData* begin, const ScriptRefData* end)
 {
-	Log(LOG_ERROR) << "Reserved operation for future use";
+	XComLog(LOG_ERROR) << "Reserved operation for future use";
 	return false;
 }
 
@@ -2398,16 +2398,16 @@ ParserWriter::Block ParserWriter::popScopeBlock()
 	return prev;
 }
 
-/// Dump to log error info about ref.
+/// Dump to XComLog error info about ref.
 void ParserWriter::logDump(const ScriptRefData& ref) const
 {
 	if (ref)
 	{
-		Log(LOG_ERROR) << "Incorrect type of argument '"<< ref.name.toString() <<"' of type "<< displayType(&parser, ref.type);
+		XComLog(LOG_ERROR) << "Incorrect type of argument '"<< ref.name.toString() <<"' of type "<< displayType(&parser, ref.type);
 	}
 	else
 	{
-		Log(LOG_ERROR) << "Unknown argument '"<< ref.name.toString() <<"'";
+		XComLog(LOG_ERROR) << "Unknown argument '"<< ref.name.toString() <<"'";
 	}
 }
 
@@ -2799,18 +2799,18 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 //			{
 //				if (i->type == ArgLabel && help.refLabels.getValue(i->value) == ProgPos::Unknown)
 //				{
-//					Log(LOG_ERROR) << err << "invalid use of label: '" << i->name.toString() << "' without declaration";
+//					XComLog(LOG_ERROR) << err << "invalid use of label: '" << i->name.toString() << "' without declaration";
 //					return false;
 //				}
 //			}
 			if (help.codeBlocks.size() > 1)
 			{
-				Log(LOG_ERROR) << err << "script have missed 'end;'";
+				XComLog(LOG_ERROR) << err << "script have missed 'end;'";
 				return false;
 			}
 			if (!haveLastReturn)
 			{
-				Log(LOG_ERROR) << err << "script need to end with return statement";
+				XComLog(LOG_ERROR) << err << "script need to end with return statement";
 				return false;
 			}
 			help.relese();
@@ -2836,7 +2836,7 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 			auto first_dot = op.find('.');
 			if (first_dot == std::string::npos)
 			{
-				Log(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
+				XComLog(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
 				return false;
 			}
 
@@ -2844,16 +2844,16 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 			auto ref = help.getReferece(temp);
 			if (!ref)
 			{
-				Log(LOG_ERROR) << "Unknown variable name '" << temp.toString() << "'";
-				Log(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
+				XComLog(LOG_ERROR) << "Unknown variable name '" << temp.toString() << "'";
+				XComLog(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
 				return false;
 			}
 
 			auto name = getTypeName(ref.type);
 			if (ref.type < ArgMax || !name)
 			{
-				Log(LOG_ERROR) << "Unsupported type for variable '" << ref.name.toString() << "'";
-				Log(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
+				XComLog(LOG_ERROR) << "Unsupported type for variable '" << ref.name.toString() << "'";
+				XComLog(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
 				return false;
 			}
 
@@ -2861,8 +2861,8 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 			op_curr = getProc(name, name_end);
 			if (!op_curr)
 			{
-				Log(LOG_ERROR) << "Unknown operation name '" << name.toString() << name_end.toString() << "' for variable '" << ref.name.toString() << "'";
-				Log(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
+				XComLog(LOG_ERROR) << "Unknown operation name '" << name.toString() << name_end.toString() << "' for variable '" << ref.name.toString() << "'";
+				XComLog(LOG_ERROR) << err << "invalid operation '" << op.toString() << "'";
 				return false;
 			}
 
@@ -2899,7 +2899,7 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 
 			if (args[ScriptMaxArg - 1].getType() != TokenNone)
 			{
-				Log(LOG_ERROR) << err << "too many arguments in line: '" << std::string(line_begin, line_end) << "'";
+				XComLog(LOG_ERROR) << err << "too many arguments in line: '" << std::string(line_begin, line_end) << "'";
 				return false;
 			}
 
@@ -2907,12 +2907,12 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 			{
 				if (args[i].getType() == TokenInvalid)
 				{
-					Log(LOG_ERROR) << err << "invalid argument '"<<  args[i].toString() <<"' in line: '" << std::string(line_begin, line_end) << "'";
+					XComLog(LOG_ERROR) << err << "invalid argument '"<<  args[i].toString() <<"' in line: '" << std::string(line_begin, line_end) << "'";
 					return false;
 				}
 			}
 
-			Log(LOG_ERROR) << err << "invalid line: '" << std::string(line_begin, line_end) << "'";
+			XComLog(LOG_ERROR) << err << "invalid line: '" << std::string(line_begin, line_end) << "'";
 			return false;
 		}
 
@@ -2928,17 +2928,17 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 
 		if (haveLastReturn && !isEnd)
 		{
-			Log(LOG_ERROR) << err << "unreachable line after return: '" << line.toString() << "'";
+			XComLog(LOG_ERROR) << err << "unreachable line after return: '" << line.toString() << "'";
 			return false;
 		}
 		if (haveCodeNormal && isVarDef)
 		{
-			Log(LOG_ERROR) << err << "invalid variable definition after other operations: '" << line.toString() << "'";
+			XComLog(LOG_ERROR) << err << "invalid variable definition after other operations: '" << line.toString() << "'";
 			return false;
 		}
 		if (label && isVarDef)
 		{
-			Log(LOG_ERROR) << err << "label can't be before variable definition: '" << line.toString() << "'";
+			XComLog(LOG_ERROR) << err << "label can't be before variable definition: '" << line.toString() << "'";
 			return false;
 		}
 
@@ -2956,14 +2956,14 @@ bool ScriptParserBase::parseBase(ScriptContainerBase& destScript, const std::str
 
 		if (label && !help.setLabel(label.parse(help), help.getCurrPos()))
 		{
-			Log(LOG_ERROR) << err << "invalid label '"<< label.toString() <<"' in line: '" << line.toString() << "'";
+			XComLog(LOG_ERROR) << err << "invalid label '"<< label.toString() <<"' in line: '" << line.toString() << "'";
 			return false;
 		}
 
 		// create normal proc call
 		if (callOverloadProc(help, op_curr, argData, argData+i) == false)
 		{
-			Log(LOG_ERROR) << err << "invalid operation in line: '" << line.toString() << "'";
+			XComLog(LOG_ERROR) << err << "invalid operation in line: '" << line.toString() << "'";
 			return false;
 		}
 	}
@@ -3243,7 +3243,7 @@ void ScriptParserEventsBase::load(const YAML::Node& scripts)
 				}
 				else
 				{
-					Log(LOG_WARNING) << "Unknown script name '" + name  + "' for " + getDescriptionNode(deleteNode);
+					XComLog(LOG_WARNING) << "Unknown script name '" + name  + "' for " + getDescriptionNode(deleteNode);
 				}
 			}
 			else
@@ -3256,7 +3256,7 @@ void ScriptParserEventsBase::load(const YAML::Node& scripts)
 				if (offset == 0 || offset >= (int)OffsetMax || offset <= -(int)OffsetMax)
 				{
 					//TODO make it a exception
-					Log(LOG_ERROR) << "Invalid offset for '" << getName() << "' equal: '" << i["offset"].as<std::string>() << "'";
+					XComLog(LOG_ERROR) << "Invalid offset for '" << getName() << "' equal: '" << i["offset"].as<std::string>() << "'";
 					continue;
 				}
 
@@ -3278,7 +3278,7 @@ void ScriptParserEventsBase::load(const YAML::Node& scripts)
 					}
 					else
 					{
-						Log(LOG_WARNING) << "Unknown script name '" + name  + "' for " + getDescriptionNode(updateNode);
+						XComLog(LOG_WARNING) << "Unknown script name '" + name  + "' for " + getDescriptionNode(updateNode);
 					}
 				}
 				else if (haveNode(overrideNode))
@@ -3343,7 +3343,7 @@ std::vector<ScriptContainerBase> ScriptParserEventsBase::releseEvents()
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Error in script parser '" << getName() << "': global script limit reach";
+			XComLog(LOG_ERROR) << "Error in script parser '" << getName() << "': global script limit reach";
 			if (reservedSpaceForZero)
 			{
 				_events.emplace_back();
@@ -3407,7 +3407,7 @@ void ScriptValuesBase::loadBase(const YAML::Node &node, const ScriptGlobal* shar
 				}
 				else
 				{
-					Log(LOG_ERROR) << "Error in tags: '" << pair.first << "' unknown tag name not defined in current file";
+					XComLog(LOG_ERROR) << "Error in tags: '" << pair.first << "' unknown tag name not defined in current file";
 				}
 			}
 		}
@@ -3678,7 +3678,7 @@ void ScriptGlobal::load(const YAML::Node& node)
 						auto ref = getRef(ScriptRef::tempFrom(namePrefix));
 						if (ref && ref->type != p.first)
 						{
-							Log(LOG_ERROR) << "Script variable '" + name + "' already used in '" + _tagNames[ref->type].name.toString() + "'.";
+							XComLog(LOG_ERROR) << "Script variable '" + name + "' already used in '" + _tagNames[ref->type].name.toString() + "'.";
 							continue;
 						}
 						auto tag = getTag(p.first, ScriptRef::tempFrom(namePrefix));
@@ -3687,20 +3687,20 @@ void ScriptGlobal::load(const YAML::Node& node)
 							auto data = getTagValueData(p.first, tag);
 							if (valueType != data.valueType)
 							{
-								Log(LOG_ERROR) << "Script variable '" + name + "' have wrong type '" << _tagValueTypes[valueType].name.toString() << "' instead of '" << _tagValueTypes[data.valueType].name.toString() << "' in '" + nodeName + "'.";
+								XComLog(LOG_ERROR) << "Script variable '" + name + "' have wrong type '" << _tagValueTypes[valueType].name.toString() << "' instead of '" << _tagValueTypes[data.valueType].name.toString() << "' in '" + nodeName + "'.";
 							}
 							continue;
 						}
 						tag = addTag(p.first, addNameRef(namePrefix), valueType);
 						if (!tag)
 						{
-							Log(LOG_ERROR) << "Script variable '" + name + "' exceeds limit of " << (int)p.second.limit << " available variables in '" + nodeName + "'.";
+							XComLog(LOG_ERROR) << "Script variable '" + name + "' exceeds limit of " << (int)p.second.limit << " available variables in '" + nodeName + "'.";
 							continue;
 						}
 					}
 					else
 					{
-						Log(LOG_ERROR) << "Invalid type def '" + type + "' for script variable '" + name + "' in '" + nodeName +"'.";
+						XComLog(LOG_ERROR) << "Invalid type def '" + type + "' for script variable '" + name + "' in '" + nodeName +"'.";
 					}
 				}
 			}

--- a/src/Engine/Script.h
+++ b/src/Engine/Script.h
@@ -723,9 +723,9 @@ public:
 		return ret;
 	}
 
-	/// Add text to log buffer.
+	/// Add text to XComLog buffer.
 	void log_buffer_add(FuncRef<std::string()> func);
-	/// Flush buffer to log file.
+	/// Flush buffer to XComLog file.
 	void log_buffer_flush(ProgPos& p);
 };
 

--- a/src/Engine/ScriptBind.h
+++ b/src/Engine/ScriptBind.h
@@ -262,7 +262,7 @@ struct ParserWriter
 
 
 
-	/// Dump to log error info about ref.
+	/// Dump to XComLog error info about ref.
 	void logDump(const ScriptRefData&) const;
 
 }; //struct ParserWriter
@@ -369,7 +369,7 @@ struct Arg<A1, A2...> : public Arg<A2...>
 	{
 		if (*begin == end)
 		{
-			Log(LOG_ERROR) << "Not enough args in operation";
+			XComLog(LOG_ERROR) << "Not enough args in operation";
 			return -1;
 		}
 		else
@@ -538,7 +538,7 @@ struct ArgColection<MaxSize>
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Too many args in operation";
+			XComLog(LOG_ERROR) << "Too many args in operation";
 			return -1;
 		}
 	}

--- a/src/Engine/Sound.cpp
+++ b/src/Engine/Sound.cpp
@@ -48,7 +48,7 @@ void Sound::load(const std::string &filename) {
 	auto s = NewSound(Mix_LoadWAV_RW(rw, SDL_TRUE));
 	if (!s)
 	{
-		Log(LOG_ERROR) << "Sound::load(" << filename << "): mix error=" << Mix_GetError();
+		XComLog(LOG_ERROR) << "Sound::load(" << filename << "): mix error=" << Mix_GetError();
 	}
 
 	//always overwrite
@@ -63,7 +63,7 @@ void Sound::load(SDL_RWops *rw) {
 	auto s = NewSound(Mix_LoadWAV_RW(rw, SDL_TRUE));
 	if (!s)
 	{
-		Log(LOG_ERROR) << "Sound::load(data): mix error=" << Mix_GetError();
+		XComLog(LOG_ERROR) << "Sound::load(data): mix error=" << Mix_GetError();
 	}
 
 	//always overwrite
@@ -81,13 +81,13 @@ void Sound::play(int channel, int angle, int distance) const
 		int chan = Mix_PlayChannel(channel, _sound.get(), 0);
 		if (chan == -1)
 		{
-			Log(LOG_WARNING) << Mix_GetError();
+			XComLog(LOG_WARNING) << Mix_GetError();
 		}
 		else if (Options::StereoSound)
 		{
 			if (!Mix_SetPosition(chan, angle, distance))
 			{
-				Log(LOG_WARNING) << Mix_GetError();
+				XComLog(LOG_WARNING) << Mix_GetError();
 			}
 		}
 	}
@@ -114,7 +114,7 @@ void Sound::loop()
 		int chan = Mix_PlayChannel(3, _sound.get(), -1);
 		if (chan == -1)
 		{
-			Log(LOG_WARNING) << Mix_GetError();
+			XComLog(LOG_WARNING) << Mix_GetError();
 		}
 	}
 }

--- a/src/Engine/SoundSet.cpp
+++ b/src/Engine/SoundSet.cpp
@@ -175,7 +175,7 @@ void SoundSet::loadCatByIndex(CatFile &catFile, int index, bool tftd)
 	_sounds[set_index] = Sound(); // in case everything else fails, an empty Sound.
 	auto rwops = catFile.getRWops(index);
 	if (!rwops) {
-		Log(LOG_VERBOSE) << "SoundSet::loadCatByIndex(" << catFile.fileName() << ", " << index << "): got NULL.";
+		XComLog(LOG_VERBOSE) << "SoundSet::loadCatByIndex(" << catFile.fileName() << ", " << index << "): got NULL.";
 		return;
 	}
 	int namesize = SDL_ReadU8(rwops);
@@ -193,7 +193,7 @@ void SoundSet::loadCatByIndex(CatFile &catFile, int index, bool tftd)
 
 	// Skip short data
 	if (size < 12) {
-		Log(LOG_VERBOSE) << "SoundSet::loadCatByIndex(" << catFile.fileName() << ", " << index << ") size=" << size <<" , skipping.";
+		XComLog(LOG_VERBOSE) << "SoundSet::loadCatByIndex(" << catFile.fileName() << ", " << index << ") size=" << size <<" , skipping.";
 		SDL_free(sound);
 		return;
 	}

--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -366,7 +366,7 @@ void Surface::loadImage(const std::string &filename)
 	_alignedBuffer = nullptr;
 	_surface = nullptr;
 
-	Log(LOG_VERBOSE) << "Loading image: " << filename;
+	XComLog(LOG_VERBOSE) << "Loading image: " << filename;
 	auto rw = FileMap::getRWops(filename);
 	if (!rw) { return; } // relevant message gets logged in FileMap.
 
@@ -416,11 +416,11 @@ void Surface::loadImage(const std::string &filename)
 					FixTransparent(_surface, transparent);
 					if (transparent != 0)
 					{
-						Log(LOG_WARNING) << "Image " << filename << " (from lodepng) has incorrect transparent color index " << transparent << " (instead of 0).";
+						XComLog(LOG_WARNING) << "Image " << filename << " (from lodepng) has incorrect transparent color index " << transparent << " (instead of 0).";
 					}
 				}
 			} else {
-				Log(LOG_ERROR) << "Image " << filename << " lodepng failed:" << lodepng_error_text(error);
+				XComLog(LOG_ERROR) << "Image " << filename << " lodepng failed:" << lodepng_error_text(error);
 			}
 		}
 		if (data) { SDL_free(data); }
@@ -450,7 +450,7 @@ void Surface::loadImage(const std::string &filename)
 		FixTransparent(_surface, surface->format->colorkey);
 		if (surface->format->colorkey != 0)
 		{
-			Log(LOG_WARNING) << "Image " << filename << " (from SDL) has incorrect transparent color index " << surface->format->colorkey << " (instead of 0).";
+			XComLog(LOG_WARNING) << "Image " << filename << " (from SDL) has incorrect transparent color index " << surface->format->colorkey << " (instead of 0).";
 		}
 	}
 }

--- a/src/Engine/Unicode.cpp
+++ b/src/Engine/Unicode.cpp
@@ -78,14 +78,14 @@ void getUtf8Locale()
 	// Try a UTF-8 locale (or default if none was found)
 	try
 	{
-		Log(LOG_INFO) << "Attempted locale: " << loc.c_str();
+		XComLog(LOG_INFO) << "Attempted locale: " << loc.c_str();
 		utf8 = std::locale(loc.c_str());
 	}
 	catch (const std::runtime_error &)
 	{
 		// Well we're stuck with the C locale, hope for the best
 	}
-	Log(LOG_INFO) << "Detected locale: " << utf8.name();
+	XComLog(LOG_INFO) << "Detected locale: " << utf8.name();
 }
 
 /**

--- a/src/Engine/Zoom.cpp
+++ b/src/Engine/Zoom.cpp
@@ -84,7 +84,7 @@ static int zoomSurface2X_64bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using somewhat fast 2X zoom routine.";
+		XComLog(LOG_INFO) << "Using somewhat fast 2X zoom routine.";
 	}
 
 	for (sy = 0; sy < src->h; ++sy, pixelDstRow += dst->pitch*2)
@@ -159,7 +159,7 @@ static int zoomSurface2X_32bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using 32-bit 2X zoom routine.";
+		XComLog(LOG_INFO) << "Using 32-bit 2X zoom routine.";
 	}
 
 
@@ -222,7 +222,7 @@ static int zoomSurface4X_64bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using modestly fast 4X zoom routine.";
+		XComLog(LOG_INFO) << "Using modestly fast 4X zoom routine.";
 	}
 
 	for (sy = 0; sy < src->h; ++sy, pixelDstRow += dst->pitch*4)
@@ -290,7 +290,7 @@ static int zoomSurface4X_32bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using 32-bit 4X zoom routine.";
+		XComLog(LOG_INFO) << "Using 32-bit 4X zoom routine.";
 	}
 
 	for (sy = 0; sy < src->h; ++sy, pixelDstRow += dst->pitch*4)
@@ -357,7 +357,7 @@ static int zoomSurface2X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using mediocre scaling routine due to screen height.";
+		XComLog(LOG_INFO) << "Using mediocre scaling routine due to screen height.";
 	}
 
 	if ((say = (Uint32 *) realloc(say, (dst->h + 1) * sizeof(Uint32))) == NULL) {
@@ -445,7 +445,7 @@ static int zoomSurface4X_XAxis_32bit(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using mediocre scaling routine due to screen height.";
+		XComLog(LOG_INFO) << "Using mediocre scaling routine due to screen height.";
 	}
 
 	if ((say = (Uint32 *) realloc(say, (dst->h + 1) * sizeof(Uint32))) == NULL) {
@@ -528,7 +528,7 @@ static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using SSE2 4X zoom routine.";
+		XComLog(LOG_INFO) << "Using SSE2 4X zoom routine.";
 	}
 
 	for (sy = 0; sy < src->h; ++sy, pixelDstRow += dst->pitch*4)
@@ -544,7 +544,7 @@ static int zoomSurface4X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 			__m128i halfDone = _mm_unpacklo_epi8(dataSrc, dataSrc);
 			dataDst = _mm_unpacklo_epi8(halfDone, halfDone);
  */
-/* #define WRITE_DST if ((char*)pixelDst4 + 128 > (char*)dst->pixels+(dst->w*dst->pitch)) { Log(LOG_ERROR) << "HELL"; exit(0); } \ */
+/* #define WRITE_DST if ((char*)pixelDst4 + 128 > (char*)dst->pixels+(dst->w*dst->pitch)) { XComLog(LOG_ERROR) << "HELL"; exit(0); } \ */
 #define WRITE_DST			*(pixelDst++) = dataDst; \
 			*(pixelDst2++) = dataDst; \
 			*(pixelDst3++) = dataDst; \
@@ -596,7 +596,7 @@ static int zoomSurface2X_SSE2(SDL_Surface *src, SDL_Surface *dst)
 	if (!proclaimed)
 	{
 		proclaimed = true;
-		Log(LOG_INFO) << "Using SSE2 2X zoom routine.";
+		XComLog(LOG_INFO) << "Using SSE2 2X zoom routine.";
 	}
 
 	for (sy = 0; sy < src->h; ++sy, pixelDstRow += dst->pitch*2)
@@ -810,7 +810,7 @@ int Zoom::_zoomSurfaceY(SDL_Surface * src, SDL_Surface * dst, int flipx, int fli
 			if (!complained)
 			{
 				complained = true;
-				Log(LOG_ERROR) << "Misaligned surface buffers.";
+				XComLog(LOG_ERROR) << "Misaligned surface buffers.";
 			}
 		}
 #endif
@@ -839,7 +839,7 @@ int Zoom::_zoomSurfaceY(SDL_Surface * src, SDL_Surface * dst, int flipx, int fli
 	*/
 	if (!proclaimed)
 	{
-		Log(LOG_INFO) << "Using software scaling routine. For best results, try an OpenGL filter.";
+		XComLog(LOG_INFO) << "Using software scaling routine. For best results, try an OpenGL filter.";
 		proclaimed = true;
 	}
 

--- a/src/Menu/CutsceneState.cpp
+++ b/src/Menu/CutsceneState.cpp
@@ -86,7 +86,7 @@ void CutsceneState::init()
 	}
 	else
 	{
-		Log(LOG_WARNING) << "cutscene definition empty: " << _cutsceneId;
+		XComLog(LOG_WARNING) << "cutscene definition empty: " << _cutsceneId;
 	}
 }
 

--- a/src/Menu/ListGamesState.cpp
+++ b/src/Menu/ListGamesState.cpp
@@ -185,7 +185,7 @@ void ListGamesState::init()
 	}
 	catch (Exception &e)
 	{
-		Log(LOG_ERROR) << e.what();
+		XComLog(LOG_ERROR) << e.what();
 	}
 }
 

--- a/src/Menu/LoadGameState.cpp
+++ b/src/Menu/LoadGameState.cpp
@@ -226,7 +226,7 @@ void LoadGameState::think()
 void LoadGameState::error(const std::string &msg, SavedGame *save)
 {
 
-	Log(LOG_ERROR) << msg;
+	XComLog(LOG_ERROR) << msg;
 	std::ostringstream error;
 	error << tr("STR_LOAD_UNSUCCESSFUL") << Unicode::TOK_NL_SMALL << msg;
 	if (_origin != OPT_BATTLESCAPE)

--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -178,13 +178,13 @@ MainMenuState::MainMenuState(bool updateCheck)
 						}
 						catch (YAML::Exception &e)
 						{
-							Log(LOG_ERROR) << e.what();
+							XComLog(LOG_ERROR) << e.what();
 						}
 					}
 				}
 			}
 		}
-		Log(LOG_INFO) << "Update check status: " << checkProgress << "; newVersion: v" << _newVersion << "; ";
+		XComLog(LOG_INFO) << "Update check status: " << checkProgress << "; newVersion: v" << _newVersion << "; ";
 	}
 #endif
 
@@ -201,7 +201,7 @@ void MainMenuState::init()
 	State::init();
 	if (Options::getLoadLastSave() && _game->getSavedGame()->getList(_game->getLanguage(), true).size() > 0)
 	{
-		Log(LOG_INFO) << "Loading last saved game";
+		XComLog(LOG_INFO) << "Loading last saved game";
 		btnLoadClick(NULL);
 	}
 }
@@ -318,7 +318,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(exeFilenameFullPath))
 	{
 		if (CrossPlatform::copyFile(exeFilenameFullPath, exeFilenameFullPath + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 0 done.";
+			XComLog(LOG_INFO) << "Update step 0 done.";
 		else return;
 	}
 
@@ -326,7 +326,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(commonDirFilename))
 	{
 		if (CrossPlatform::moveFile(commonDirFilename, commonDirFilename + "-" + now))
-			Log(LOG_INFO) << "Update step 1 done.";
+			XComLog(LOG_INFO) << "Update step 1 done.";
 		else return;
 	}
 
@@ -334,7 +334,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(commonZipFilename))
 	{
 		if (CrossPlatform::moveFile(commonZipFilename, commonZipFilename + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 2 done.";
+			XComLog(LOG_INFO) << "Update step 2 done.";
 		else return;
 	}
 
@@ -342,7 +342,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(standardDirFilename))
 	{
 		if (CrossPlatform::moveFile(standardDirFilename, standardDirFilename + "-" + now))
-			Log(LOG_INFO) << "Update step 3 done.";
+			XComLog(LOG_INFO) << "Update step 3 done.";
 		else return;
 	}
 
@@ -350,7 +350,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(standardZipFilename))
 	{
 		if (CrossPlatform::moveFile(standardZipFilename, standardZipFilename + "-" + now + ".bak"))
-			Log(LOG_INFO) << "Update step 4 done.";
+			XComLog(LOG_INFO) << "Update step 4 done.";
 		else return;
 	}
 
@@ -358,7 +358,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(exeZipFilename))
 	{
 		if (CrossPlatform::deleteFile(exeZipFilename))
-			Log(LOG_INFO) << "Update step 5 done.";
+			XComLog(LOG_INFO) << "Update step 5 done.";
 		else return;
 	}
 
@@ -366,28 +366,28 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(exeNewFilename))
 	{
 		if (CrossPlatform::deleteFile(exeNewFilename))
-			Log(LOG_INFO) << "Update step 6 done.";
+			XComLog(LOG_INFO) << "Update step 6 done.";
 		else return;
 	}
 
 	// 7. download common zip
 	if (CrossPlatform::downloadFile(commonZipUrl, commonZipFilename))
 	{
-		Log(LOG_INFO) << "Update step 7 done.";
+		XComLog(LOG_INFO) << "Update step 7 done.";
 	}
 	else return;
 
 	// 8. download standard zip
 	if (CrossPlatform::downloadFile(standardZipUrl, standardZipFilename))
 	{
-		Log(LOG_INFO) << "Update step 8 done.";
+		XComLog(LOG_INFO) << "Update step 8 done.";
 	}
 	else return;
 
 	// 9. download exe zip
 	if (CrossPlatform::downloadFile(exeZipUrl, exeZipFilename))
 	{
-		Log(LOG_INFO) << "Update step 9 done.";
+		XComLog(LOG_INFO) << "Update step 9 done.";
 	}
 	else return;
 
@@ -397,38 +397,38 @@ void MainMenuState::btnUpdateClick(Action*)
 		const std::string file_to_extract = "OpenXcomEx.exe.new";
 		SDL_RWops *rwo_read = FileMap::zipGetFileByName(relativeExeZipFileName, file_to_extract);
 		if (!rwo_read) {
-			Log(LOG_ERROR) << "Step 10a: failed to unzip file.";
+			XComLog(LOG_ERROR) << "Step 10a: failed to unzip file.";
 			return;
 		}
 		size_t size = 0;
 		auto data = SDL_LoadFile_RW(rwo_read, &size, SDL_TRUE);
 		if (!data) {
-			Log(LOG_ERROR) << "Step 10b: failed to unzip file." << SDL_GetError(); // out of memory for a copy ?
+			XComLog(LOG_ERROR) << "Step 10b: failed to unzip file." << SDL_GetError(); // out of memory for a copy ?
 			return;
 		}
 		SDL_RWops *rwo_write = SDL_RWFromFile(relativeExeNewFileName.c_str(), "wb");
 		if (!rwo_write) {
-			Log(LOG_ERROR) << "Step 10c: failed to open exe.new file for writing." << SDL_GetError();
+			XComLog(LOG_ERROR) << "Step 10c: failed to open exe.new file for writing." << SDL_GetError();
 			return;
 		}
 		auto wsize = SDL_RWwrite(rwo_write, data, size, 1);
 		if (wsize != 1) {
-			Log(LOG_ERROR) << "Step 10d: failed to write exe.new file." << SDL_GetError();
+			XComLog(LOG_ERROR) << "Step 10d: failed to write exe.new file." << SDL_GetError();
 			return;
 		}
 		if (SDL_RWclose(rwo_write)) {
-			Log(LOG_ERROR) << "Step 10e: failed to write exe.new file." << SDL_GetError();
+			XComLog(LOG_ERROR) << "Step 10e: failed to write exe.new file." << SDL_GetError();
 			return;
 		}
 	} else {
-		Log(LOG_ERROR) << "Update step 10 failed."; // exe dir and working dir not the same
+		XComLog(LOG_ERROR) << "Update step 10 failed."; // exe dir and working dir not the same
 		return;
 	}
 
 	// 11. check if extracted exe exists
 	if (!CrossPlatform::fileExists(exeNewFilename))
 	{
-		Log(LOG_ERROR) << "Update step 11 failed.";
+		XComLog(LOG_ERROR) << "Update step 11 failed.";
 		return;
 	}
 
@@ -436,7 +436,7 @@ void MainMenuState::btnUpdateClick(Action*)
 	if (CrossPlatform::fileExists(exeZipFilename))
 	{
 		if (CrossPlatform::deleteFile(exeZipFilename))
-			Log(LOG_INFO) << "Update step 12 done.";
+			XComLog(LOG_INFO) << "Update step 12 done.";
 		else return;
 	}
 
@@ -470,7 +470,7 @@ void MainMenuState::btnUpdateClick(Action*)
 		// do nothing
 	}
 
-	Log(LOG_INFO) << "Update prepared, restarting.";
+	XComLog(LOG_INFO) << "Update prepared, restarting.";
 	_game->setUpdateFlag(true);
 	_game->quit();
 #endif

--- a/src/Menu/NewBattleState.cpp
+++ b/src/Menu/NewBattleState.cpp
@@ -404,7 +404,7 @@ void NewBattleState::load(const std::string &filename)
 		}
 		catch (YAML::Exception &e)
 		{
-			Log(LOG_WARNING) << e.what();
+			XComLog(LOG_WARNING) << e.what();
 			initSave();
 		}
 	}
@@ -431,7 +431,7 @@ void NewBattleState::save(const std::string &filename)
 	std::string filepath = Options::getMasterUserFolder() + filename + ".cfg";
 	if (!CrossPlatform::writeFile(filepath, out.c_str()))
 	{
-		Log(LOG_WARNING) << "Failed to save " << filepath;
+		XComLog(LOG_WARNING) << "Failed to save " << filepath;
 		return;
 	}
 }

--- a/src/Menu/OptionsVideoState.cpp
+++ b/src/Menu/OptionsVideoState.cpp
@@ -99,7 +99,7 @@ OptionsVideoState::OptionsVideoState(OptionsOrigin origin) : OptionsBaseState(or
 		_resAmount = 0;
 		_btnDisplayResolutionDown->setVisible(false);
 		_btnDisplayResolutionUp->setVisible(false);
-		Log(LOG_WARNING) << "Couldn't get display resolutions";
+		XComLog(LOG_WARNING) << "Couldn't get display resolutions";
 	}
 
 	add(_displaySurface);

--- a/src/Menu/SaveGameState.cpp
+++ b/src/Menu/SaveGameState.cpp
@@ -210,7 +210,7 @@ void SaveGameState::think()
  */
 void SaveGameState::error(const std::string &msg)
 {
-	Log(LOG_ERROR) << msg;
+	XComLog(LOG_ERROR) << msg;
 	std::ostringstream error;
 	error << tr("STR_SAVE_UNSUCCESSFUL") << Unicode::TOK_NL_SMALL << msg;
 	if (_origin != OPT_BATTLESCAPE)

--- a/src/Menu/StartState.cpp
+++ b/src/Menu/StartState.cpp
@@ -173,7 +173,7 @@ void StartState::think()
 		break;
 	case LOADING_SUCCESSFUL:
 		CrossPlatform::flashWindow();
-		Log(LOG_INFO) << "OpenXcom started successfully!";
+		XComLog(LOG_INFO) << "OpenXcom started successfully!";
 		_game->setState(new GoToMainMenuState(true));
 		if (_oldMaster != Options::getActiveMaster() && Options::playIntro)
 		{
@@ -305,19 +305,19 @@ int StartState::load(void *game_ptr)
 	Game *game = (Game*)game_ptr;
 	try
 	{
-		Log(LOG_INFO) << "Loading data...";
+		XComLog(LOG_INFO) << "Loading data...";
 		Options::updateMods();
 		game->loadMods();
-		Log(LOG_INFO) << "Data loaded successfully.";
-		Log(LOG_INFO) << "Loading language...";
+		XComLog(LOG_INFO) << "Data loaded successfully.";
+		XComLog(LOG_INFO) << "Loading language...";
 		game->loadLanguages();
-		Log(LOG_INFO) << "Language loaded successfully.";
+		XComLog(LOG_INFO) << "Language loaded successfully.";
 		loading = LOADING_SUCCESSFUL;
 	}
 	catch (std::exception &e)
 	{
 		error = e.what();
-		Log(LOG_ERROR) << error;
+		XComLog(LOG_ERROR) << error;
 		loading = LOADING_FAILED;
 	}
 

--- a/src/Menu/TestState.cpp
+++ b/src/Menu/TestState.cpp
@@ -271,14 +271,14 @@ void TestState::testCase4()
 	terrainMap.erase("globeTerrain");
 
 	// 1. check terrain existence in ruleset
-	Log(LOG_INFO) << "----------------------------------------------1. check terrain existence in ruleset";
+	XComLog(LOG_INFO) << "----------------------------------------------1. check terrain existence in ruleset";
 	for (auto &pair : terrainMap)
 	{
 		RuleTerrain *tRule = _game->getMod()->getTerrain(pair.first);
 		if (!tRule)
 		{
 			++total;
-			Log(LOG_INFO) << "Terrain '" << pair.first << "' does not exist!";
+			XComLog(LOG_INFO) << "Terrain '" << pair.first << "' does not exist!";
 		}
 	}
 
@@ -331,7 +331,7 @@ void TestState::testCase4()
 	}
 
 	// 2. check for existence of mapblock MAP and RMP files
-	Log(LOG_INFO) << "----------------------------------------------2. check for existence of mapblock MAP and RMP files";
+	XComLog(LOG_INFO) << "----------------------------------------------2. check for existence of mapblock MAP and RMP files";
 
 	auto checkExistence = [](std::map<std::string, int> &mapRef, const std::string &dir, const std::string &ext, int &totalRef)
 	{
@@ -342,7 +342,7 @@ void TestState::testCase4()
 			if (!FileMap::fileExists(filename.str()))
 			{
 				++totalRef;
-				Log(LOG_INFO) << filename.str() << " not found";
+				XComLog(LOG_INFO) << filename.str() << " not found";
 			}
 		}
 	};
@@ -351,14 +351,14 @@ void TestState::testCase4()
 	checkExistence(blockMap, "ROUTES/", ".RMP", total);
 
 	// 3. check for existence of mapdataset MCD, PCK and TAB files
-	Log(LOG_INFO) << "----------------------------------------------3. check for existence of mapdataset MCD, PCK and TAB files";
+	XComLog(LOG_INFO) << "----------------------------------------------3. check for existence of mapdataset MCD, PCK and TAB files";
 
 	checkExistence(datasetMap, "TERRAIN/", ".MCD", total);
 	checkExistence(datasetMap, "TERRAIN/", ".PCK", total);
 	checkExistence(datasetMap, "TERRAIN/", ".TAB", total);
 
 	// 4. check for unused mapblock MAP and RMP files
-	Log(LOG_INFO) << "----------------------------------------------4. check for unused mapblock MAP and RMP files";
+	XComLog(LOG_INFO) << "----------------------------------------------4. check for unused mapblock MAP and RMP files";
 
 	auto findUnusedFiles = [](std::map<std::string, int> &mapRef, const std::string &dir, int &totalRef)
 	{
@@ -381,7 +381,7 @@ void TestState::testCase4()
 				if (fullpath.find("/TFTD/TERRAIN/") != std::string::npos) continue;
 
 				++totalRef;
-				Log(LOG_INFO) << fullpath << " not used anywhere.";
+				XComLog(LOG_INFO) << fullpath << " not used anywhere.";
 			}
 		}
 	};
@@ -390,7 +390,7 @@ void TestState::testCase4()
 	findUnusedFiles(blockMap, "ROUTES/", total);
 
 	// 5. check for unused mapdataset MCD, PCK and TAB files
-	Log(LOG_INFO) << "----------------------------------------------5. check for unused mapdataset MCD, PCK and TAB files";
+	XComLog(LOG_INFO) << "----------------------------------------------5. check for unused mapdataset MCD, PCK and TAB files";
 
 	findUnusedFiles(datasetMap, "TERRAIN/", total);
 
@@ -434,9 +434,9 @@ void TestState::testCase3()
 		}
 	}
 
-	Log(LOG_INFO) << "----------------------------------------------";
-	Log(LOG_INFO) << "Copy/paste into a CSV file";
-	Log(LOG_INFO) << "----------------------------------------------";
+	XComLog(LOG_INFO) << "----------------------------------------------";
+	XComLog(LOG_INFO) << "Copy/paste into a CSV file";
+	XComLog(LOG_INFO) << "----------------------------------------------";
 	{
 		std::ostringstream ssNames;
 		ssNames << ";Armor";
@@ -444,7 +444,7 @@ void TestState::testCase3()
 		{
 			ssNames << ";" << n.first;
 		}
-		Log(LOG_INFO) << ssNames.str();
+		XComLog(LOG_INFO) << ssNames.str();
 	}
 	for (auto armorName : _game->getMod()->getArmorsList())
 	{
@@ -461,11 +461,11 @@ void TestState::testCase3()
 				ss << (*findIt).second;
 			}
 		}
-		Log(LOG_INFO) << ss.str();
+		XComLog(LOG_INFO) << ss.str();
 	}
-	Log(LOG_INFO) << "----------------------------------------------";
-	Log(LOG_INFO) << "End of export";
-	Log(LOG_INFO) << "----------------------------------------------";
+	XComLog(LOG_INFO) << "----------------------------------------------";
+	XComLog(LOG_INFO) << "End of export";
+	XComLog(LOG_INFO) << "----------------------------------------------";
 
 	_lstOutput->addRow(1, tr("STR_TESTS_FINISHED").c_str());
 }
@@ -543,7 +543,7 @@ void TestState::testCase2()
 						}
 						catch (Exception &e)
 						{
-							Log(LOG_WARNING) << e.what();
+							XComLog(LOG_WARNING) << e.what();
 						}
 					}
 				}
@@ -584,7 +584,7 @@ int TestState::checkPalette(const std::string& fullPath, int width, int height)
 	SDL_Palette *palette = image->getSurface()->format->palette;
 	if (!palette)
 	{
-		Log(LOG_ERROR) << "Image doesn't have a palette at all! Full path: " << fullPath;
+		XComLog(LOG_ERROR) << "Image doesn't have a palette at all! Full path: " << fullPath;
 		delete image;
 		return 1;
 	}
@@ -592,7 +592,7 @@ int TestState::checkPalette(const std::string& fullPath, int width, int height)
 	int ncolors = image->getSurface()->format->palette->ncolors;
 	if (ncolors != 256)
 	{
-		Log(LOG_ERROR) << "Image palette doesn't have 256 colors! Full path: " << fullPath;
+		XComLog(LOG_ERROR) << "Image palette doesn't have 256 colors! Full path: " << fullPath;
 	}
 
 	int bestMatch = 0;
@@ -615,7 +615,7 @@ int TestState::checkPalette(const std::string& fullPath, int width, int height)
 
 	if (bestMatch < 100)
 	{
-		Log(LOG_INFO) << "Best match: " << bestMatch << "%; palette: " << _paletteMetadataMap[matchedPaletteIndex].paletteName << "; path: " << fullPath;
+		XComLog(LOG_INFO) << "Best match: " << bestMatch << "%; palette: " << _paletteMetadataMap[matchedPaletteIndex].paletteName << "; path: " << fullPath;
 		return 1;
 	}
 
@@ -707,9 +707,9 @@ void TestState::testCase1()
 	// summary (unique)
 	if (total > 0)
 	{
-		Log(LOG_INFO) << "----------";
-		Log(LOG_INFO) << "SUMMARY";
-		Log(LOG_INFO) << "----------";
+		XComLog(LOG_INFO) << "----------";
+		XComLog(LOG_INFO) << "SUMMARY";
+		XComLog(LOG_INFO) << "----------";
 		for (auto mapItem : uniqueResults)
 		{
 			std::ostringstream ss;
@@ -728,7 +728,7 @@ void TestState::testCase1()
 				ss << setItem;
 			}
 			std::string line = ss.str();
-			Log(LOG_INFO) << line;
+			XComLog(LOG_INFO) << line;
 		}
 	}
 	_lstOutput->addRow(1, tr("STR_TESTS_FINISHED").c_str());
@@ -750,7 +750,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 				std::ostringstream ss;
 				ss << "terrain: " << terrainRule->getName() << " dataset: " << myMapDataSet->getName() << " object " << index << " has armor: " << myMapData->getArmor();
 				std::string str = ss.str();
-				Log(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
+				XComLog(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
 				errors++;
 				uniqueResults[myMapDataSet->getName()].insert(index);
 			}
@@ -761,7 +761,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 				std::ostringstream ss;
 				ss << "terrain: " << terrainRule->getName() << " dataset: " << myMapDataSet->getName() << " object " << index << " has invalid DieMCD: " << myMapData->getDieMCD();
 				std::string str = ss.str();
-				Log(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
+				XComLog(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
 				errors++;
 				uniqueResults[myMapDataSet->getName()].insert(index);
 			}
@@ -770,7 +770,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 				std::ostringstream ss;
 				ss << "terrain: " << terrainRule->getName() << " dataset: " << myMapDataSet->getName() << " object " << index << " has invalid AltMCD: " << myMapData->getAltMCD();
 				std::string str = ss.str();
-				Log(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
+				XComLog(LOG_ERROR) << "Error in " << str << ". Found using OXCE test cases.";
 				errors++;
 				uniqueResults[myMapDataSet->getName()].insert(index);
 			}
@@ -784,7 +784,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 					std::ostringstream ss;
 					ss << "terrain: " << terrainRule->getName() << " dataset: " << myMapDataSet->getName() << " object " << index << " is a walkable floor tile with 'No_Floor' flag set to true.";
 					std::string str = ss.str();
-					Log(LOG_WARNING) << "Potential issue in " << str << ". Found using OXCE test cases.";
+					XComLog(LOG_WARNING) << "Potential issue in " << str << ". Found using OXCE test cases.";
 					errors++;
 					uniqueResults[myMapDataSet->getName()].insert(index);
 				}
@@ -793,7 +793,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 					std::ostringstream ss;
 					ss << " walk:" << myMapData->getTUCost(MT_WALK) << " terrain:" << terrainRule->getName() << " dataset:" << myMapDataSet->getName() << " index:" << index;
 					std::string str = ss.str();
-					Log(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
+					XComLog(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
 					errors++;
 					uniqueResults[myMapDataSet->getName()].insert(index);
 				}
@@ -802,7 +802,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 					std::ostringstream ss;
 					ss << "  fly:" << myMapData->getTUCost(MT_FLY) << " terrain:" << terrainRule->getName() << " dataset:" << myMapDataSet->getName() << " index:" << index;
 					std::string str = ss.str();
-					Log(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
+					XComLog(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
 					errors++;
 					uniqueResults[myMapDataSet->getName()].insert(index);
 				}
@@ -811,7 +811,7 @@ int TestState::checkMCD(RuleTerrain *terrainRule, std::map<std::string, std::set
 					std::ostringstream ss;
 					ss << "slide:" << myMapData->getTUCost(MT_SLIDE) << " terrain:" << terrainRule->getName() << " dataset:" << myMapDataSet->getName() << " index:" << index;
 					std::string str = ss.str();
-					Log(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
+					XComLog(LOG_INFO) << "Zero movement cost on floor object: " << str << ". Found using OXCE test cases.";
 					errors++;
 					uniqueResults[myMapDataSet->getName()].insert(index);
 				}
@@ -903,7 +903,7 @@ int TestState::checkRMP(MapBlock *mapblock)
 		}
 		else
 		{
-			Log(LOG_INFO) << "Bad node in RMP file: " << filename.str() << " Node #" << nodesAdded << " is outside map boundaries at X:" << pos_x << " Y:" << pos_y << " Z:" << pos_z << ". Found using OXCE test cases.";
+			XComLog(LOG_INFO) << "Bad node in RMP file: " << filename.str() << " Node #" << nodesAdded << " is outside map boundaries at X:" << pos_x << " Y:" << pos_y << " Z:" << pos_z << ". Found using OXCE test cases.";
 			errors++;
 		}
 		nodesAdded++;

--- a/src/Menu/VideoState.cpp
+++ b/src/Menu/VideoState.cpp
@@ -339,17 +339,17 @@ static struct AudioSequence
 				switch(command)
 				{
 				case 0x200:
-					Log(LOG_DEBUG) << "Playing gmintro1";
+					XComLog(LOG_DEBUG) << "Playing gmintro1";
 					m = mod->getMusic("GMINTRO1");
 					m->play(1);
 					break;
 				case 0x201:
-					Log(LOG_DEBUG) << "Playing gmintro2";
+					XComLog(LOG_DEBUG) << "Playing gmintro2";
 					m = mod->getMusic("GMINTRO2");
 					m->play(1);
 					break;
 				case 0x202:
-					Log(LOG_DEBUG) << "Playing gmintro3";
+					XComLog(LOG_DEBUG) << "Playing gmintro3";
 					m = mod->getMusic("GMINTRO3");
 					m->play(1);
 					//Mix_HookMusicFinished(_FlcPlayer::stop);
@@ -361,7 +361,7 @@ static struct AudioSequence
 			{
 				int newSpeed = (command & 0xff);
 				_flcPlayer->setHeaderSpeed(newSpeed);
-				Log(LOG_DEBUG) << "Frame delay now: " << newSpeed;
+				XComLog(LOG_DEBUG) << "Frame delay now: " << newSpeed;
 			}
 			else if (command <= 0x19)
 			{
@@ -370,7 +370,7 @@ static struct AudioSequence
 					soundInFile *sf = (*sounds) + command;
 					int channel = trackPosition % 4; // use at most four channels to play sound effects
 					double ratio = (double)Options::soundVolume / MIX_MAX_VOLUME;
-					Log(LOG_DEBUG) << "playing: " << sf->catFile << ":" << sf->sound << " for index " << command;
+					XComLog(LOG_DEBUG) << "playing: " << sf->catFile << ":" << sf->sound << " for index " << command;
 					s = mod->getSound(sf->catFile, sf->sound/*, false*/);
 					if (s)
 					{
@@ -378,7 +378,7 @@ static struct AudioSequence
 						Mix_Volume(channel, sf->volume * ratio);
 						break;
 					}
-					else Log(LOG_DEBUG) << "Couldn't play " << sf->catFile << ":" << sf->sound;
+					else XComLog(LOG_DEBUG) << "Couldn't play " << sf->catFile << ":" << sf->sound;
 				}
 			}
 			++trackPosition;

--- a/src/Mod/ExtraSounds.cpp
+++ b/src/Mod/ExtraSounds.cpp
@@ -83,12 +83,12 @@ SoundSet *ExtraSounds::loadSoundSet(SoundSet *set) const
 {
 	if (set == 0)
 	{
-		Log(LOG_WARNING) << "Creating new sound set: " << _type << ", this will likely have no in-game use.";
+		XComLog(LOG_WARNING) << "Creating new sound set: " << _type << ", this will likely have no in-game use.";
 		set = new SoundSet();
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding/Replacing items in sound set: " << _type;
+		XComLog(LOG_VERBOSE) << "Adding/Replacing items in sound set: " << _type;
 	}
 	for (std::map<int, std::string>::const_iterator j = _sounds.begin(); j != _sounds.end(); ++j)
 	{
@@ -96,7 +96,7 @@ SoundSet *ExtraSounds::loadSoundSet(SoundSet *set) const
 		std::string fileName = j->second;
 		if (fileName[fileName.length() - 1] == '/')
 		{
-			Log(LOG_VERBOSE) << "Loading sound set from folder: " << fileName << " starting at index: " << startSound;
+			XComLog(LOG_VERBOSE) << "Loading sound set from folder: " << fileName << " starting at index: " << startSound;
 			int offset = startSound;
 			std::vector<std::string> contents;
 			for (auto f: FileMap::getVFolderContents(fileName)) { contents.push_back(f); }
@@ -110,7 +110,7 @@ SoundSet *ExtraSounds::loadSoundSet(SoundSet *set) const
 				}
 				catch (Exception &e)
 				{
-					Log(LOG_WARNING) << e.what();
+					XComLog(LOG_WARNING) << e.what();
 				}
 			}
 		}
@@ -139,11 +139,11 @@ void ExtraSounds::loadSound(SoundSet *set, int index, const std::string &fileNam
 	Sound *sound = set->getSound(indexWithOffset);
 	if (sound)
 	{
-		Log(LOG_VERBOSE) << "Replacing sound: " << index << ", using index: " << indexWithOffset;
+		XComLog(LOG_VERBOSE) << "Replacing sound: " << index << ", using index: " << indexWithOffset;
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding sound: " << index << ", using index: " << indexWithOffset;
+		XComLog(LOG_VERBOSE) << "Adding sound: " << index << ", using index: " << indexWithOffset;
 		sound = set->addSound(indexWithOffset);
 	}
 	sound->load(fileName);

--- a/src/Mod/ExtraSprites.cpp
+++ b/src/Mod/ExtraSprites.cpp
@@ -181,11 +181,11 @@ Surface *ExtraSprites::loadSurface(Surface *surface)
 
 	if (surface == 0)
 	{
-		Log(LOG_VERBOSE) << "Creating new single image: " << _type;
+		XComLog(LOG_VERBOSE) << "Creating new single image: " << _type;
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding/Replacing single image: " << _type;
+		XComLog(LOG_VERBOSE) << "Adding/Replacing single image: " << _type;
 		delete surface;
 	}
 	surface = new Surface(_width, _height);
@@ -209,15 +209,15 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 	auto surfaceSetY = subdivision ? _subY : _height;
 	if (set == 0)
 	{
-		Log(LOG_VERBOSE) << "Creating new surface set: " << _type;
+		XComLog(LOG_VERBOSE) << "Creating new surface set: " << _type;
 		set = new SurfaceSet(surfaceSetX, surfaceSetY);
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding/Replacing items in surface set: " << _type;
+		XComLog(LOG_VERBOSE) << "Adding/Replacing items in surface set: " << _type;
 		if (set->getTotalFrames() == 0 && (set->getWidth() != surfaceSetX || set->getHeight() != surfaceSetY))
 		{
-			Log(LOG_VERBOSE) << "Resize empty set to: " << surfaceSetX << " x " << surfaceSetY;
+			XComLog(LOG_VERBOSE) << "Resize empty set to: " << surfaceSetX << " x " << surfaceSetY;
 			auto shared = set->getMaxSharedFrames();
 			*set = SurfaceSet(surfaceSetX, surfaceSetY);
 			set->setMaxSharedFrames(shared);
@@ -230,7 +230,7 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 		std::string fileName = j->second;
 		if (fileName[fileName.length() - 1] == '/')
 		{
-			Log(LOG_VERBOSE) << "Loading surface set from folder: " << fileName << " starting at frame: " << startFrame;
+			XComLog(LOG_VERBOSE) << "Loading surface set from folder: " << fileName << " starting at frame: " << startFrame;
 			int offset = startFrame;
 			std::vector<std::string> contents;
 			for (auto f: FileMap::getVFolderContents(fileName)) { contents.push_back(f); }
@@ -246,7 +246,7 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 				}
 				catch (Exception &e)
 				{
-					Log(LOG_WARNING) << e.what();
+					XComLog(LOG_WARNING) << e.what();
 				}
 			}
 		}
@@ -263,7 +263,7 @@ SurfaceSet *ExtraSprites::loadSurfaceSet(SurfaceSet *set)
 				int xDivision = _width / _subX;
 				int yDivision = _height / _subY;
 				int frames = xDivision * yDivision;
-				Log(LOG_VERBOSE) << "Subdividing into " << frames << " frames.";
+				XComLog(LOG_VERBOSE) << "Subdividing into " << frames << " frames.";
 				int offset = startFrame;
 
 				for (int y = 0; y != yDivision; ++y)
@@ -305,12 +305,12 @@ Surface *ExtraSprites::getFrame(SurfaceSet *set, int index) const
 	Surface *frame = set->getFrame(indexWithOffset);
 	if (frame)
 	{
-		Log(LOG_VERBOSE) << "Replacing frame: " << index << ", using index: " << indexWithOffset;
+		XComLog(LOG_VERBOSE) << "Replacing frame: " << index << ", using index: " << indexWithOffset;
 		frame->clear();
 	}
 	else
 	{
-		Log(LOG_VERBOSE) << "Adding frame: " << index << ", using index: " << indexWithOffset;
+		XComLog(LOG_VERBOSE) << "Adding frame: " << index << ", using index: " << indexWithOffset;
 		frame = set->addFrame(indexWithOffset);
 	}
 	return frame;

--- a/src/Mod/MapDataSet.cpp
+++ b/src/Mod/MapDataSet.cpp
@@ -229,15 +229,15 @@ void MapDataSet::loadData(MCDPatch *patch, bool validate)
 		{
 			if ((size_t)_objects[i]->getDieMCD() >= _objects.size())
 			{
-				Log(LOG_INFO) << "MCD " << _name << " object " << i << " has invalid DieMCD: " << _objects[i]->getDieMCD();
+				XComLog(LOG_INFO) << "MCD " << _name << " object " << i << " has invalid DieMCD: " << _objects[i]->getDieMCD();
 			}
 			if ((size_t)_objects[i]->getAltMCD() >= _objects.size())
 			{
-				Log(LOG_INFO) << "MCD " << _name << " object " << i << " has invalid AltMCD: " << _objects[i]->getAltMCD();
+				XComLog(LOG_INFO) << "MCD " << _name << " object " << i << " has invalid AltMCD: " << _objects[i]->getAltMCD();
 			}
 			if (_objects[i]->getArmor() == 0)
 			{
-				Log(LOG_INFO) << "MCD " << _name << " object " << i << " has 0 armor";
+				XComLog(LOG_INFO) << "MCD " << _name << " object " << i << " has 0 armor";
 			}
 		}
 	}

--- a/src/Mod/MapScript.h
+++ b/src/Mod/MapScript.h
@@ -101,7 +101,7 @@ struct VerticalLevel
 		}
 		else
 		{
-			Log(LOG_WARNING) << "'" << type << "'" << " does not resolve into a valid verticalLevel type, loading as 'middle'.";
+			XComLog(LOG_WARNING) << "'" << type << "'" << " does not resolve into a valid verticalLevel type, loading as 'middle'.";
 			levelType = VLT_MIDDLE;
 		}
 

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -917,7 +917,7 @@ void Mod::playMusic(const std::string &name, int id)
 				}
 			}
 		}
-		Log(LOG_VERBOSE)<<"Mod::playMusic('" << name << "'): playing " << _playingMusic;
+		XComLog(LOG_VERBOSE)<<"Mod::playMusic('" << name << "'): playing " << _playingMusic;
 	}
 }
 
@@ -951,14 +951,14 @@ Sound *Mod::getSound(const std::string &set, int sound) const
 			Sound *s = ss->getSound(sound);
 			if (s == 0)
 			{
-				Log(LOG_ERROR) << "Sound " << sound << " in " << set << " not found";
+				XComLog(LOG_ERROR) << "Sound " << sound << " in " << set << " not found";
 				return _muteSound;
 			}
 			return s;
 		}
 		else
 		{
-			Log(LOG_ERROR) << "SoundSet " << set << " not found";
+			XComLog(LOG_ERROR) << "SoundSet " << set << " not found";
 			return _muteSound;
 		}
 	}
@@ -1931,14 +1931,14 @@ static void throwModOnErrorHelper(const std::string& modId, const std::string& e
 
 	if (!Options::debug)
 	{
-		Log(LOG_WARNING) << "disabling mod with invalid ruleset: " << modId;
+		XComLog(LOG_WARNING) << "disabling mod with invalid ruleset: " << modId;
 		std::vector<std::pair<std::string, bool> >::iterator it =
 			std::find(Options::mods.begin(), Options::mods.end(),
 				std::pair<std::string, bool>(modId, true));
 		if (it == Options::mods.end())
 		{
-			Log(LOG_ERROR) << "cannot find broken mod in mods list: " << modId;
-			Log(LOG_ERROR) << "clearing mods list";
+			XComLog(LOG_ERROR) << "cannot find broken mod in mods list: " << modId;
+			XComLog(LOG_ERROR) << "clearing mods list";
 			Options::mods.clear();
 		}
 		else
@@ -1964,14 +1964,14 @@ void Mod::loadAll()
 	ModScript parser{ _scriptGlobal, this };
 	auto mods = FileMap::getRulesets();
 
-	Log(LOG_INFO) << "Loading begins...";
+	XComLog(LOG_INFO) << "Loading begins...";
 	if (Options::oxceModValidationLevel < LOG_ERROR)
 	{
-		Log(LOG_ERROR) << "Validation of mod data disabled, game can crash when run";
+		XComLog(LOG_ERROR) << "Validation of mod data disabled, game can crash when run";
 	}
 	else if (Options::oxceModValidationLevel < LOG_WARNING)
 	{
-		Log(LOG_WARNING) << "Validation of mod data reduced, game can behave incorrectly";
+		XComLog(LOG_WARNING) << "Validation of mod data reduced, game can behave incorrectly";
 	}
 	_scriptGlobal->beginLoad();
 	_modData.clear();
@@ -2001,7 +2001,7 @@ void Mod::loadAll()
 		offset += size;
 	}
 
-	Log(LOG_INFO) << "Pre-loading rulesets...";
+	XComLog(LOG_INFO) << "Pre-loading rulesets...";
 	// load rulesets that can affect loading vanilla resources
 	for (size_t i = 0; _modData.size() > i; ++i)
 	{
@@ -2016,7 +2016,7 @@ void Mod::loadAll()
 		}
 	}
 
-	Log(LOG_INFO) << "Loading vanilla resources...";
+	XComLog(LOG_INFO) << "Loading vanilla resources...";
 	// vanilla resources load
 	_modCurrent = &_modData.at(0);
 	loadVanillaResources();
@@ -2030,7 +2030,7 @@ void Mod::loadAll()
 	_soundOffsetBattle = _sounds["BATTLE.CAT"]->getMaxSharedSounds();
 	_soundOffsetGeo = _sounds["GEO.CAT"]->getMaxSharedSounds();
 
-	Log(LOG_INFO) << "Loading rulesets...";
+	XComLog(LOG_INFO) << "Loading rulesets...";
 	// load rest rulesets
 	for (size_t i = 0; mods.size() > i; ++i)
 	{
@@ -2046,7 +2046,7 @@ void Mod::loadAll()
 			throwModOnErrorHelper(modId, e.what());
 		}
 	}
-	Log(LOG_INFO) << "Loading rulesets done.";
+	XComLog(LOG_INFO) << "Loading rulesets done.";
 
 	//back master
 	_modCurrent = &_modData.at(0);
@@ -2094,7 +2094,7 @@ void Mod::loadAll()
 	loadExtraResources();
 
 
-	Log(LOG_INFO) << "After load.";
+	XComLog(LOG_INFO) << "After load.";
 	// cross link rule objects
 
 	afterLoadHelper("research", this, _research, &RuleResearch::afterLoad);
@@ -2227,7 +2227,7 @@ void Mod::loadAll()
 		Options::save();
 	}
 
-	Log(LOG_INFO) << "Loading ended.";
+	XComLog(LOG_INFO) << "Loading ended.";
 
 	sortLists();
 	modResources();
@@ -2243,7 +2243,7 @@ void Mod::loadMod(const std::vector<FileMap::FileRecord> &rulesetFiles, ModScrip
 {
 	for (auto i = rulesetFiles.begin(); i != rulesetFiles.end(); ++i)
 	{
-		Log(LOG_VERBOSE) << "- " << i->fullpath;
+		XComLog(LOG_VERBOSE) << "- " << i->fullpath;
 		try
 		{
 			loadFile(*i, parsers);
@@ -2662,7 +2662,7 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 			else
 			{
 				if (!(*i)["type_id"].IsDefined()) { // otherwise it throws and I wasted hours
-					Log(LOG_ERROR) << "ufopaedia item misses type_id attribute.";
+					XComLog(LOG_ERROR) << "ufopaedia item misses type_id attribute.";
 					continue;
 				}
 				UfopaediaTypeId type = (UfopaediaTypeId)(*i)["type_id"].as<int>();
@@ -3374,7 +3374,7 @@ SavedGame *Mod::newSave(GameDifficulty diff) const
 			int randomSoldiers = node.as<int>(0);
 			if (randomSoldiers > 0 && soldierTypes.empty())
 			{
-				Log(LOG_ERROR) << "Cannot generate soldiers for the starting base. There are no available soldier types. Maybe all of them are locked by research?";
+				XComLog(LOG_ERROR) << "Cannot generate soldiers for the starting base. There are no available soldier types. Maybe all of them are locked by research?";
 			}
 			else
 			{
@@ -5000,18 +5000,18 @@ void Mod::loadVanillaResources()
 					std::string fname = "SOUND/" + cats[j][i];
 					if (FileMap::fileExists(fname))
 					{
-						Log(LOG_VERBOSE) << catsId[i] << ": loading sound "<<fname;
+						XComLog(LOG_VERBOSE) << catsId[i] << ": loading sound "<<fname;
 						CatFile catfile(fname);
 						sound->loadCat(catfile);
 						Options::currentSound = (wav) ? SOUND_14 : SOUND_10;
 						break;
 					} else {
-						Log(LOG_VERBOSE) << catsId[i] << ": sound file not found: "<<fname;
+						XComLog(LOG_VERBOSE) << catsId[i] << ": sound file not found: "<<fname;
 					}
 				}
 				if (sound->getTotalSounds() == 0)
 				{
-					Log(LOG_ERROR) << catsId[i] << " not found: " << catsWin[i] + " or " + catsDos[i] + " required";
+					XComLog(LOG_ERROR) << catsId[i] << " not found: " << catsWin[i] + " or " + catsDos[i] + " required";
 				}
 			}
 		}
@@ -5024,7 +5024,7 @@ void Mod::loadVanillaResources()
 				if (_sounds.find(i.first) == _sounds.end())
 				{
 					_sounds[i.first] = new SoundSet();
-					Log(LOG_VERBOSE) << "TFTD: adding soundset" << i.first;
+					XComLog(LOG_VERBOSE) << "TFTD: adding soundset" << i.first;
 				}
 				std::string fname = "SOUND/" + i.second->getCATFile();
 				if (FileMap::fileExists(fname))
@@ -5033,12 +5033,12 @@ void Mod::loadVanillaResources()
 					for (auto j : i.second->getSoundList())
 					{
 						_sounds[i.first]->loadCatByIndex(catfile, j, true);
-						Log(LOG_VERBOSE) << "TFTD: adding sound " << j << " to " << i.first;
+						XComLog(LOG_VERBOSE) << "TFTD: adding sound " << j << " to " << i.first;
 					}
 				}
 				else
 				{
-					Log(LOG_ERROR) << "TFTD sound file not found:" << fname;
+					XComLog(LOG_ERROR) << "TFTD sound file not found:" << fname;
 				}
 			}
 		}
@@ -5085,7 +5085,7 @@ void Mod::loadVanillaResources()
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Surface set " << surfaceNames[i] << " not found.";
+				XComLog(LOG_ERROR) << "Surface set " << surfaceNames[i] << " not found.";
 				throw Exception("Surface set " + surfaceNames[i] + " not found.");
 			}
 		}
@@ -5179,7 +5179,7 @@ void Mod::loadBattlescapeResources()
 	// incomplete chryssalid set: 1.0 data: stop loading.
 	if (_sets.find("CHRYS.PCK") != _sets.end() && !_sets["CHRYS.PCK"]->getFrame(225))
 	{
-		Log(LOG_FATAL) << "Version 1.0 data detected";
+		XComLog(LOG_FATAL) << "Version 1.0 data detected";
 		throw Exception("Invalid CHRYS.PCK, please patch your X-COM data to the latest version");
 	}
 	// TFTD uses the loftemps dat from the terrain folder, but still has enemy unknown's version in the geodata folder, which is short by 2 entries.
@@ -5433,7 +5433,7 @@ void Mod::loadExtraResources()
 {
 	// Load fonts
 	YAML::Node doc = FileMap::getYAML("Language/" + _fontName);
-	Log(LOG_INFO) << "Loading fonts... " << _fontName;
+	XComLog(LOG_INFO) << "Loading fonts... " << _fontName;
 	for (YAML::const_iterator i = doc["fonts"].begin(); i != doc["fonts"].end(); ++i)
 	{
 		std::string id = (*i)["id"].as<std::string>();
@@ -5490,10 +5490,10 @@ void Mod::loadExtraResources()
 	}
 #endif
 
-	Log(LOG_INFO) << "Lazy loading: " << Options::lazyLoadResources;
+	XComLog(LOG_INFO) << "Lazy loading: " << Options::lazyLoadResources;
 	if (!Options::lazyLoadResources)
 	{
-		Log(LOG_INFO) << "Loading extra resources from ruleset...";
+		XComLog(LOG_INFO) << "Loading extra resources from ruleset...";
 		for (std::map<std::string, std::vector<ExtraSprites *> >::const_iterator i = _extraSprites.begin(); i != _extraSprites.end(); ++i)
 		{
 			for (std::vector<ExtraSprites*>::const_iterator j = i->second.begin(); j != i->second.end(); ++j)
@@ -5520,20 +5520,20 @@ void Mod::loadExtraResources()
 		}
 	}
 
-	Log(LOG_INFO) << "Loading custom palettes from ruleset...";
+	XComLog(LOG_INFO) << "Loading custom palettes from ruleset...";
 	for (std::map<std::string, CustomPalettes *>::const_iterator i = _customPalettes.begin(); i != _customPalettes.end(); ++i)
 	{
 		CustomPalettes *palDef = i->second;
 		std::string palTargetName = palDef->getTarget();
 		if (_palettes.find(palTargetName) == _palettes.end())
 		{
-			Log(LOG_INFO) << "Creating a new palette: " << palTargetName;
+			XComLog(LOG_INFO) << "Creating a new palette: " << palTargetName;
 			_palettes[palTargetName] = new Palette();
 			_palettes[palTargetName]->initBlack();
 		}
 		else
 		{
-			Log(LOG_VERBOSE) << "Replacing items in target palette: " << palTargetName;
+			XComLog(LOG_VERBOSE) << "Replacing items in target palette: " << palTargetName;
 		}
 
 		Palette *target = _palettes[palTargetName];
@@ -5571,8 +5571,8 @@ void Mod::loadExtraResources()
 	{
 		if (pal.first.find("PAL_") == 0)
 		{
-			if (!backup_logged) { Log(LOG_INFO) << "Making palette backups..."; backup_logged = true; }
-			Log(LOG_VERBOSE) << "Creating a backup for palette: " << pal.first;
+			if (!backup_logged) { XComLog(LOG_INFO) << "Making palette backups..."; backup_logged = true; }
+			XComLog(LOG_VERBOSE) << "Creating a backup for palette: " << pal.first;
 			std::string newName = "BACKUP_" + pal.first;
 			_palettes[newName] = new Palette();
 			_palettes[newName]->initBlack();
@@ -5585,14 +5585,14 @@ void Mod::loadExtraResources()
 	{
 		if (_palettes["PAL_BATTLESCAPE"])
 		{
-			Log(LOG_INFO) << "Creating transparency LUTs for PAL_BATTLESCAPE...";
+			XComLog(LOG_INFO) << "Creating transparency LUTs for PAL_BATTLESCAPE...";
 			createTransparencyLUT(_palettes["PAL_BATTLESCAPE"]);
 		}
 		if (_palettes["PAL_BATTLESCAPE_1"] &&
 			_palettes["PAL_BATTLESCAPE_2"] &&
 			_palettes["PAL_BATTLESCAPE_3"])
 		{
-			Log(LOG_INFO) << "Creating transparency LUTs for hybrid custom palettes...";
+			XComLog(LOG_INFO) << "Creating transparency LUTs for hybrid custom palettes...";
 			createTransparencyLUT(_palettes["PAL_BATTLESCAPE_1"]);
 			createTransparencyLUT(_palettes["PAL_BATTLESCAPE_2"]);
 			createTransparencyLUT(_palettes["PAL_BATTLESCAPE_3"]);
@@ -5831,7 +5831,7 @@ Music *Mod::loadMusic(MusicFormat fmt, const std::string &file, size_t track, fl
 	}
 	catch (Exception &e)
 	{
-		Log(LOG_INFO) << e.what();
+		XComLog(LOG_INFO) << e.what();
 		if (music) delete music;
 		music = 0;
 	}

--- a/src/Mod/Mod.h
+++ b/src/Mod/Mod.h
@@ -455,7 +455,7 @@ public:
 			auto ex = LoadRuleException(parent, node, error);
 			if (Options::oxceModValidationLevel < level)
 			{
-				Log(level) << "Supressed " << ex.what();
+				XComLog(level) << "Supressed " << ex.what();
 				return true;
 			}
 			else
@@ -474,7 +474,7 @@ public:
 			auto ex = LoadRuleException(parent, error);
 			if (Options::oxceModValidationLevel < level)
 			{
-				Log(level) << "Supressed " << ex.what();
+				XComLog(level) << "Supressed " << ex.what();
 				return true;
 			}
 			else

--- a/src/Mod/RuleCraftWeapon.cpp
+++ b/src/Mod/RuleCraftWeapon.cpp
@@ -107,11 +107,11 @@ void RuleCraftWeapon::afterLoad(const Mod* mod)
 		}
 		else if (_projectileSpeed <= 4 && _range > 10)
 		{
-			Log(LOG_WARNING) << "Missile speed for " << _type << " is very low! Depending on craft approach speed, the missile may seem not moving, or even moving backwards. Speed: " << _projectileSpeed << "; range: " << _range;
+			XComLog(LOG_WARNING) << "Missile speed for " << _type << " is very low! Depending on craft approach speed, the missile may seem not moving, or even moving backwards. Speed: " << _projectileSpeed << "; range: " << _range;
 		}
 		else if (_projectileSpeed <= 5 && _range > 20)
 		{
-			Log(LOG_INFO) << "Missile speed for " << _type << " is quite low. Depending on craft approach speed, the missile may seem moving very slowly. Speed: " << _projectileSpeed << "; range: " << _range;
+			XComLog(LOG_INFO) << "Missile speed for " << _type << " is quite low. Depending on craft approach speed, the missile may seem moving very slowly. Speed: " << _projectileSpeed << "; range: " << _range;
 		}
 	}
 	if (_launcher == nullptr)

--- a/src/Mod/RuleItem.cpp
+++ b/src/Mod/RuleItem.cpp
@@ -252,7 +252,7 @@ void RuleItem::loadAmmoSlotChecked(int& result, const YAML::Node& node, const st
 		auto s = node.as<int>(result);
 		if (s < AmmoSlotSelfUse || s >= AmmoSlotMax)
 		{
-			Log(LOG_ERROR) << "ammoSlot outside of allowed range in '" << parentName << "'";
+			XComLog(LOG_ERROR) << "ammoSlot outside of allowed range in '" << parentName << "'";
 		}
 		else
 		{

--- a/src/Mod/RuleRegion.cpp
+++ b/src/Mod/RuleRegion.cpp
@@ -85,7 +85,7 @@ void RuleRegion::load(const YAML::Node &node)
 		{
 			if (z.areas.size() < 1)
 			{
-				Log(LOG_WARNING) << "Empty zone, region: " << _type << ", zone: " << zn;
+				XComLog(LOG_WARNING) << "Empty zone, region: " << _type << ", zone: " << zn;
 				continue;
 			}
 			int an = 0;
@@ -94,13 +94,13 @@ void RuleRegion::load(const YAML::Node &node)
 			{
 				if (a.isPoint() != firstAreaType)
 				{
-					Log(LOG_WARNING) << "Mixed area types (point vs non-point), region: " << _type << ", zone: " << zn << ", area: " << an;
+					XComLog(LOG_WARNING) << "Mixed area types (point vs non-point), region: " << _type << ", zone: " << zn << ", area: " << an;
 				}
 				if (a.lonMin > a.lonMax)
 				{
-					Log(LOG_ERROR) << "Crossing the prime meridian in mission zones requires a different syntax, region: " << _type << ", zone: " << zn << ", area: " << an << ", lonMin: " << Rad2Deg(a.lonMin) << ", lonMax: " << Rad2Deg(a.lonMax);
-					Log(LOG_INFO) << "  Wrong example: [350,   8, 20, 30]";
-					Log(LOG_INFO) << "Correct example: [350, 368, 20, 30]";
+					XComLog(LOG_ERROR) << "Crossing the prime meridian in mission zones requires a different syntax, region: " << _type << ", zone: " << zn << ", area: " << an << ", lonMin: " << Rad2Deg(a.lonMin) << ", lonMax: " << Rad2Deg(a.lonMax);
+					XComLog(LOG_INFO) << "  Wrong example: [350,   8, 20, 30]";
+					XComLog(LOG_INFO) << "Correct example: [350, 368, 20, 30]";
 				}
 				++an;
 			}

--- a/src/Mod/RuleStartingCondition.cpp
+++ b/src/Mod/RuleStartingCondition.cpp
@@ -73,7 +73,7 @@ void RuleStartingCondition::load(const YAML::Node& node, Mod *mod)
 	if (node["environmentalConditions"] || node["paletteTransformations"] || node["armorTransformations"]
 		|| node["mapBackgroundColor"] || node["inventoryShockIndicator"] || node["mapShockIndicator"])
 	{
-		Log(LOG_ERROR) << "There are invalid/obsolete attributes in starting condition " << _type << ". Please review the ruleset.";
+		XComLog(LOG_ERROR) << "There are invalid/obsolete attributes in starting condition " << _type << ". Please review the ruleset.";
 	}
 }
 

--- a/src/OpenXcom.2010.vcxproj
+++ b/src/OpenXcom.2010.vcxproj
@@ -92,7 +92,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\SourceCode\pbrt-v4-v2-mod-for-openxcom\src;$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;YAML_CPP_DLL;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -127,7 +127,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\SourceCode\pbrt-v4-v2-mod-for-openxcom\src;$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;YAML_CPP_DLL;_DEBUG;_CONSOLE%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -158,7 +158,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\SourceCode\pbrt-v4-v2-mod-for-openxcom\src;$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;YAML_CPP_DLL;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level1</WarningLevel>
@@ -193,7 +193,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\SourceCode\pbrt-v4-v2-mod-for-openxcom\src;$(ProjectDir)..\deps\include;$(ProjectDir)..\deps\include\SDL;$(ProjectDir)..\deps\include\yaml-cpp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;YAML_CPP_DLL;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>

--- a/src/Savegame/AlienMission.cpp
+++ b/src/Savegame/AlienMission.cpp
@@ -112,7 +112,7 @@ void AlienMission::load(const YAML::Node& node, SavedGame &game, const Mod* mod)
 	RuleRegion* region = mod->getRegion(_region, false);
 	if (!region)
 	{
-		Log(LOG_ERROR) << "Corrupted save: Mission with uniqueID: " << _uniqueID << " has an invalid region: " << _region;
+		XComLog(LOG_ERROR) << "Corrupted save: Mission with uniqueID: " << _uniqueID << " has an invalid region: " << _region;
 		_interrupted = true;
 		if (_missionSiteZone > -1)
 		{
@@ -121,9 +121,9 @@ void AlienMission::load(const YAML::Node& node, SavedGame &game, const Mod* mod)
 		_region = mod->getRegionsList().front();
 		if (_liveUfos > 0)
 		{
-			Log(LOG_ERROR) << "Mission still has some live UFOs, please leave them be until they disappear.";
+			XComLog(LOG_ERROR) << "Mission still has some live UFOs, please leave them be until they disappear.";
 		}
-		Log(LOG_ERROR) << "Mission was interrupted! Temporarily assigned to a new region: " << _region;
+		XComLog(LOG_ERROR) << "Mission was interrupted! Temporarily assigned to a new region: " << _region;
 	}
 }
 
@@ -1202,10 +1202,10 @@ std::pair<double, double> AlienMission::getLandPoint(const Globe &globe, const R
 
 		if (tries == 100)
 		{
-			Log(LOG_WARNING) << "Region: " << region.getType() << " Longitude: " << pos.first << " Latitude: " << pos.second << " invalid zone: " << zone << " ufo forced to land on water (or invalid texture)!";
+			XComLog(LOG_WARNING) << "Region: " << region.getType() << " Longitude: " << pos.first << " Latitude: " << pos.second << " invalid zone: " << zone << " ufo forced to land on water (or invalid texture)!";
 			if (wantsToLandOnFakeWater)
 			{
-				Log(LOG_WARNING) << "UFO: " << ufo.getRules()->getType() << " wanted to land on fake water.";
+				XComLog(LOG_WARNING) << "UFO: " << ufo.getRules()->getType() << " wanted to land on fake water.";
 			}
 		}
 	}
@@ -1273,10 +1273,10 @@ std::pair<double, double> AlienMission::getLandPointForMissionSite(const Globe& 
 
 		if (tries == 100)
 		{
-			Log(LOG_WARNING) << "Region: " << region.getType() << " Longitude: " << pos.first << " Latitude: " << pos.second << " zone: " << zone << " area: " << area << " ufo forced to land on water (or invalid texture)!";
+			XComLog(LOG_WARNING) << "Region: " << region.getType() << " Longitude: " << pos.first << " Latitude: " << pos.second << " zone: " << zone << " area: " << area << " ufo forced to land on water (or invalid texture)!";
 			if (wantsToLandOnFakeWater)
 			{
-				Log(LOG_WARNING) << "UFO: " << ufo.getRules()->getType() << " wanted to land on fake water.";
+				XComLog(LOG_WARNING) << "UFO: " << ufo.getRules()->getType() << " wanted to land on fake water.";
 			}
 		}
 	}

--- a/src/Savegame/AlienStrategy.cpp
+++ b/src/Savegame/AlienStrategy.cpp
@@ -93,7 +93,7 @@ void AlienStrategy::load(const YAML::Node &node, const Mod* mod)
 		}
 		else
 		{
-			Log(LOG_WARNING) << "Corrupted save: Alien strategy contains an invalid region: " << region << ", skipping...";
+			XComLog(LOG_WARNING) << "Corrupted save: Alien strategy contains an invalid region: " << region << ", skipping...";
 		}
 	}
 	_missionLocations = node["missionLocations"].as< std::map<std::string, std::vector<std::pair<std::string, int> > > >(_missionLocations);

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -119,7 +119,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Failed to load facility " << type;
+				XComLog(LOG_ERROR) << "Failed to load facility " << type;
 			}
 		}
 	}
@@ -135,7 +135,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load craft " << type;
+			XComLog(LOG_ERROR) << "Failed to load craft " << type;
 		}
 	}
 
@@ -163,7 +163,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load soldier " << type;
+			XComLog(LOG_ERROR) << "Failed to load soldier " << type;
 		}
 	}
 
@@ -173,7 +173,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 	{
 		if (_mod->getItem(i->first) == 0)
 		{
-			Log(LOG_ERROR) << "Failed to load item " << i->first;
+			XComLog(LOG_ERROR) << "Failed to load item " << i->first;
 			_items->getContents()->erase(i++);
 		}
 		else
@@ -208,7 +208,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 		else
 		{
 			_scientists += (*i)["assigned"].as<int>(0);
-			Log(LOG_ERROR) << "Failed to load research " << research;
+			XComLog(LOG_ERROR) << "Failed to load research " << research;
 		}
 	}
 
@@ -224,7 +224,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 		else
 		{
 			_engineers += (*i)["assigned"].as<int>(0);
-			Log(LOG_ERROR) << "Failed to load manufacture " << item;
+			XComLog(LOG_ERROR) << "Failed to load manufacture " << item;
 		}
 	}
 
@@ -243,7 +243,7 @@ void Base::load(const YAML::Node &node, SavedGame *save, bool newGame, bool newB
 	}
 	_fakeUnderwater = node["fakeUnderwater"].as<bool>(_fakeUnderwater);
 
-	isOverlappingOrOverflowing(); // don't crash, just report in the log file...
+	isOverlappingOrOverflowing(); // don't crash, just report in the XComLog file...
 }
 
 /**
@@ -275,7 +275,7 @@ void Base::finishLoading(const YAML::Node &node, SavedGame *save)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load craft " << type;
+			XComLog(LOG_ERROR) << "Failed to load craft " << type;
 		}
 	}
 }
@@ -307,7 +307,7 @@ bool Base::isOverlappingOrOverflowing()
 
 		if (facilityX < 0 || facilityY < 0 || facilityX + (facilitySize - 1) >= BASE_SIZE || facilityY + (facilitySize - 1) >= BASE_SIZE)
 		{
-			Log(LOG_ERROR) << "Facility " << rules->getType() << " at [" << facilityX << ", " << facilityY << "] (size " << facilitySize << ") is outside of base boundaries.";
+			XComLog(LOG_ERROR) << "Facility " << rules->getType() << " at [" << facilityX << ", " << facilityY << "] (size " << facilitySize << ") is outside of base boundaries.";
 			result = true;
 			continue;
 		}
@@ -318,7 +318,7 @@ bool Base::isOverlappingOrOverflowing()
 			{
 				if (grid[x][y] != 0)
 				{
-					Log(LOG_ERROR) << "Facility " << rules->getType() << " at [" << facilityX << ", " << facilityY << "] (size " << facilitySize
+					XComLog(LOG_ERROR) << "Facility " << rules->getType() << " at [" << facilityX << ", " << facilityY << "] (size " << facilitySize
 						<< ") overlaps with " << grid[x][y]->getRules()->getType() << " at [" << x << ", " << y << "] (size " << grid[x][y]->getRules()->getSize() << ")";
 					result = true;
 				}

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -3060,7 +3060,7 @@ bool BattleUnit::addItem(BattleItem *item, const Mod *mod, bool allowSecondClip,
 		{
 			if (getBaseStats()->strength >= weight) // weight is always considered 0 for aliens
 			{
-				// this is `n*(log(n) + log(n))` code, it could be `n` but we would lose predefined order, as `RuleItem` have them in effective in random order (depending on global memory allocations)
+				// this is `n*(XComLog(n) + XComLog(n))` code, it could be `n` but we would lose predefined order, as `RuleItem` have them in effective in random order (depending on global memory allocations)
 				for (const std::string &s : mod->getInvsList())
 				{
 					RuleInventory *slot = mod->getInventory(s);
@@ -4940,7 +4940,7 @@ void BattleUnit::addLoadedSpecialWeapon(BattleItem* item)
 			return;
 		}
 	}
-	Log(LOG_ERROR) << "Failed to add special built-in item '" << item->getRules()->getType() << "' (id " << item->getId() << ") to unit '" << getType() << "' (id " << getId() << ")";
+	XComLog(LOG_ERROR) << "Failed to add special built-in item '" << item->getRules()->getType() << "' (id " << item->getId() << ") to unit '" << getType() << "' (id " << getId() << ")";
 }
 
 /**

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -165,7 +165,7 @@ void Craft::load(const YAML::Node &node, const ScriptGlobal *shared, const Mod *
 				_weapons[j] = 0;
 				if (type != "0")
 				{
-					Log(LOG_ERROR) << "Failed to load craft weapon " << type;
+					XComLog(LOG_ERROR) << "Failed to load craft weapon " << type;
 				}
 			}
 			j++;
@@ -178,7 +178,7 @@ void Craft::load(const YAML::Node &node, const ScriptGlobal *shared, const Mod *
 	{
 		if (mod->getItem(i->first) == 0)
 		{
-			Log(LOG_ERROR) << "Failed to load item " << i->first;
+			XComLog(LOG_ERROR) << "Failed to load item " << i->first;
 			_items->getContents()->erase(i++);
 		}
 		else
@@ -202,12 +202,12 @@ void Craft::load(const YAML::Node &node, const ScriptGlobal *shared, const Mod *
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Failed to load vehicle " << type;
+				XComLog(LOG_ERROR) << "Failed to load vehicle " << type;
 			}
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load vehicles item " << type;
+			XComLog(LOG_ERROR) << "Failed to load vehicles item " << type;
 		}
 	}
 	_status = node["status"].as<std::string>(_status);

--- a/src/Savegame/HitLog.cpp
+++ b/src/Savegame/HitLog.cpp
@@ -35,7 +35,7 @@ HitLog::HitLog(Language *lang) : _lastEventType(HITLOG_EMPTY), _lastFaction(FACT
 }
 
 /**
- * Clears the hit log. And updates the turn diary.
+ * Clears the hit XComLog. And updates the turn diary.
  */
 void HitLog::clearHitLog(bool resetTurnDiary, bool ignoreLastEntry)
 {
@@ -53,8 +53,8 @@ void HitLog::clearHitLog(bool resetTurnDiary, bool ignoreLastEntry)
 }
 
 /**
- * Appends a given entry to the hit log.
- * @param type Type of hit log entry.
+ * Appends a given entry to the hit XComLog.
+ * @param type Type of hit XComLog entry.
  * @param faction Faction of the actor.
  */
 void HitLog::appendToHitLog(HitLogEntryType type, UnitFaction faction)
@@ -101,8 +101,8 @@ void HitLog::appendToHitLog(HitLogEntryType type, UnitFaction faction)
 }
 
 /**
- * Appends a given entry to the hit log.
- * @param type Type of hit log entry.
+ * Appends a given entry to the hit XComLog.
+ * @param type Type of hit XComLog entry.
  * @param faction Faction of the actor.
  * @param text Text to append.
  */
@@ -129,9 +129,9 @@ void HitLog::appendToHitLog(HitLogEntryType type, UnitFaction faction, const std
 }
 
 /**
- * Gets the hit log text.
+ * Gets the hit XComLog text.
  * @param convert Convert line breaks to spaces?
- * @return hit log text.
+ * @return hit XComLog text.
  */
 std::string HitLog::getHitLogText(bool convert) const
 {

--- a/src/Savegame/HitLog.h
+++ b/src/Savegame/HitLog.h
@@ -52,16 +52,16 @@ private:
 	UnitFaction _lastFaction;
 	std::string _lastPlayerWeapon;
 
-	/// Clears the hit log. And updates the turn diary.
+	/// Clears the hit XComLog. And updates the turn diary.
 	void clearHitLog(bool resetTurnDiary, bool ignoreLastEntry = false);
 
 public:
-	/// Creates a new hit log.
+	/// Creates a new hit XComLog.
 	HitLog(Language *lang);
-	/// Appends the given text to the hit log.
+	/// Appends the given text to the hit XComLog.
 	void appendToHitLog(HitLogEntryType type, UnitFaction faction);
 	void appendToHitLog(HitLogEntryType type, UnitFaction faction, const std::string &text);
-	/// Gets the hit log text.
+	/// Gets the hit XComLog text.
 	std::string getHitLogText(bool convert = false) const;
 	/// Gets the turn diary.
 	const std::vector<std::string> &getTurnDiary() const { return _turnDiary; }

--- a/src/Savegame/SavedBattleGame.cpp
+++ b/src/Savegame/SavedBattleGame.cpp
@@ -356,7 +356,7 @@ void SavedBattleGame::load(const YAML::Node &node, Mod *mod, SavedGame* savedGam
 			}
 			else
 			{
-				Log(LOG_ERROR) << "Failed to load item " << type;
+				XComLog(LOG_ERROR) << "Failed to load item " << type;
 			}
 		}
 	}
@@ -2261,7 +2261,7 @@ Node *SavedBattleGame::getPatrolNode(bool scout, BattleUnit *unit, Node *fromNod
 
 	if (fromNode == 0)
 	{
-		if (Options::traceAI) { Log(LOG_INFO) << "This alien got lost. :("; }
+		if (Options::traceAI) { XComLog(LOG_INFO) << "This alien got lost. :("; }
 		fromNode = getNodes()->at(RNG::generate(0, getNodes()->size() - 1));
 		while (fromNode->isDummy())
 		{
@@ -2303,7 +2303,7 @@ Node *SavedBattleGame::getPatrolNode(bool scout, BattleUnit *unit, Node *fromNod
 
 	if (compliantNodes.empty())
 	{
-		if (Options::traceAI) { Log(LOG_INFO) << (scout ? "Scout " : "Guard") << " found on patrol node! XXX XXX XXX"; }
+		if (Options::traceAI) { XComLog(LOG_INFO) << (scout ? "Scout " : "Guard") << " found on patrol node! XXX XXX XXX"; }
 		if (unit->getArmor()->getSize() > 1 && !scout)
 		{
 			return getPatrolNode(true, unit, fromNode); // move dammit
@@ -2322,7 +2322,7 @@ Node *SavedBattleGame::getPatrolNode(bool scout, BattleUnit *unit, Node *fromNod
 		if (!preferred) return 0;
 
 		// non-scout patrols to highest value unoccupied node that's not fromNode
-		if (Options::traceAI) { Log(LOG_INFO) << "Choosing node flagged " << preferred->getFlags(); }
+		if (Options::traceAI) { XComLog(LOG_INFO) << "Choosing node flagged " << preferred->getFlags(); }
 		return preferred;
 	}
 }
@@ -3344,7 +3344,7 @@ std::string SavedBattleGame::getHiddenMovementBackground() const
 }
 
 /**
- * Appends a given entry to the hit log. Works only during the player's turn.
+ * Appends a given entry to the hit XComLog. Works only during the player's turn.
  */
 void SavedBattleGame::appendToHitLog(HitLogEntryType type, UnitFaction faction)
 {
@@ -3353,7 +3353,7 @@ void SavedBattleGame::appendToHitLog(HitLogEntryType type, UnitFaction faction)
 }
 
 /**
- * Appends a given entry to the hit log. Works only during the player's turn.
+ * Appends a given entry to the hit XComLog. Works only during the player's turn.
  */
 void SavedBattleGame::appendToHitLog(HitLogEntryType type, UnitFaction faction, const std::string &text)
 {
@@ -3362,8 +3362,8 @@ void SavedBattleGame::appendToHitLog(HitLogEntryType type, UnitFaction faction, 
 }
 
 /**
- * Gets the hit log.
- * @return hit log
+ * Gets the hit XComLog.
+ * @return hit XComLog
  */
 const HitLog *SavedBattleGame::getHitLog() const
 {

--- a/src/Savegame/SavedBattleGame.h
+++ b/src/Savegame/SavedBattleGame.h
@@ -608,10 +608,10 @@ public:
 	void setRandomHiddenMovementBackground(const Mod *mod);
 	/// Gets the hidden movement background ID.
 	std::string getHiddenMovementBackground() const;
-	/// Appends a given entry to the hit log. Works only during the player's turn.
+	/// Appends a given entry to the hit XComLog. Works only during the player's turn.
 	void appendToHitLog(HitLogEntryType type, UnitFaction faction);
 	void appendToHitLog(HitLogEntryType type, UnitFaction faction, const std::string &text);
-	/// Gets the hit log.
+	/// Gets the hit XComLog.
 	const HitLog *getHitLog() const;
 	/// Reset all the unit hit state flags.
 	void resetUnitHitStates();

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -272,7 +272,7 @@ static bool _isCurrentGameType(const SaveInfo &saveInfo, const std::string &curM
 
 	if (!matchMasterMod)
 	{
-		Log(LOG_DEBUG) << "skipping save from inactive master: " << saveInfo.fileName;
+		XComLog(LOG_DEBUG) << "skipping save from inactive master: " << saveInfo.fileName;
 	}
 
 	return matchMasterMod;
@@ -309,12 +309,12 @@ std::vector<SaveInfo> SavedGame::getList(Language *lang, bool autoquick)
 		}
 		catch (Exception &e)
 		{
-			Log(LOG_ERROR) << filename << ": " << e.what();
+			XComLog(LOG_ERROR) << filename << ": " << e.what();
 			continue;
 		}
 		catch (YAML::Exception &e)
 		{
-			Log(LOG_ERROR) << filename << ": " << e.what();
+			XComLog(LOG_ERROR) << filename << ": " << e.what();
 			continue;
 		}
 	}
@@ -459,7 +459,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load country " << type;
+			XComLog(LOG_ERROR) << "Failed to load country " << type;
 		}
 	}
 
@@ -474,7 +474,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load region " << type;
+			XComLog(LOG_ERROR) << "Failed to load region " << type;
 		}
 	}
 
@@ -490,7 +490,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load deployment for alien base " << deployment;
+			XComLog(LOG_ERROR) << "Failed to load deployment for alien base " << deployment;
 		}
 	}
 
@@ -508,7 +508,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load mission " << missionType;
+			XComLog(LOG_ERROR) << "Failed to load mission " << missionType;
 		}
 	}
 
@@ -523,7 +523,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load UFO " << type;
+			XComLog(LOG_ERROR) << "Failed to load UFO " << type;
 		}
 	}
 
@@ -540,7 +540,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load geoscape event " << eventName;
+			XComLog(LOG_ERROR) << "Failed to load geoscape event " << eventName;
 		}
 	}
 
@@ -564,7 +564,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load mission " << type << " deployment " << deployment;
+			XComLog(LOG_ERROR) << "Failed to load mission " << type << " deployment " << deployment;
 		}
 	}
 
@@ -581,7 +581,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load mission " << type << " deployment " << deployment;
+			XComLog(LOG_ERROR) << "Failed to load mission " << type << " deployment " << deployment;
 		}
 	}
 
@@ -595,7 +595,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load research " << research;
+			XComLog(LOG_ERROR) << "Failed to load research " << research;
 		}
 	}
 	sortReserchVector(_discovered);
@@ -675,7 +675,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load research " << id;
+			XComLog(LOG_ERROR) << "Failed to load research " << id;
 		}
 	}
 	_alienStrategy->load(doc["alienStrategy"], mod);
@@ -691,7 +691,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load soldier " << type;
+			XComLog(LOG_ERROR) << "Failed to load soldier " << type;
 		}
 	}
 
@@ -2690,7 +2690,7 @@ Region *SavedGame::locateRegion(double lon, double lat) const
 	{
 		return *found;
 	}
-	Log(LOG_ERROR) << "Failed to find a region at location [" << lon << ", " << lat << "].";
+	XComLog(LOG_ERROR) << "Failed to find a region at location [" << lon << ", " << lat << "].";
 	return 0;
 }
 
@@ -2734,7 +2734,7 @@ Country* SavedGame::locateCountry(double lon, double lat) const
 	{
 		return *found;
 	}
-	//Log(LOG_DEBUG) << "Failed to find a country at location [" << lon << ", " << lat << "].";
+	//XComLog(LOG_DEBUG) << "Failed to find a country at location [" << lon << ", " << lat << "].";
 	return 0;
 }
 

--- a/src/Savegame/Transfer.cpp
+++ b/src/Savegame/Transfer.cpp
@@ -69,7 +69,7 @@ bool Transfer::load(const YAML::Node& node, Base *base, const Mod *mod, SavedGam
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load soldier " << type;
+			XComLog(LOG_ERROR) << "Failed to load soldier " << type;
 			delete this;
 			return false;
 		}
@@ -84,7 +84,7 @@ bool Transfer::load(const YAML::Node& node, Base *base, const Mod *mod, SavedGam
 		}
 		else
 		{
-			Log(LOG_ERROR) << "Failed to load craft " << type;
+			XComLog(LOG_ERROR) << "Failed to load craft " << type;
 			delete this;
 			return false;
 		}
@@ -95,7 +95,7 @@ bool Transfer::load(const YAML::Node& node, Base *base, const Mod *mod, SavedGam
 		_itemId = item.as<std::string>(_itemId);
 		if (mod->getItem(_itemId) == 0)
 		{
-			Log(LOG_ERROR) << "Failed to load item " << _itemId;
+			XComLog(LOG_ERROR) << "Failed to load item " << _itemId;
 			delete this;
 			return false;
 		}

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -345,10 +345,10 @@ void StatsForNerdsState::btnOkClick(Action *)
 {
 	if (_game->isCtrlPressed())
 	{
-		Log(LOG_INFO) << _txtArticle->getText();
+		XComLog(LOG_INFO) << _txtArticle->getText();
 		for (size_t row = 0; row < _lstRawData->getTexts(); ++row)
 		{
-			Log(LOG_INFO) << _lstRawData->getCellText(row, 0) << "\t\t" << _lstRawData->getCellText(row, 1);
+			XComLog(LOG_INFO) << _lstRawData->getCellText(row, 0) << "\t\t" << _lstRawData->getCellText(row, 1);
 		}
 		return;
 	}


### PR DESCRIPTION
Macro Log was causing conflicts with PBRT Log function.
Therefore renamed OpenXCom Log macro to XComLog.

(I highly recommend incorporating ;) this small change to the code base to prevent future conflicts with other libraries that have their own Log function)

(Macros are not part of namespaces in C++)

Though this commit is not entirely clean, there are some small pieces of code referencing PBRT in map.cpp, but that should be easy to remove.