### PR TITLE
Items created from geoscape events now arrive immediately.

### DIFF
--- a/src/Battlescape/DebriefingState.cpp
+++ b/src/Battlescape/DebriefingState.cpp
@@ -869,6 +869,16 @@ void DebriefingState::btnOkClick(Action *)
 			if (canSpawn)
 			{
 				_game->pushState(new GeoscapeEventState(*_eventToSpawn));
+				if (_eventToSpawn->isAnyItemTransfer())
+				{
+					Base *hq = _game->getSavedGame()->getBases()->front();
+					if (hq != _base && Options::storageLimitsEnforced && hq != 0 && hq->storesOverfull()) // The current base will be checked in a moment.
+					{
+						_game->pushState(new SellState(hq, 0));
+						_game->pushState(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(hq->getName()), _palette, _game->getMod()->getInterface("debriefing")->getElement("errorMessage")->color, "BACK01.SCR", _game->getMod()->getInterface("debriefing")->getElement("errorPalette")->color));
+					}
+					// _game->pushState(new ItemsArrivingState(geoscapeState)); // Can't create an 'items arriving' popup for this type of event, because we don't have a geoscape state.
+				}
 			}
 		}
 		if (!_deadSoldiersCommended.empty())

--- a/src/Geoscape/GeoscapeEventState.cpp
+++ b/src/Geoscape/GeoscapeEventState.cpp
@@ -255,9 +255,10 @@ void GeoscapeEventState::eventLogic()
 
 	for (auto& ti : itemsToTransfer)
 	{
-		Transfer *t = new Transfer(1);
+		Transfer *t = new Transfer(0);
 		t->setItems(ti.first, ti.second);
 		hq->getTransfers()->push_back(t);
+		t->advance(hq); // Have the items arrive right away.
 	}
 
 	// 4. give bonus research

--- a/src/Geoscape/GeoscapeEventState.cpp
+++ b/src/Geoscape/GeoscapeEventState.cpp
@@ -255,7 +255,7 @@ void GeoscapeEventState::eventLogic()
 
 	for (auto& ti : itemsToTransfer)
 	{
-		Transfer *t = new Transfer(0);
+		Transfer *t = new Transfer(1);
 		t->setItems(ti.first, ti.second);
 		hq->getTransfers()->push_back(t);
 		t->advance(hq); // Have the items arrive right away.
@@ -347,13 +347,6 @@ void GeoscapeEventState::init()
 void GeoscapeEventState::btnOkClick(Action *)
 {
 	_game->popState();
-
-	Base *base = _game->getSavedGame()->getBases()->front();
-	if (_game->getSavedGame()->getMonthsPassed() > -1 && Options::storageLimitsEnforced && base != 0 && base->storesOverfull())
-	{
-		_game->pushState(new SellState(base, 0));
-		_game->pushState(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(base->getName()), _palette, _game->getMod()->getInterface("debriefing")->getElement("errorMessage")->color, "BACK01.SCR", _game->getMod()->getInterface("debriefing")->getElement("errorPalette")->color));
-	}
 
 	if (!_bonusResearchName.empty())
 	{

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1793,7 +1793,15 @@ bool GeoscapeState::processMissionSite(MissionSite *site)
 			if (eventRules->isAnyItemTransfer())
 			{
 				popup(new ItemsArrivingState(this));
+
+				Base *hq = _game->getSavedGame()->getBases()->front();
+				if (Options::storageLimitsEnforced && hq != 0 && hq->storesOverfull())
+				{
+					popup(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(hq->getName()), _palette, _game->getMod()->getInterface("debriefing")->getElement("errorMessage")->color, "BACK01.SCR", _game->getMod()->getInterface("debriefing")->getElement("errorPalette")->color));
+					popup(new SellState(hq, 0));
+				}
 			}
+
 		}
 	}
 
@@ -2058,6 +2066,13 @@ void GeoscapeState::time30Minutes()
 				if (ge->getRules().isAnyItemTransfer())
 				{
 					popup(new ItemsArrivingState(this));
+
+					Base *hq = _game->getSavedGame()->getBases()->front();
+					if (Options::storageLimitsEnforced && hq != 0 && hq->storesOverfull())
+					{
+						popup(new ErrorMessageState(tr("STR_STORAGE_EXCEEDED").arg(hq->getName()), _palette, _game->getMod()->getInterface("debriefing")->getElement("errorMessage")->color, "BACK01.SCR", _game->getMod()->getInterface("debriefing")->getElement("errorPalette")->color));
+						popup(new SellState(hq, 0));
+					}
 				}
 			}
 		}

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1790,6 +1790,10 @@ bool GeoscapeState::processMissionSite(MissionSite *site)
 		{
 			timerReset();
 			popup(new GeoscapeEventState(*eventRules));
+			if (eventRules->isAnyItemTransfer())
+			{
+				popup(new ItemsArrivingState(this));
+			}
 		}
 	}
 
