### PR TITLE
Implementation of Country New Month Scripting

### DIFF
--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -2579,7 +2579,7 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 		RuleCountry *rule = loadRule(*i, &_countries, &_countriesIndex);
 		if (rule != 0)
 		{
-			rule->load(*i);
+			rule->load(*i, parsers);
 		}
 	}
 	for (YAML::const_iterator i : iterateRules("extraGlobeLabels", "type"))
@@ -2587,7 +2587,7 @@ void Mod::loadFile(const FileMap::FileRecord &filerec, ModScript &parsers)
 		RuleCountry *rule = loadRule(*i, &_extraGlobeLabels, &_extraGlobeLabelsIndex);
 		if (rule != 0)
 		{
-			rule->load(*i);
+			rule->load(*i, parsers);
 		}
 	}
 	for (YAML::const_iterator i : iterateRules("regions", "type"))

--- a/src/Mod/ModScript.h
+++ b/src/Mod/ModScript.h
@@ -28,6 +28,7 @@ class Surface;
 class SurfaceSet;
 class Soldier;
 class RuleCountry;
+class Country;
 class RuleRegion;
 class RuleBaseFacility;
 class RuleCraft;
@@ -239,6 +240,15 @@ class ModScript
 	};
 
 	////////////////////////////////////////////////////////////
+	//					country script
+	////////////////////////////////////////////////////////////
+	// Output(fundingChange, newSatisfaction, newPact, cancelPact), Input(Country, Save, XComScore, AlienScore)
+	struct NewMonthCountryParser : ScriptParserEvents<ScriptOutputArgs<int&, int&, int&, int&>, Country*, SavedGame*, int, int>
+	{
+		NewMonthCountryParser(ScriptGlobal* shared, const std::string& name, Mod* mod);
+	};
+
+	////////////////////////////////////////////////////////////
 	//					ufo script
 	////////////////////////////////////////////////////////////
 
@@ -368,6 +378,12 @@ public:
 	using SkillUseUnit = MACRO_NAMED_SCRIPT("skillUseUnit", SkillUseUnitParser);
 
 	////////////////////////////////////////////////////////////
+	//					country script
+	////////////////////////////////////////////////////////////
+
+	using NewMonthCountry = MACRO_NAMED_SCRIPT("newMonthCountry", NewMonthCountryParser);
+
+	////////////////////////////////////////////////////////////
 	//					ufo script
 	////////////////////////////////////////////////////////////
 
@@ -466,6 +482,10 @@ public:
 		SkillUseUnit
 	>;
 
+	using CountryScripts = ScriptGroup<Mod,
+		NewMonthCountry
+	>;
+
 	using UfoScripts = ScriptGroup<Mod,
 		DetectUfoFromBase,
 		DetectUfoFromCraft,
@@ -488,6 +508,7 @@ public:
 	BattleItemScripts battleItemScripts = { _shared, _mod, "item" };
 	BonusStatsScripts bonusStatsScripts = { _shared, _mod, "bonuses" };
 	SkillScripts skillScripts = { _shared, _mod, "skill" };
+	CountryScripts countryScripts = { _shared, _mod, "country" };
 	UfoScripts ufoScripts = { _shared, _mod, "ufo" };
 	CraftScripts craftScripts = { _shared, _mod, "craft" };
 	SoldierBonusScripts soldierBonusScripts = { _shared, _mod, "soldier" };

--- a/src/Mod/RuleCountry.h
+++ b/src/Mod/RuleCountry.h
@@ -20,11 +20,14 @@
 #include <string>
 #include <yaml-cpp/yaml.h>
 #include "RuleEvent.h"
