### PR TITLE
Rewrite of StatString and Addition of New percentage based rules.

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -269,6 +269,7 @@ void create()
 	_info.push_back(OptionInfo("oxceDisableAlienInventory", &oxceDisableAlienInventory, false, "", "HIDDEN"));
 	_info.push_back(OptionInfo("oxceDisableInventoryTuCost", &oxceDisableInventoryTuCost, false, "", "HIDDEN"));
 	_info.push_back(OptionInfo("oxceShowBaseNameInPopups", &oxceShowBaseNameInPopups, false, "", "HIDDEN"));
+	_info.push_back(OptionInfo("oxceStatStringDivider", &oxceStatStringDivider, "/", "", "HIDDEN"));
 
 	// controls
 	_info.push_back(OptionInfo("keyOk", &keyOk, SDLK_RETURN, "STR_OK", "STR_GENERAL"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -121,6 +121,7 @@ OPT bool oxceDisableHitLog;
 OPT bool oxceDisableAlienInventory;
 OPT bool oxceDisableInventoryTuCost;
 OPT bool oxceShowBaseNameInPopups;
+OPT std::string oxceStatStringDivider;
 
 // Flags and other stuff that don't need OptionInfo's.
 OPT bool mute, reload, newOpenGL, newScaleFilter, newHQXFilter, newXBRZFilter, newRootWindowedMode, newFullscreen, newAllowResize, newBorderless;

--- a/src/Mod/StatString.cpp
+++ b/src/Mod/StatString.cpp
@@ -25,34 +25,36 @@
 namespace OpenXcom
 {
 
-constexpr static auto absoluteConditionData = std::array<std::pair<std::string_view, StatType>, 12>{{
-	{"psiStrength", StatType::PSI_STRENGTH},
-	{"psiSkill", StatType::PSI_SKILL},
-	{"bravery", StatType::BRAVERY},
-	{"strength", StatType::STRENGTH},
-	{"firing", StatType::FIRING},
-	{"reactions", StatType::REACTIONS},
-	{"stamina", StatType::STAMINA},
-	{"tu", StatType::TU},
-	{"health", StatType::HEALTH},
-	{"throwing", StatType::THROWING},
-	{"melee", StatType::MELEE},
-	{"manaPool", StatType::MANA},
+typedef UnitStats::Type UnitStat;
+
+constexpr static auto absoluteConditionData = std::array<std::pair<std::string_view, UnitStat UnitStats::*>, 12>{{
+	{"psiStrength", &UnitStats::psiStrength},
+	{"psiSkill",    &UnitStats::psiSkill},
+	{"bravery",     &UnitStats::bravery},
+	{"strength",    &UnitStats::strength},
+	{"firing",      &UnitStats::firing},
+	{"reactions",   &UnitStats::reactions},
+	{"stamina",     &UnitStats::stamina},
+	{"tu",          &UnitStats::tu},
+	{"health",      &UnitStats::health},
+	{"throwing",    &UnitStats::throwing},
+	{"melee",       &UnitStats::melee},
+	{"manaPool",    &UnitStats::mana},
 }};
 
-constexpr static auto percentConditionData = std::array<std::pair<std::string_view, StatType>, 12>{{
-	{"percentPsiStrength", StatType::PSI_STRENGTH},
-	{"percentPsiSkill", StatType::PSI_SKILL},
-	{"percentBravery", StatType::BRAVERY},
-	{"percentStrength", StatType::STRENGTH},
-	{"percentFiring", StatType::FIRING},
-	{"percentReactions", StatType::REACTIONS},
-	{"percentStamina", StatType::STAMINA},
-	{"percentTu", StatType::TU},
-	{"percentHealth", StatType::HEALTH},
-	{"percentThrowing", StatType::THROWING},
-	{"percentMelee", StatType::MELEE},
-	{"percentManaPool", StatType::MANA},
+constexpr static auto percentConditionData = std::array<std::pair<std::string_view, UnitStats::Type UnitStats::*>, 12>{{
+	{"percentPsiStrength", &UnitStats::psiStrength},
+	{"percentPsiSkill",    &UnitStats::psiSkill},
+	{"percentBravery",     &UnitStats::bravery},
+	{"percentStrength",    &UnitStats::strength},
+	{"percentFiring",      &UnitStats::firing},
+	{"percentReactions",   &UnitStats::reactions},
+	{"percentStamina",     &UnitStats::stamina},
+	{"percentTu",          &UnitStats::tu},
+	{"percentHealth",      &UnitStats::health},
+	{"percentThrowing",    &UnitStats::throwing},
+	{"percentMelee",       &UnitStats::melee},
+	{"percentManaPool",    &UnitStats::mana},
 }};
 
 constexpr static auto trainingConditionData = std::array<std::pair<std::string_view, TrainingType>, 2>{{

--- a/src/Mod/StatString.h
+++ b/src/Mod/StatString.h
@@ -105,14 +105,14 @@ static constexpr bool STATSTRING_GLOBALRULE_DEFAULT = false;
 
 class StatString
 {
-  private:
+private:
 	/// string that is added if conditions are met.
 	std::string _conditionString;
 	std::vector<std::unique_ptr<const StatStringCondition>> _conditions;
 	/// global rules combine with soldierType specific rules.
 	bool _globalRule = STATSTRING_GLOBALRULE_DEFAULT;
 
-  public:
+public:
 	/// Creates a blank StatString ruleset.
 	StatString() = default;
 

--- a/src/Mod/StatStringCondition.cpp
+++ b/src/Mod/StatStringCondition.cpp
@@ -17,72 +17,62 @@
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "StatStringCondition.h"
-
+#include "../Savegame/Soldier.h"
+#include "../Mod/RuleSoldier.h"
+#include "../Engine/Logger.h"
 
 namespace OpenXcom
 {
 /**
- * Creates a blank StatStringCondition.
- * @param conditionName Name of the condition.
- * @param minVal Minimum value.
- * @param maxVal Maximum value.
- */
-StatStringCondition::StatStringCondition(const std::string &conditionName, int minVal, int maxVal) : _conditionName(conditionName), _minVal(minVal), _maxVal(maxVal)
-{
-}
-
-/**
- * Cleans up the extra StatStringCondition.
- */
-StatStringCondition::~StatStringCondition()
-{
-}
-
-/**
- * Gets the condition string.
- * @return Name of the associated stat.
- */
-std::string StatStringCondition::getConditionName() const
-{
-	return _conditionName;
-}
-
-/**
- * Gets the minimum value for the condition (default is 0).
- * @return The minimum value.
- */
-int StatStringCondition::getMinVal() const
-{
-	return _minVal;
-}
-
-/**
- * Gets the maximum value for the condition (default is 255).
- * @return The maximum value.
- */
-int StatStringCondition::getMaxVal() const
-{
-	return _maxVal;
-}
-
-/**
- * Checks if this condition is valid for the current stat.
- * @param stat The current soldier stat.
- * @param psi Can we show psi stats?
+ * Checks if this condition is valid for the given soldier.
+ * @param soldier The soldier to test.
  * @return If the condition is met.
  */
-bool StatStringCondition::isMet(int stat, bool psi) const
+bool StatStringConditionAbsolulte::isMet(const Soldier &soldier) const
 {
-	if (_conditionName == "psiTraining")
-	{
-		return true;
-	}
-	bool conditionMet = (stat >= _minVal && stat <= _maxVal);
-	if (_conditionName == "psiStrength" || _conditionName == "psiSkill")
-	{
-		conditionMet = conditionMet && psi;
-	}
-	return conditionMet;
+	const int stat = soldier.getCurrentStats()[_statType];
+	return stat >= _minVal && stat <= _maxVal;
 }
 
+/**
+ * Checks if this condition is valid for the given soldier.
+ * @param soldier The soldier to test.
+ * @return If the condition is met.
+ */
+bool StatStringConditionPercent::isMet(const Soldier &soldier) const
+{
+	const int stat = soldier.getCurrentStats()[_statType];
+	const int cap = soldier.getRules()->getStatCaps()[_statType];
+
+	// cap should probably never be 0, but we'll handle that just in case to avoid DBZ.
+	if (cap == 0)
+	{
+		return _minVal <= 0;
+	}
+
+	// we store our percents as values from 0-100, so multiply to get them in range.
+	float percent = (static_cast<float>(stat) / cap) * 100;
+
+	// Since these are not integers we make do a range that is [minVal, maxVal)
+	return percent >= _minVal && percent < _maxVal;
+}
+
+/**
+ * Checks if this condition is valid for the given soldier.
+ * @param soldier The soldier to test.
+ * @return If the condition is met.
+ */
+bool StatStringConditionTraining::isMet(const Soldier &soldier) const
+{
+	switch (_trainingType)
+	{
+	case TrainingType::PSI_TRAINING:
+		return soldier.isInPsiTraining() == _inTraining;
+	case TrainingType::PHYS_TRAINING:
+		return soldier.isInTraining() == _inTraining;
+	default:
+		Log(LOG_ERROR) << "Invalid Training Type Enum.";
+		return false;
+	}
+}
 }

--- a/src/Mod/StatStringCondition.cpp
+++ b/src/Mod/StatStringCondition.cpp
@@ -30,7 +30,7 @@ namespace OpenXcom
  */
 bool StatStringConditionAbsolulte::isMet(const Soldier &soldier) const
 {
-	const int stat = soldier.getCurrentStats()[_statType];
+	const int stat = soldier.getCurrentStats().*_statRef;
 	return stat >= _minVal && stat <= _maxVal;
 }
 
@@ -41,8 +41,8 @@ bool StatStringConditionAbsolulte::isMet(const Soldier &soldier) const
  */
 bool StatStringConditionPercent::isMet(const Soldier &soldier) const
 {
-	const int stat = soldier.getCurrentStats()[_statType];
-	const int cap = soldier.getRules()->getStatCaps()[_statType];
+	const int stat = soldier.getCurrentStats().*_statRef;
+	const int cap = soldier.getRules()->getStatCaps().*_statRef;
 
 	// cap should probably never be 0, but we'll handle that just in case to avoid DBZ.
 	if (cap == 0)

--- a/src/Mod/StatStringCondition.h
+++ b/src/Mod/StatStringCondition.h
@@ -39,10 +39,10 @@ static constexpr bool STAT_CONDITION_TRAINING_INTRAINING_DEFAULT = true;
  */
 class StatStringCondition
 {
-  private:
+private:
 	bool _psiCondition;
 
-  public:
+public:
 	/// Create a new StatString Condition
 	StatStringCondition(bool psi) : _psiCondition(psi) {}
 
@@ -65,15 +65,15 @@ class StatStringCondition
  */
 class StatStringConditionAbsolulte : public StatStringCondition
 {
-  private:
+private:
 	int _minVal, _maxVal;
-	StatType _statType;
+	UnitStats::Type UnitStats::* _statRef;
 
-  public:
+public:
 	/// Creates a StandardStatStringCondition, for testing if a stat is in an attribute range.
-	StatStringConditionAbsolulte(StatType stat,  int minVal, int maxVal)
-		: StatStringCondition(stat == StatType::PSI_SKILL || stat == StatType::PSI_STRENGTH),
-			_statType(stat), _minVal(minVal), _maxVal(maxVal) {}
+	StatStringConditionAbsolulte(UnitStats::Type UnitStats::* stat, int minVal, int maxVal)
+	  : StatStringCondition(stat == &UnitStats::psiStrength || stat == &UnitStats::psiSkill),
+			_statRef(stat), _minVal(minVal), _maxVal(maxVal) {}
 	
 	/// Checks if a soldier meets this condition.
 	bool isMet(const Soldier &soldier) const override;
@@ -86,15 +86,15 @@ class StatStringConditionAbsolulte : public StatStringCondition
  */
 class StatStringConditionPercent : public StatStringCondition
 {
-  private:
+private:
 	float _minVal, _maxVal;
-	StatType _statType;
+	UnitStats::Type UnitStats::*_statRef;
 
-  public:
+public:
 	/// Creates a condition, for testing if a stat is an percentage range.
-	StatStringConditionPercent(StatType stat, float minVal, float maxVal)
-		: StatStringCondition(stat == StatType::PSI_SKILL || stat == StatType::PSI_STRENGTH),
-		  _statType(stat), _minVal(minVal), _maxVal(maxVal) {}
+	StatStringConditionPercent(UnitStats::Type UnitStats::* stat, float minVal, float maxVal)
+		: StatStringCondition(stat == &UnitStats::psiStrength || stat == &UnitStats::psiSkill),
+		  _statRef(stat), _minVal(minVal), _maxVal(maxVal) {}
 
 	bool isMet(const Soldier &soldier) const override;
 };
@@ -106,17 +106,16 @@ enum class TrainingType { PSI_TRAINING, PHYS_TRAINING };
  */
 class StatStringConditionTraining : public StatStringCondition
 {
-  private:
+private:
 	bool _inTraining = STAT_CONDITION_TRAINING_INTRAINING_DEFAULT;
 	TrainingType _trainingType;
 
-  public:
+public:
 	/// Creates a conditio for checking if a soldier is in PsiTraining.
 	StatStringConditionTraining(TrainingType trainingType, bool inTraining = STAT_CONDITION_TRAINING_INTRAINING_DEFAULT)
 		: StatStringCondition(trainingType == TrainingType::PSI_TRAINING), _trainingType(trainingType), _inTraining(inTraining) {}
 
 	bool isMet(const Soldier &soldier) const override;
 };
-
 
 }

--- a/src/Mod/StatStringCondition.h
+++ b/src/Mod/StatStringCondition.h
@@ -17,30 +17,106 @@
  * You should have received a copy of the GNU General Public License
  * along with OpenXcom.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <string>
+#include "Unit.h"
 
 namespace OpenXcom
 {
 
+class Soldier;
+
+// from X-Com Util.
+static constexpr int STATSTRING_CONDITION_ABSOLUTE_DEFAULT_MIN = 0;
+static constexpr int STATSTRING_CONDITION_ABSOLUTE_DEFAULT_MAX = 255;
+
+static constexpr float STATSTRING_CONDITION_PERCENT_DEFAULT_MIN = 0;
+static constexpr float STATSTRING_CONDITION_PERCENT_DEFAULT_MAX = 255;
+
+static constexpr bool STAT_CONDITION_TRAINING_INTRAINING_DEFAULT = true;
+
+/**
+ * @brief Abstract base class for a condition.
+ * All conditions are either psi related conditions or not, and can test if a soldier meets them.
+ */
 class StatStringCondition
 {
-private:
-	std::string _conditionName;
-	int _minVal;
-	int _maxVal;
-public:
-	/// Creates a blank StatStringCondition.
-	StatStringCondition(const std::string &conditionName, int minVal, int maxVal);
-	/// Cleans up the StatStringCondition.
-	virtual ~StatStringCondition();
-	/// Gets the condition name.
-	std::string getConditionName() const;
-	/// Gets the minimum value.
-	int getMinVal() const;
-	/// Gets the maximum value.
-	int getMaxVal() const;
-	/// Checks if the condition has been met.
-	bool isMet(int stat, bool psi) const;
+  private:
+	bool _psiCondition;
+
+  public:
+	/// Create a new StatString Condition
+	StatStringCondition(bool psi) : _psiCondition(psi) {}
+
+	/// none of our chihldren should need special destruction, but just in case.
+	virtual ~StatStringCondition() = default;
+
+	// because this is an abstract class, we don't want it to be copied, slicing will result.
+	StatStringCondition(const StatStringCondition&) = delete;
+	StatStringCondition &operator=(const StatStringCondition &) = delete;
+
+	/// Gets if this condition is a psi or not.
+	virtual bool isPsiCondition() const { return _psiCondition; }
+	/// Checks if a soldier meets this condition.
+	virtual bool isMet(const Soldier &soldier) const = 0;
 };
+
+/**
+ * @brief Condition to test if a soldiers attribute is in a given range.
+ * Range is treated as [minVal, maxVal]. Is a PsiCondition if the stat is a psiStat.
+ */
+class StatStringConditionAbsolulte : public StatStringCondition
+{
+  private:
+	int _minVal, _maxVal;
+	StatType _statType;
+
+  public:
+	/// Creates a StandardStatStringCondition, for testing if a stat is in an attribute range.
+	StatStringConditionAbsolulte(StatType stat,  int minVal, int maxVal)
+		: StatStringCondition(stat == StatType::PSI_SKILL || stat == StatType::PSI_STRENGTH),
+			_statType(stat), _minVal(minVal), _maxVal(maxVal) {}
+	
+	/// Checks if a soldier meets this condition.
+	bool isMet(const Soldier &soldier) const override;
+};
+
+/**
+ * @brief Condition to test if a soldiers attributes fall in a given percent range of their cap.
+ * Note that while the min/max are floats, they are stored on a 0-100 basis, not 0-1.
+ * Range is treated as [minVal, maxVal). Is a PsiCondition if the stat is a psiStat.
+ */
+class StatStringConditionPercent : public StatStringCondition
+{
+  private:
+	float _minVal, _maxVal;
+	StatType _statType;
+
+  public:
+	/// Creates a condition, for testing if a stat is an percentage range.
+	StatStringConditionPercent(StatType stat, float minVal, float maxVal)
+		: StatStringCondition(stat == StatType::PSI_SKILL || stat == StatType::PSI_STRENGTH),
+		  _statType(stat), _minVal(minVal), _maxVal(maxVal) {}
+
+	bool isMet(const Soldier &soldier) const override;
+};
+
+enum class TrainingType { PSI_TRAINING, PHYS_TRAINING };
+
+/**
+ * @brief Condition to test if a soldier is in Training. Always a psi condition. 
+ */
+class StatStringConditionTraining : public StatStringCondition
+{
+  private:
+	bool _inTraining = STAT_CONDITION_TRAINING_INTRAINING_DEFAULT;
+	TrainingType _trainingType;
+
+  public:
+	/// Creates a conditio for checking if a soldier is in PsiTraining.
+	StatStringConditionTraining(TrainingType trainingType, bool inTraining = STAT_CONDITION_TRAINING_INTRAINING_DEFAULT)
+		: StatStringCondition(trainingType == TrainingType::PSI_TRAINING), _trainingType(trainingType), _inTraining(inTraining) {}
+
+	bool isMet(const Soldier &soldier) const override;
+};
+
 
 }

--- a/src/Mod/Unit.h
+++ b/src/Mod/Unit.h
@@ -19,9 +19,11 @@
  */
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <yaml-cpp/yaml.h>
 #include <SDL_types.h>
 #include "../Engine/RNG.h"
+#include "../Engine/Logger.h"
 
 namespace OpenXcom
 {
@@ -33,6 +35,23 @@ class ModScript;
 class ScriptParserBase;
 
 enum SpecialAbility { SPECAB_NONE, SPECAB_EXPLODEONDEATH, SPECAB_BURNFLOOR, SPECAB_BURN_AND_EXPLODE };
+
+enum class StatType
+{
+	PSI_STRENGTH,
+	PSI_SKILL,
+	BRAVERY,
+	STRENGTH,
+	FIRING,
+	REACTIONS,
+	STAMINA,
+	TU,
+	HEALTH,
+	THROWING,
+	MELEE,
+	MANA,
+};
+
 /**
  * This struct holds some plain unit attribute data together.
  */
@@ -62,6 +81,45 @@ struct UnitStats
 	UnitStats operator-(const UnitStats& stats) const { return UnitStats(tu - stats.tu, stamina - stats.stamina, health - stats.health, bravery - stats.bravery, reactions - stats.reactions, firing - stats.firing, throwing - stats.throwing, strength - stats.strength, psiStrength - stats.psiStrength, psiSkill - stats.psiSkill, melee - stats.melee, mana - stats.mana); }
 	UnitStats operator-() const { return UnitStats(-tu, -stamina, -health, -bravery, -reactions, -firing, -throwing, -strength, -psiStrength, -psiSkill, -melee, -mana); }
 	void merge(const UnitStats& stats) { tu = (stats.tu ? stats.tu : tu); stamina = (stats.stamina ? stats.stamina : stamina); health = (stats.health ? stats.health : health); bravery = (stats.bravery ? stats.bravery : bravery); reactions = (stats.reactions ? stats.reactions : reactions); firing = (stats.firing ? stats.firing : firing); throwing = (stats.throwing ? stats.throwing : throwing); strength = (stats.strength ? stats.strength : strength); psiStrength = (stats.psiStrength ? stats.psiStrength : psiStrength); psiSkill = (stats.psiSkill ? stats.psiSkill : psiSkill); melee = (stats.melee ? stats.melee : melee); mana = (stats.mana ? stats.mana : mana); };
+
+	/**
+	 * @brief Gets the attribute identified by a text string. 
+	 * @param attribute the attribute to get. 
+	 * @return a const reference to the attribute.
+	*/
+	const Type &operator[](StatType attribute) const
+	{
+		switch (attribute)
+		{
+		case StatType::PSI_STRENGTH:
+			return psiStrength;
+		case StatType::PSI_SKILL:
+			return psiSkill;
+		case StatType::BRAVERY:
+			return bravery;
+		case StatType::STRENGTH:
+			return strength;
+		case StatType::FIRING:
+			return firing; 
+		case StatType::REACTIONS:
+			return reactions;
+		case StatType::STAMINA:
+			return stamina;
+		case StatType::TU:
+			return tu;
+		case StatType::HEALTH:
+			return health;
+		case StatType::THROWING:
+			return throwing;
+		case StatType::MELEE:
+			return melee;
+		case StatType::MANA:
+			return mana;
+		default:
+			Log(LOG_FATAL) << "Stat enum value not found.";
+			throw new std::logic_error("Stat enum value not found.");
+		}
+	}
 
 	template<typename Func>
 	static void fieldLoop(Func f)

--- a/src/Mod/Unit.h
+++ b/src/Mod/Unit.h
@@ -36,22 +36,6 @@ class ScriptParserBase;
 
 enum SpecialAbility { SPECAB_NONE, SPECAB_EXPLODEONDEATH, SPECAB_BURNFLOOR, SPECAB_BURN_AND_EXPLODE };
 
-enum class StatType
-{
-	PSI_STRENGTH,
-	PSI_SKILL,
-	BRAVERY,
-	STRENGTH,
-	FIRING,
-	REACTIONS,
-	STAMINA,
-	TU,
-	HEALTH,
-	THROWING,
-	MELEE,
-	MANA,
-};
-
 /**
  * This struct holds some plain unit attribute data together.
  */
@@ -81,45 +65,6 @@ struct UnitStats
 	UnitStats operator-(const UnitStats& stats) const { return UnitStats(tu - stats.tu, stamina - stats.stamina, health - stats.health, bravery - stats.bravery, reactions - stats.reactions, firing - stats.firing, throwing - stats.throwing, strength - stats.strength, psiStrength - stats.psiStrength, psiSkill - stats.psiSkill, melee - stats.melee, mana - stats.mana); }
 	UnitStats operator-() const { return UnitStats(-tu, -stamina, -health, -bravery, -reactions, -firing, -throwing, -strength, -psiStrength, -psiSkill, -melee, -mana); }
 	void merge(const UnitStats& stats) { tu = (stats.tu ? stats.tu : tu); stamina = (stats.stamina ? stats.stamina : stamina); health = (stats.health ? stats.health : health); bravery = (stats.bravery ? stats.bravery : bravery); reactions = (stats.reactions ? stats.reactions : reactions); firing = (stats.firing ? stats.firing : firing); throwing = (stats.throwing ? stats.throwing : throwing); strength = (stats.strength ? stats.strength : strength); psiStrength = (stats.psiStrength ? stats.psiStrength : psiStrength); psiSkill = (stats.psiSkill ? stats.psiSkill : psiSkill); melee = (stats.melee ? stats.melee : melee); mana = (stats.mana ? stats.mana : mana); };
-
-	/**
-	 * @brief Gets the attribute identified by a text string. 
-	 * @param attribute the attribute to get. 
-	 * @return a const reference to the attribute.
-	*/
-	const Type &operator[](StatType attribute) const
-	{
-		switch (attribute)
-		{
-		case StatType::PSI_STRENGTH:
-			return psiStrength;
-		case StatType::PSI_SKILL:
-			return psiSkill;
-		case StatType::BRAVERY:
-			return bravery;
-		case StatType::STRENGTH:
-			return strength;
-		case StatType::FIRING:
-			return firing; 
-		case StatType::REACTIONS:
-			return reactions;
-		case StatType::STAMINA:
-			return stamina;
-		case StatType::TU:
-			return tu;
-		case StatType::HEALTH:
-			return health;
-		case StatType::THROWING:
-			return throwing;
-		case StatType::MELEE:
-			return melee;
-		case StatType::MANA:
-			return mana;
-		default:
-			Log(LOG_FATAL) << "Stat enum value not found.";
-			throw new std::logic_error("Stat enum value not found.");
-		}
-	}
 
 	template<typename Func>
 	static void fieldLoop(Func f)

--- a/src/Savegame/Soldier.h
+++ b/src/Savegame/Soldier.h
@@ -166,6 +166,8 @@ public:
 	UnitStats *getInitStats();
 	/// Get pointer to current stats.
 	UnitStats *getCurrentStats();
+	/// Get a const reference to current stats.
+	const UnitStats &getCurrentStats() const;
 	/// Set initial and current stats.
 	void setBothStats(UnitStats *stats);
 	/// Get whether the unit was recently promoted.


### PR DESCRIPTION
New Features:
- New StatString rules, following the format: `percentSTAT: [MIN, MAX]`. The numbers are interpreted as floats but are 0-100 based rather than 0-1 based. Ranges are compared using [MIN, MAX).
- Ability to mark a StatString rule as a "GlobalRule." via the syntax: `globalRule: true` (defaults to false). Global Rules are only meaningful on `statString` rules on the top scope, as opposed to those on `soldiers`. If true, the associated rules are processed together with any type specific rules, happening first in order (global rules are processed first, then soldier rules). Otherwise, the current logic is respected, and no global rule is processed if there are any soldier rules.
- New `physTraining` rule, corresponding to the old `psiTraining` rule.
- Ability to negate a training rule by giving it the value of `false`. (condition is passed if the soldier is not in training) Any value that does not translate to false (including `true`, obviously) preserves the old behavior, and the rule will trigger true if the soldier is in training.
- Ability to set a custom divider via the `oxceStatStringDivider` option. It defaults to "\\" and does not appear in the menu.
- All old functionality and logic is preserved.

So I ended up more or less rewriting most of the StatString code in this feature. I've tested it extensively and haven't found any bugs, but I went more deeply than intended (though not as deep as I might have wanted, lots of code I wanted to improve). The new `StatStringCondition` classes use inheritance and are stored in a vector of `unique_ptr`s. As such, copy constructors/assignment have been disabled as appropriate. I didn't bother writing any sort of clone methods, as I couldn't see the need for them, but they could be added later if necessary. None of this makes any difference to existing code but is something to keep in mind if things are refactored.

There is also a circular dependency on the Soldier class, which is less than ideal. But I couldn't see how to resolve that without doing a more major rewrite or bloating up the code and making it less flexible. Still, all in all, I think it's pretty clean, but then again, I would think that I wrote it. :)