@@ -2051,6 +2055,10 @@ void GeoscapeState::time30Minutes()
 			{
 				timerReset();
 				popup(new GeoscapeEventState(ge->getRules()));
+				if (ge->getRules().isAnyItemTransfer())
+				{
+					popup(new ItemsArrivingState(this));
+				}
 			}
 		}
 	}

--- a/src/Geoscape/ItemsArrivingState.cpp
+++ b/src/Geoscape/ItemsArrivingState.cpp
@@ -100,7 +100,7 @@ ItemsArrivingState::ItemsArrivingState(GeoscapeState *state) : _state(state), _b
 	{
 		for (std::vector<Transfer*>::iterator j = (*i)->getTransfers()->begin(); j != (*i)->getTransfers()->end();)
 		{
-			if ((*j)->getHours() == 0)
+			if ((*j)->isDelivered())
 			{
 				_base = (*i);
 

--- a/src/Mod/RuleEvent.h
+++ b/src/Mod/RuleEvent.h
@@ -90,6 +90,8 @@ public:
 	const std::vector<std::map<std::string, int> > &getRandomMultiItemList() const { return _randomMultiItemList; }
 	/// Gets a list of items; one of them is randomly selected (considering weights) and transferred to HQ stores when this event pops up.
 	const WeightedOptions &getWeightedItemList() const { return _weightedItemList; }
+	/// Returns true if the event has any type of item transfer to HQ
+	bool isAnyItemTransfer() const { return !_everyItemList.empty() || !_everyMultiItemList.empty() || !_randomItemList.empty() || !_randomMultiItemList.empty() || !_weightedItemList.empty(); }
 	/// Gets a list of research projects; one of them will be randomly discovered when this event pops up.
 	const std::vector<std::string> &getResearchList() const { return _researchList; }
 	/// Gets the research project that will interrupt/terminate an already generated (but not yet popped up) event.

--- a/src/Savegame/Base.cpp
+++ b/src/Savegame/Base.cpp
@@ -821,6 +821,9 @@ double Base::getUsedStores(bool excludeNormalItems) const
 	}
 	for (std::vector<Transfer*>::const_iterator i = _transfers.begin(); i != _transfers.end(); ++i)
 	{
+		if ((*i)->isDelivered()) // Just in case we want to check storage before the popup clears a completed transfer.
+			continue;
+
 		if ((*i)->getType() == TRANSFER_ITEM)
 		{
 			total += (*i)->getQuantity() * _mod->getItem((*i)->getItems(), true)->getSize();

--- a/src/Savegame/Transfer.cpp
+++ b/src/Savegame/Transfer.cpp
@@ -298,7 +298,7 @@ TransferType Transfer::getType() const
 void Transfer::advance(Base *base)
 {
 	_hours--;
-	if (_hours <= 0)
+	if (_hours <= 0 && !_delivered)
 	{
 		if (_soldier != 0)
 		{

--- a/src/Savegame/Transfer.h
+++ b/src/Savegame/Transfer.h
@@ -95,6 +95,8 @@ public:
 	std::string getName(Language *lang) const;
 	/// Gets the hours remaining of the transfer.
 	int getHours() const;
+	/// Has the transfer arrived at the destination?
+	bool isDelivered() const { return _delivered; }
 	/// Gets the quantity of the transfer.
 	int getQuantity() const;
 	/// Gets the type of the transfer.


### PR DESCRIPTION
Previously, items from geoscape events were scheduled to arrive after 1 hour. This created an awkward time where the items were unseen and unusable, but still took up storage space.

This change makes the items arrive immediately after the event, and shows the usual 'items arriving' popup.

Also added `Transfer::isDelivered()`; which is more explicit and less error-prone than checking `getHours() == 0`.

Note: only events that have one or more item lists will trigger the immediate popup. But the popup will still be triggered even if the event fails to create the items. For example, if the event only lists items that don't exist - the player will still see an 'items arriving' popup that lists nothing. This may or may not be appropriate. I've never seen anyone make an event like that, so I'm not sure what the desired behaviour would be.

<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->