+#include "ModScript.h"
+#include "../Engine/Script.h"
 
 namespace OpenXcom
 {
 
 class Mod;
+class ModScript;
 
 /**
  * Represents a specific funding country.
@@ -42,13 +45,18 @@ private:
 	int _labelColor, _zoomLevel;
 	const RuleEvent* _signedPactEvent = nullptr;
 	const RuleEvent* _rejoinedXcomEvent = nullptr;
+
+	/// holds references to user tags. 
+	ScriptValues<RuleCountry> _scriptValues;
+	/// holds references to country specific scripts.
+	ModScript::CountryScripts::Container _countryScripts;
 public:
 	/// Creates a blank country ruleset.
 	RuleCountry(const std::string &type);
 	/// Cleans up the country ruleset.
 	~RuleCountry();
 	/// Loads the country from YAML.
-	void load(const YAML::Node& node);
+	void load(const YAML::Node& node, const ModScript& parsers);
 	/// Cross link with other rules.
 	void afterLoad(const Mod* mod);
 	/// Gets the country's type.
@@ -75,6 +83,14 @@ public:
 	int getLabelColor() const;
 	/// Gets the minimum zoom level required to display the label (Note: works for extraGlobeLabels only, not for vanilla countries).
 	int getZoomLevel() const;
+
+	/// Name of class used in script.
+	static constexpr const char* ScriptName = "RuleCountry";
+	/// Register all useful function used by script.
+	static void ScriptRegister(ScriptParserBase* parser);
+
+	template<typename Script>
+	const typename Script::Container& getScript() const { return _countryScripts.get<Script>(); }
 };
 
 }

--- a/src/OpenXcom.2010.vcxproj.user
+++ b/src/OpenXcom.2010.vcxproj.user
@@ -20,4 +20,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerCommandArguments>-data "$(ProjectDir)..\bin"</LocalDebuggerCommandArguments>
   </PropertyGroup>
+  <PropertyGroup>
+    <ShowAllFiles>true</ShowAllFiles>
+  </PropertyGroup>
 </Project>

--- a/src/Savegame/Country.cpp
+++ b/src/Savegame/Country.cpp
@@ -371,20 +371,17 @@ bool Country::canBeInfiltrated()
 namespace
 {
 
-int checkBoundsAndGet(int index, const std::vector<int>& element)
+int checkBoundsAndGetFromEnd(int index, const std::vector<int>& element)
 {
-	if (index < 0 || index > element.size()) {
-		Log(LOG_WARNING) << "Attempted to get invalid data point.";
-		return -1;
-	}
-	return element[index];
+	if (index < 0 || index > element.size()) { return 0; }
+	return element[element.size() - index - 1];
 }
 
 }
 
-int Country::getMonthlyActivityAlien(int month) const { return checkBoundsAndGet(month, _activityAlien); }
-int Country::getMonthlyActivityXcom(int month) const { return checkBoundsAndGet(month, _activityXcom); }
-int Country::getMonthlyFunding(int month) const { return checkBoundsAndGet(month, _funding); }
+int Country::getMonthlyActivityAlien(int month) const { return checkBoundsAndGetFromEnd(month, _activityAlien); }
+int Country::getMonthlyActivityXcom(int month) const { return checkBoundsAndGetFromEnd(month, _activityXcom); }
+int Country::getMonthlyFunding(int month) const { return checkBoundsAndGetFromEnd(month, _funding); }
 
 namespace // script helpers
 {
@@ -420,9 +417,9 @@ void Country::ScriptRegister(ScriptParserBase* parser)
 	countryBinder.add<&Country::getCurrentActivityXcom>("getCurrentActivityXcom", "Get the countries current xcom activity.");
 
 	countryBinder.add<&Country::getMonthsTracked>("getMonthsTracked", "Gets the number of months currently tracked. [2, 12].");
-	countryBinder.add<&Country::getMonthlyFunding>("getFunding", "Gets funding for a tracked month [0 to monthsTracked), -1 on error.");
-	countryBinder.add<&Country::getMonthlyActivityAlien>("getAlienActivity", "Gets alien activity for a tracked month [0 to monthsTracked), -1 on error.");
-	countryBinder.add<&Country::getMonthlyActivityXcom>("getXcomActivity", "Gets xcom activity for a tracked month [0 to monthsTracked), -1 on error.");
+	countryBinder.add<&Country::getMonthlyFunding>("getFunding", "Gets funding working backwards from the present [0 to monthsTracked), 0 on error. (funding monthsAgo)");
+	countryBinder.add<&Country::getMonthlyActivityAlien>("getAlienActivity", "Gets alien activity working backwards from the present [0 to monthsTracked), 0 on error. (activity monthsAgo)");
+	countryBinder.add<&Country::getMonthlyActivityXcom>("getXcomActivity", "Gets xcom activity working backwards from the present [0 to monthsTracked), 0 on error. (activity monthsAgo)");
 
 	countryBinder.addScriptValue<BindBase::SetAndGet, &Country::_scriptValues>();
 	countryBinder.addDebugDisplay<&debugDisplayScript>();

--- a/src/Savegame/Country.h
+++ b/src/Savegame/Country.h
@@ -19,11 +19,14 @@
  */
 #include <vector>
 #include <yaml-cpp/yaml.h>
+#include "../Engine/Script.h"
 
 namespace OpenXcom
 {
 
 class RuleCountry;
+class ModScript;
+class SavedGame;
 
 /**
  * Represents a country that funds the player.
@@ -32,28 +35,35 @@ class RuleCountry;
  */
 class Country
 {
+public:
+	/// A countries satisfaction level.
+	enum class Satisfaction { ALIEN_PACT, UNHAPPY, SATISFIED, HAPPY };
+
 private:
 	RuleCountry *_rules;
 	bool _pact, _newPact, _cancelPact;
 	std::vector<int> _funding, _activityXcom, _activityAlien;
-	int _satisfaction;
+	Satisfaction _satisfaction;
+	/// holds references to user tags. 
+	ScriptValues<Country> _scriptValues;
 public:
 	/// Creates a new country of the specified type.
 	Country(RuleCountry *rules, bool gen = true);
 	/// Cleans up the country.
 	~Country();
 	/// Loads the country from YAML.
-	void load(const YAML::Node& node);
+	void load(const YAML::Node& node, const ScriptGlobal& tags);
 	/// Saves the country to YAML.
-	YAML::Node save() const;
+	YAML::Node save(const ScriptGlobal& tags) const;
 	/// Gets the country's ruleset.
 	RuleCountry *getRules() const;
 	/// Gets the country's funding.
 	std::vector<int> &getFunding();
 	/// Sets the country's funding.
 	void setFunding(int funding);
+
 	/// get the country's satisfaction level
-	int getSatisfaction() const;
+	Satisfaction getSatisfaction() const;
 	/// add xcom activity in this country
 	void addActivityXcom(int activity);
 	/// add alien activity in this country
@@ -62,8 +72,8 @@ public:
 	std::vector<int> &getActivityXcom();
 	/// get xcom activity to this country
 	std::vector<int> &getActivityAlien();
-	/// store last month's counters, start new counters, set this month's change.
-	void newMonth(int xcomTotal, int alienTotal, int pactScore, int averageFunding);
+	/// store last month's counters, start new counters, set this month's change, return funding change.
+	int newMonth(int xcomScore, int alienScore, int pactScore, SavedGame& save);
 	/// are we signing a new pact?
 	bool getNewPact() const;
 	/// sign a pact at the end of this month.
@@ -78,6 +88,30 @@ public:
 	void setPact();
 	/// can be (re)infiltrated?
 	bool canBeInfiltrated();
+
+	/// Name of class used in script.
+	static constexpr const char* ScriptName = "Country";
+	/// Register all useful function used by script.
+	static void ScriptRegister(ScriptParserBase* parser);
+
+private:
+	/// calculates the potential changes in a countries satisifaction and funding, given it's current state.
+	[[nodiscard]] std::pair<int, Country::Satisfaction> CalculateChanges(const OpenXcom::SavedGame& save, int xcomTotal, int alienTotal) const;
+
+	// helper methods for scripting.
+	// friend class ModScript::NewMonthCountryParser;
+
+	int getSatisfactionInt() { return static_cast<int>(_satisfaction); }
+	// void setSatisfactionInt(int satisfaction) { _satisfaction = static_cast<Satisfaction>(satisfaction); }
+
+	int getCurrentFunding() const { return _funding.back(); }
+	int getCurrentActivityAlien()  const { return _activityAlien.back(); }
+	int getCurrentActivityXcom() const { return _activityXcom.back(); }
+
+	int getMonthsTracked() const { return _funding.size(); }
+	int getMonthlyFunding(int month) const;
+	int getMonthlyActivityAlien(int month) const;
+	int getMonthlyActivityXcom(int month) const;
 };
 
 }

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -459,7 +459,7 @@ void SavedGame::load(const std::string &filename, Mod *mod, Language *lang)
 		if (mod->getCountry(type))
 		{
 			Country *c = new Country(mod->getCountry(type), false);
-			c->load(*i);
+			c->load(*i, *mod->getScriptGlobal());
 			_countries.push_back(c);
 		}
 		else
@@ -877,7 +877,7 @@ void SavedGame::save(const std::string &filename, Mod *mod) const
 	node["ids"] = _ids;
 	for (const auto* country : _countries)
 	{
-		node["countries"].push_back(country->save());
+		node["countries"].push_back(country->save(*mod->getScriptGlobal()));
 	}
 	for (const auto* region : _regions)
 	{

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -247,6 +247,8 @@ public:
 	void setAllIds(const std::map<std::string, int> &ids);
 	/// Gets the list of countries.
 	std::vector<Country*> *getCountries();
+	/// Gets the list of countries.
+	[[nodiscard]] const std::vector<Country*>* getCountries() const { return &_countries; }
 	/// Gets the total country funding.
 	int getCountryFunding() const;
 	/// Gets the list of regions.


### PR DESCRIPTION
Implementation of NewMonthCountry scripting. While NewMonthCountry takes a mutable/non-const reference to `Country` it does not expose any non-const methods to the scripting engine, aside from the ability to set scripting values. Instead, new values are returned, and C++ handles any changes to state after scripting exits. Doing it this way required some reworking of the involved methods, but they are probably better for it. Scripts are stored in the `RuleCountry` class, though both classes can take tags.

NewMonthCountry runs before `Country`'s state is changed by NewMonth, but it is passed in the proposed changes to the country's state. The values returned by `NewMonthCountry` are applied to `Country` or the proposed/default changes are applied if there is no change.

No specific constraints are imposed on the scripting return logic. Arbitrary transformations are possible, including ones that are invalid under default rules, such as a country having an alien pact but still providing funding or even providing negative funding. It is assumed that if you want to alter these rules, you mean what you say, so there isn't any point in enforcing existing constraints. This also means that if you want to perform some standard logic via script, you need to reimplement that logic via script, though this is straightforward to do, and I can provide an example script.

Of course, if no script is invoked, then the existing rules apply as standard.

There was no added provisions for getting a RNG generator, one should already be accessible via `GeoscapeGame.getRandomState`. 

Satisfaction was transformed into an enum as just some housekeeping, as its only purpose is to communicate state back to the end-of-month function. If a script wants to use satisfaction for other purposes, it can apply its own tag.