### PR TITLE
Adds RequiredCountryBuy for Crafts and Soldiers.

### DIFF
--- a/src/Basescape/PurchaseState.cpp
+++ b/src/Basescape/PurchaseState.cpp
@@ -55,6 +55,22 @@ namespace OpenXcom
 {
 
 /**
+ * @brief Combines any number of functions into a functions that returns true if all of them are true.
+ * Short circuits as well.
+ * @tparam ...Functions type of the function to combine.
+ * @param ...funcs the functions to combine.
+ * @return a new function that is true only if all predicates are satisfied. 
+*/
+template <typename... Functions>
+inline constexpr auto allOf(Functions... funcs)
+{
+	return [=](const auto &x)
+	{
+		return (... and funcs(x));
+	};
+}
+
+/**
  * Initializes all the elements in the Purchase/Hire screen.
  * @param game Pointer to the core game.
  * @param base Pointer to the base to get info from.
@@ -159,12 +175,39 @@ PurchaseState::PurchaseState(Base *base, CannotReequipState *parent) : _base(bas
 		_cats.push_back("STR_FILTER_MISSING");
 	}
 
-	RuleBaseFacilityFunctions providedBaseFunc = _base->getProvidedBaseFunc({});
+	auto providedBaseFunc = _base->getProvidedBaseFunc({});
+
+	// setup the filter methods to be used in standard situations (craft, soldiers, items).
+	constexpr auto costIsNotZero = [](const auto *rule) { return rule->getBuyCost() != 0; };
+	constexpr auto requirementsAreResearched = [](const auto *rule)
+	{
+		return _game->getSavedGame()->isResearched(rule->getRequirements());
+	};
+	auto necessaryBaseFunctionsPresent = [&providedBaseFunc](const auto *rule)
+	{
+		return (~providedBaseFunc & rule->getRequiresBuyBaseFunc()).none();
+	};
+	constexpr auto requiredCountryAllied = [](const auto *rule)
+	{
+		std::string_view requiredCountry = rule->getRequiresBuyCountry();
+		if (!requiredCountry.empty())
+		{
+			for (const auto &country : *_game->getSavedGame()->getCountries())
+			{
+				if (country->getRules()->getType() == requiredCountry)
+				{
+					return !country->getPact();
+				}
+			}
+		}
+		return true;
+	};
+
+	auto standardFilter = allOf(costIsNotZero, requirementsAreResearched, necessaryBaseFunctionsPresent, requiredCountryAllied);
 	for (auto& soldierType : _game->getMod()->getSoldiersList())
 	{
 		RuleSoldier *rule = _game->getMod()->getSoldier(soldierType);
-		RuleBaseFacilityFunctions purchaseBaseFunc = rule->getRequiresBuyBaseFunc();
-		if (rule->getBuyCost() != 0 && _game->getSavedGame()->isResearched(rule->getRequirements()) && (~providedBaseFunc & purchaseBaseFunc).none())
+		if (standardFilter(rule))
 		{
 			TransferRow row = { TRANSFER_SOLDIER, rule, tr(rule->getType()), rule->getBuyCost(), _base->getSoldierCountAndSalary(rule->getType()).first, 0, 0, -4, 0, 0, 0 };
 			_items.push_back(row);
@@ -200,8 +243,7 @@ PurchaseState::PurchaseState(Base *base, CannotReequipState *parent) : _base(bas
 	for (auto& craftType : _game->getMod()->getCraftsList())
 	{
 		RuleCraft *rule = _game->getMod()->getCraft(craftType);
-		RuleBaseFacilityFunctions purchaseBaseFunc = rule->getRequiresBuyBaseFunc();
-		if (rule->getBuyCost() != 0 && _game->getSavedGame()->isResearched(rule->getRequirements()) && (~providedBaseFunc & purchaseBaseFunc).none())
+		if (standardFilter(rule))
 		{
 			TransferRow row = { TRANSFER_CRAFT, rule, tr(rule->getType()), rule->getBuyCost(), _base->getCraftCount(rule), 0, 0, -1, 0, 0, 0 };
 			_items.push_back(row);
@@ -215,8 +257,7 @@ PurchaseState::PurchaseState(Base *base, CannotReequipState *parent) : _base(bas
 	for (auto& itemType : _game->getMod()->getItemsList())
 	{
 		RuleItem *rule = _game->getMod()->getItem(itemType);
-		RuleBaseFacilityFunctions purchaseBaseFunc = rule->getRequiresBuyBaseFunc();
-		if (rule->getBuyCost() != 0 && _game->getSavedGame()->isResearched(rule->getRequirements()) && _game->getSavedGame()->isResearched(rule->getBuyRequirements()) && (~providedBaseFunc & purchaseBaseFunc).none())
+		if (standardFilter(rule))
 		{
 			TransferRow row = { TRANSFER_ITEM, rule, tr(rule->getType()), rule->getBuyCost(), _base->getStorageItems()->getItem(rule), 0, 0, rule->getListOrder(), 0, 0, 0 };
 			_items.push_back(row);
@@ -615,24 +656,6 @@ void PurchaseState::updateList()
 		if (_items[i].type == TRANSFER_ITEM)
 		{
 			RuleItem *rule = (RuleItem*)_items[i].rule;
-			if (!rule->getRequiresBuyCountry().empty())
-			{
-				// required allied country
-				bool allied = true;
-				auto* countries = _game->getSavedGame()->getCountries();
-				for (const auto* country : *countries)
-				{
-					if (country->getPact() && country->getRules()->getType() == rule->getRequiresBuyCountry())
-					{
-						allied = false;
-						break;
-					}
-				}
-				if (!allied)
-				{
-					continue;
-				}
-			}
 			ammo = (rule->getBattleType() == BT_AMMO || (rule->getBattleType() == BT_NONE && rule->getClipSize() > 0));
 			if (ammo)
 			{

--- a/src/Mod/RuleCraft.cpp
+++ b/src/Mod/RuleCraft.cpp
@@ -81,6 +81,7 @@ void RuleCraft::load(const YAML::Node &node, Mod *mod, const ModScript &parsers)
 	//requires
 	mod->loadUnorderedNames(_type, _requires, node["requires"]);
 	mod->loadBaseFunction(_type, _requiresBuyBaseFunc, node["requiresBuyBaseFunc"]);
+	_requiresBuyCountry = node["requiresBuyCountry"].as<std::string>(_requiresBuyCountry);
 
 	if (node["sprite"])
 	{

--- a/src/Mod/RuleCraft.h
+++ b/src/Mod/RuleCraft.h
@@ -165,6 +165,7 @@ private:
 	std::string _type;
 	std::vector<std::string> _requires;
 	RuleBaseFacilityFunctions _requiresBuyBaseFunc;
+	std::string _requiresBuyCountry;
 	int _sprite, _marker;
 	std::vector<int> _skinSprites;
 	int _weapons, _soldiers, _pilots, _vehicles;
@@ -210,6 +211,8 @@ public:
 	const std::vector<std::string> &getRequirements() const;
 	/// Gets the base functions required to buy craft.
 	RuleBaseFacilityFunctions getRequiresBuyBaseFunc() const { return _requiresBuyBaseFunc; }
+	/// Gets the allied country name required to buy.
+	const std::string &getRequiresBuyCountry() const { return _requiresBuyCountry; }
 	/// Gets the craft's sprite.
 	int getSprite(int skinIndex) const;
 	const std::vector<int> &getSkinSpritesRaw() const { return _skinSprites; }

--- a/src/Mod/RuleSoldier.cpp
+++ b/src/Mod/RuleSoldier.cpp
@@ -79,7 +79,7 @@ void RuleSoldier::load(const YAML::Node &node, Mod *mod, const ModScript &parser
 	//requires
 	mod->loadUnorderedNames(_type, _requires, node["requires"]);
 	mod->loadBaseFunction(_type, _requiresBuyBaseFunc, node["requiresBuyBaseFunc"]);
-
+	_requiresBuyCountry = node["requiresBuyCountry"].as<std::string>(_requiresBuyCountry);
 
 	_minStats.merge(node["minStats"].as<UnitStats>(_minStats));
 	_maxStats.merge(node["maxStats"].as<UnitStats>(_maxStats));

--- a/src/Mod/RuleSoldier.h
+++ b/src/Mod/RuleSoldier.h
@@ -66,6 +66,7 @@ private:
 	int _listOrder;
 	std::vector<std::string> _requires;
 	RuleBaseFacilityFunctions _requiresBuyBaseFunc;
+	std::string _requiresBuyCountry;
 	UnitStats _minStats, _maxStats, _statCaps, _trainingStatCaps, _dogfightExperience;
 	std::string _armorName;
 	const Armor* _armor;
@@ -116,6 +117,8 @@ public:
 	const std::vector<std::string> &getRequirements() const;
 	/// Gets the base functions required to buy solder.
 	RuleBaseFacilityFunctions getRequiresBuyBaseFunc() const { return _requiresBuyBaseFunc; }
+	/// Gets the allied country name required to buy a soldier.
+	const std::string &getRequiresBuyCountry() const { return _requiresBuyCountry; }
 	/// Gets the minimum stats for the random stats generator.
 	UnitStats getMinStats() const;
 	/// Gets the maximum stats for the random stats generator.


### PR DESCRIPTION
As the title says, it implements the feature requested [here](https://openxcom.org/forum/index.php/topic,11180.0.html). It also adds the feature to craft. The filtering function is also reworked. The main improvement is that filtering for RequiredCountryBuy for items is processed when the items are added to the list, rather than whenever the list is updated. Also, the logic is centralized and standardized between Crafts, Soldiers, and Items. 