### PR TITLE
Melee attacks from ranged weapons now identifiable in soldier stats

### DIFF
--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -716,12 +716,12 @@ void BattlescapeGame::checkForCasualties(const RuleDamageType *damageType, Battl
 		}
 		if (attack.damage_item)
 		{
-			// If the secondary melee data is used, represent this by setting the ammo to "BA_HIT".
+			// If the secondary melee data is used, represent this by setting the ammo to "__GUNBUTT".
 			// Note: BT_MELEE items use their normal attack data rather than 'melee' data. So their 'ammo' should be the weapon itself.
 			// (The following condition should match what is used in ExplosionBState::init to choose the damage power and type.)
 			if (attack.type == BA_HIT && attack.damage_item->getRules()->getBattleType() != BT_MELEE)
 			{
-				tempAmmo = "BA_HIT";
+				tempAmmo = "__GUNBUTT";
 			}
 			else
 			{

--- a/src/Battlescape/BattlescapeGame.cpp
+++ b/src/Battlescape/BattlescapeGame.cpp
@@ -716,7 +716,17 @@ void BattlescapeGame::checkForCasualties(const RuleDamageType *damageType, Battl
 		}
 		if (attack.damage_item)
 		{
-			tempAmmo = attack.damage_item->getRules()->getName();
+			// If the secondary melee data is used, represent this by setting the ammo to "BA_HIT".
+			// Note: BT_MELEE items use their normal attack data rather than 'melee' data. So their 'ammo' should be the weapon itself.
+			// (The following condition should match what is used in ExplosionBState::init to choose the damage power and type.)
+			if (attack.type == BA_HIT && attack.damage_item->getRules()->getBattleType() != BT_MELEE)
+			{
+				tempAmmo = "BA_HIT";
+			}
+			else
+			{
+				tempAmmo = attack.damage_item->getRules()->getName();
+			}
 		}
 	}
 

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -464,37 +464,46 @@ bool SoldierDiary::manageCommendations(Mod *mod, std::vector<MissionStatistics*>
 							// Loop over the DETAILs of one AND vector.
 							for (std::vector<std::string>::const_iterator detail = andCriteria->second.begin(); detail != andCriteria->second.end(); ++detail)
 							{
-								int battleType = 0;
-								for (; battleType != BATTLE_TYPES; ++battleType)
+								// Look if for match for this criteria.
+								// If we find a match, continue to the next criteria. (We must match all criteria in the list.)
+								// If we don't find a match, set foundMatch = false; then break.
+
+								if ( (*singleKill)->rank == (*detail) || (*singleKill)->race == (*detail) ||
+									 (*singleKill)->weapon == (*detail) || (*singleKill)->weaponAmmo == (*detail) ||
+									 (*singleKill)->getUnitStatusString() == (*detail) || (*singleKill)->getUnitFactionString() == (*detail) ||
+									 (*singleKill)->getUnitSideString() == (*detail) || (*singleKill)->getUnitBodyPartString() == (*detail) )
 								{
-									if ((*detail) == battleTypeArray[battleType])
-									{
-										break;
-									}
+									// Found match
+									continue;
 								}
 
-								int damageType = 0;
-								for (; damageType != DAMAGE_TYPES; ++damageType)
-								{
-									if ((*detail) == damageTypeArray[damageType])
-									{
-										break;
-									}
-								}
-
-								// See if we find _no_ matches with any criteria. If so, break and try the next kill.
+								// check the weapon's battle type and damage type
 								RuleItem *weapon = mod->getItem((*singleKill)->weapon);
-								RuleItem *weaponAmmo = mod->getItem((*singleKill)->weaponAmmo);
-								if (weapon == 0 || weaponAmmo == 0 ||
-									((*singleKill)->rank != (*detail) && (*singleKill)->race != (*detail) &&
-									 (*singleKill)->weapon != (*detail) && (*singleKill)->weaponAmmo != (*detail) &&
-									 (*singleKill)->getUnitStatusString() != (*detail) && (*singleKill)->getUnitFactionString() != (*detail) &&
-									 (*singleKill)->getUnitSideString() != (*detail) && (*singleKill)->getUnitBodyPartString() != (*detail) &&
-									 weaponAmmo->getDamageType()->ResistType != damageType && weapon->getBattleType() != battleType))
+								if (weapon != 0)
 								{
-									foundMatch = false;
-									break;
+									int battleType = weapon->getBattleType();
+
+									if (battleType >=0 && battleType < BATTLE_TYPES && battleTypeArray[battleType] == (*detail))
+									{
+										// the detail matched the weapon's battle type
+										continue;
+									}
+
+									// damage type. If no 'ammo' is listed, we assume that the gun's secondary melee attack was used.
+									// (i.e. weaponAmmo == "BA_HIT")
+									RuleItem *weaponAmmo = mod->getItem((*singleKill)->weaponAmmo);
+									int damageType = (weaponAmmo != 0) ? weaponAmmo->getDamageType()->ResistType : weapon->getMeleeType()->ResistType;
+
+									if (damageType >= 0 && damageType < DAMAGE_TYPES && damageTypeArray[damageType] == (*detail))
+									{
+										// the detail matched the damage type
+										continue;
+									}
 								}
+
+								// That's all we can check. We didn't find a match
+								foundMatch = false;
+								break;
 							} /// End of DETAIL loop.
 
 							if (foundMatch)

--- a/src/Savegame/SoldierDiary.cpp
+++ b/src/Savegame/SoldierDiary.cpp
@@ -489,10 +489,20 @@ bool SoldierDiary::manageCommendations(Mod *mod, std::vector<MissionStatistics*>
 										continue;
 									}
 
-									// damage type. If no 'ammo' is listed, we assume that the gun's secondary melee attack was used.
-									// (i.e. weaponAmmo == "BA_HIT")
+
 									RuleItem *weaponAmmo = mod->getItem((*singleKill)->weaponAmmo);
-									int damageType = (weaponAmmo != 0) ? weaponAmmo->getDamageType()->ResistType : weapon->getMeleeType()->ResistType;
+									int damageType = -1;
+
+									if (weaponAmmo != 0)
+									{
+										damageType = weaponAmmo->getDamageType()->ResistType;
+									}
+									else if ((*singleKill)->weaponAmmo == "__GUNBUTT")
+									{
+										// If weaponAmmo == "__GUNBUTT", that means the gun's secondary melee attack was used.
+										damageType = weapon->getMeleeType()->ResistType;
+									}
+									// If we were unable to determine the damage type, leave it as -1.
 
 									if (damageType >= 0 && damageType < DAMAGE_TYPES && damageTypeArray[damageType] == (*detail))
 									{


### PR DESCRIPTION
Kill stats record the weapon name and the ammo name used for each kill.
But until now, there was no way of telling if a gun's melee attack was used.
This led to incorrect damage types when awarding commendations.

To fix this, we now list 'BA_HIT' as the ammo type when the secondary melee
damage is used. Melee weapons and ammoless guns still put the weapon itself
as the ammo field so that their main damage data is used.

When checking commendation conditions, 'BA_HIT' indicates that the ranged
weapon's melee damage data should be used rather than the default data.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->