### PR TITLE
fix: inverted X axis logic in checkVoxel()

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -4504,10 +4504,11 @@ VoxelType TileEngine::voxelCheck(Position voxel, BattleUnit *excludeUnit, bool e
 				if (unit->isBigUnit())
 				{
 					tilepos = tile->getPosition();
-					part = tilepos.x - unitpos.x + (tilepos.y - unitpos.y)*2;
+					constexpr static int parts[] = {1,0,3,2}; // Change order 0,1,2,3 -> 1,0,3,2
+					part = parts[tilepos.x - unitpos.x + (tilepos.y - unitpos.y)*2];
 				}
 				int idx = (unit->getLoftemps(part) * 16) + y;
-				if (_voxelData->at(idx) & (1 << x))
+				if (_voxelData->at(idx) & (0x8000 >> x))
 				{
 					return V_UNIT;
 				}


### PR DESCRIPTION
I found some odd behaviour when TileEngine::calculateLineVoxel() successfully creates the trajectory to voxel inside a unit, but returns V_EMPTY instead of V_UNIT.

[I checked it all by hand first](https://cdn.discordapp.com/attachments/292085473890009088/1138016394546528327/IMG_5956.jpg).

[Resulting trajectory surely hits target voxel of 11,7](https://media.discordapp.net/attachments/292085473890009088/1138017261576278056/image.png).

[LOFTemps data stored in memory in "right" direction, with positive X axis from left to right](https://media.discordapp.net/attachments/292085473890009088/1138062021921878016/image.png).

[1 << x in code counts X axis in negative direction, from right to left](https://cdn.discordapp.com/attachments/292085473890009088/1138062324490571836/IMG_5957.jpg). LOFTemp becomes [effectively inverted from left to right](https://cdn.discordapp.com/attachments/292085473890009088/1138261841575948348/image.png), which moves unit slightly to the left.

code for terrain check:

`int x = 15 - voxel.x%16;`
`int y = voxel.y%16;`

but the unit check does:

`int x = voxel.x%16;`
`int y = voxel.y%16;`

[Also, in original X-Com it was definitely 0x8000 >> x](https://media.discordapp.net/attachments/292085473890009088/1138080727494295623/image.png)

Current 2x2 units loftemps loading logic is inverted too, but workaround is trivial (switching left/right parts).

Maybe, this bug was the reason that "targeting" in several parts of the code was changed to (7,8) instead of unit center (8,8), if that's the case - [it should be changed too](https://github.com/OpenXcom/OpenXcom/commit/757d67404eebc289ea8df26e3b7aa4c0be495f25).

Images [before](https://cdn.discordapp.com/attachments/292085473890009088/1138262212939612311/fpslook055.png) and [after](https://cdn.discordapp.com/attachments/292085473890009088/1138262213212246057/fpslook0552.png) a patch.
<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->