### PR TITLE
Feature: soldiers and vehicles as modifiable craft stats.

### DIFF
--- a/src/Basescape/CraftInfoState.cpp
+++ b/src/Basescape/CraftInfoState.cpp
@@ -76,7 +76,7 @@ CraftInfoState::CraftInfoState(Base *base, size_t craftId) : _base(base), _craft
 	if (_game->getSavedGame()->getDebugMode() && _game->getSavedGame()->getMonthsPassed() != -1)
 	{
 		// only the first craft can be used
-		if (_craftId == 0 && _craft->getRules()->getMaxUnits() > 0 && _craft->getRules()->getAllowLanding())
+		if (_craftId == 0 && _craft->getMaxUnits() > 0 && _craft->getRules()->getAllowLanding())
 		{
 			showNewBattle = 1;
 		}
@@ -263,7 +263,7 @@ void CraftInfoState::init()
 	}
 	_txtShield->setText(thirdLine.str());
 
-	if (_craft->getRules()->getMaxUnits() > 0)
+	if (_craft->getMaxUnits() > 0)
 	{
 		_crew->clear();
 		_equip->clear();

--- a/src/Basescape/CraftWeaponsState.cpp
+++ b/src/Basescape/CraftWeaponsState.cpp
@@ -34,6 +34,8 @@
 #include "../Savegame/Base.h"
 #include "../Savegame/SavedGame.h"
 #include "../Ufopaedia/Ufopaedia.h"
+#include "../Menu/ErrorMessageState.h"
+#include "../Mod/RuleInterface.h"
 
 namespace OpenXcom
 {
@@ -163,30 +165,64 @@ void CraftWeaponsState::btnCancelClick(Action *)
  */
 void CraftWeaponsState::lstWeaponsClick(Action *)
 {
-	CraftWeapon *current = _craft->getWeapons()->at(_weapon);
-	// Remove current weapon
-	if (current != 0)
+	bool allowChange = true;
+	bool unitCapChanged = false;
+	const RuleCraftWeapon* refWeapon = nullptr;
+	const RuleCraftWeapon* currWeapon = nullptr;
+	CraftWeapon* current = _craft->getWeapons()->at(_weapon);
+	if (_weapons[_lstWeapons->getSelectedRow()] != 0)
+		refWeapon = _weapons[_lstWeapons->getSelectedRow()];
+	if (current != 0) currWeapon = current->getRules();
+
+	if ((refWeapon != nullptr && refWeapon->getBonusStats().soldiers != 0) ||
+		 (currWeapon != nullptr && currWeapon->getBonusStats().soldiers != 0))
 	{
-		_base->getStorageItems()->addItem(current->getRules()->getLauncherItem());
-		_base->getStorageItems()->addItem(current->getRules()->getClipItem(), current->getClipsLoaded());
-		_craft->addCraftStats(-current->getRules()->getBonusStats());
-		// Make sure any extra shield is removed from craft too when the shield capacity decreases (exploit protection)
-		_craft->setShield(_craft->getShield());
-		delete current;
-		_craft->getWeapons()->at(_weapon) = 0;
+		int refUnitCapBonus = refWeapon != nullptr ? refWeapon->getBonusStats().soldiers : 0;
+		int currUnitCapBonus = currWeapon != nullptr ? currWeapon->getBonusStats().soldiers : 0;
+		unitCapChanged = (refUnitCapBonus - currUnitCapBonus) != 0;
+		if (unitCapChanged) // Unit capacity changed, verify that change is allowed
+		{
+			if ((_craft->getMaxUnits() - _craft->getSpaceUsed() +
+				refUnitCapBonus - currUnitCapBonus) < 0)
+				allowChange = false;
+		}
 	}
 
-	// Equip new weapon
-	if (_weapons[_lstWeapons->getSelectedRow()] != 0)
+	if (allowChange)
 	{
-		CraftWeapon *sel = new CraftWeapon(_weapons[_lstWeapons->getSelectedRow()], 0);
-		_craft->addCraftStats(sel->getRules()->getBonusStats());
-		_base->getStorageItems()->removeItem(sel->getRules()->getLauncherItem());
-		_craft->getWeapons()->at(_weapon) = sel;
+		// Remove current weapon
+		if (current != 0)
+		{
+			_base->getStorageItems()->addItem(current->getRules()->getLauncherItem());
+			_base->getStorageItems()->addItem(current->getRules()->getClipItem(), current->getClipsLoaded());
+			_craft->addCraftStats(-current->getRules()->getBonusStats());
+			// Make sure any extra shield is removed from craft too when the shield capacity decreases (exploit protection)
+			_craft->setShield(_craft->getShield());
+			delete current;
+			_craft->getWeapons()->at(_weapon) = 0;
+		}
+
+		// Equip new weapon
+		if (_weapons[_lstWeapons->getSelectedRow()] != 0)
+		{
+			CraftWeapon* sel = new CraftWeapon(_weapons[_lstWeapons->getSelectedRow()], 0);
+			_craft->addCraftStats(sel->getRules()->getBonusStats());
+			_base->getStorageItems()->removeItem(sel->getRules()->getLauncherItem());
+			_craft->getWeapons()->at(_weapon) = sel;
+		}
 	}
 
 	_craft->checkup();
 	_game->popState();
+
+	if (!allowChange)
+	{
+		std::string errorMessage = "STR_NO_CARGO_SPACE_FOR_REFIT";
+		RuleInterface* menuInterface = _game->getMod()->getInterface("craftWeapons");
+		_game->pushState(new ErrorMessageState(tr(errorMessage), _palette,
+			menuInterface->getElement("window")->color, "BACK14.SCR",
+			menuInterface->getElement("palette")->color));
+	}
 }
 
 /**

--- a/src/Geoscape/GeoscapeCraftState.cpp
+++ b/src/Geoscape/GeoscapeCraftState.cpp
@@ -270,9 +270,9 @@ GeoscapeCraftState::GeoscapeCraftState(Craft *craft, Globe *globe, Waypoint *way
 		_btnPatrol->setVisible(false);
 	}
 
-	if (_craft->getRules()->getMaxUnits() == 0)
+	if (_craft->getMaxUnits() == 0)
 		_txtSoldier->setVisible(false);
-	if (_craft->getRules()->getMaxVehiclesAndLargeSoldiers() == 0)
+	if (_craft->getMaxVehiclesAndLargeSoldiers() == 0)
 		_txtHWP->setVisible(false);
 }
 

--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1124,7 +1124,7 @@ void GeoscapeState::time5Seconds()
 					}
 				}
 				// if a transport craft has been shot down, kill all the soldiers on board.
-				if (xcraft->getRules()->getMaxUnits() > 0)
+				if (xcraft->getMaxUnits() > 0)
 				{
 					for (auto soldierIt = xbase->getSoldiers()->begin(); soldierIt != xbase->getSoldiers()->end();)
 					{

--- a/src/Mod/Mod.cpp
+++ b/src/Mod/Mod.cpp
@@ -2164,6 +2164,7 @@ void Mod::loadAll()
 	afterLoadHelper("skills", this, _skills, &RuleSkill::afterLoad);
 	afterLoadHelper("craftWeapons", this, _craftWeapons, &RuleCraftWeapon::afterLoad);
 	afterLoadHelper("countries", this, _countries, &RuleCountry::afterLoad);
+	afterLoadHelper("crafts", this, _crafts, &RuleCraft::afterLoad);
 
 	for (auto& a : _armors)
 	{
@@ -3732,7 +3733,7 @@ SavedGame *Mod::newSave(GameDifficulty diff) const
 				Craft *found = 0;
 				for (auto* craft : *base->getCrafts())
 				{
-					if (!found && craft->getRules()->getAllowLanding() && craft->getSpaceUsed() < craft->getRules()->getMaxUnits())
+					if (!found && craft->getRules()->getAllowLanding() && craft->getSpaceUsed() < craft->getMaxUnits())
 					{
 						// Remember transporter as fall-back, but search further for interceptors
 						found = craft;
@@ -3750,7 +3751,7 @@ SavedGame *Mod::newSave(GameDifficulty diff) const
 				Craft *found = 0;
 				for (auto* craft : *base->getCrafts())
 				{
-					if (craft->getRules()->getAllowLanding() && craft->getSpaceUsed() < craft->getRules()->getMaxUnits())
+					if (craft->getRules()->getAllowLanding() && craft->getSpaceUsed() < craft->getMaxUnits())
 					{
 						// First available transporter will do
 						found = craft;

--- a/src/Mod/RuleCraft.h
+++ b/src/Mod/RuleCraft.h
@@ -38,14 +38,15 @@ class ScriptParserBase;
  */
 struct RuleCraftStats
 {
-	int fuelMax, damageMax, speedMax, accel, radarRange, radarChance, sightRange, hitBonus, avoidBonus, powerBonus, armor, shieldCapacity, shieldRecharge, shieldRechargeInGeoscape, shieldBleedThrough;
+	int fuelMax, damageMax, speedMax, accel, radarRange, radarChance, sightRange, hitBonus, avoidBonus, powerBonus, armor, shieldCapacity, shieldRecharge, shieldRechargeInGeoscape, shieldBleedThrough, soldiers, vehicles;
 
 	/// Default constructor.
 	RuleCraftStats() :
 		fuelMax(0), damageMax(0), speedMax(0), accel(0),
 		radarRange(0), radarChance(0), sightRange(0),
 		hitBonus(0), avoidBonus(0), powerBonus(0), armor(0),
-		shieldCapacity(0), shieldRecharge(0), shieldRechargeInGeoscape(0), shieldBleedThrough(0)
+		shieldCapacity(0), shieldRecharge(0), shieldRechargeInGeoscape(0), shieldBleedThrough(0),
+		soldiers(0), vehicles(0)
 	{
 
 	}
@@ -67,6 +68,8 @@ struct RuleCraftStats
 		shieldRecharge += r.shieldRecharge;
 		shieldRechargeInGeoscape += r.shieldRechargeInGeoscape;
 		shieldBleedThrough += r.shieldBleedThrough;
+		soldiers += r.soldiers;
+		vehicles += r.vehicles;
 		return *this;
 	}
 	/// Subtract different stats.
@@ -87,6 +90,8 @@ struct RuleCraftStats
 		shieldRecharge -= r.shieldRecharge;
 		shieldRechargeInGeoscape -= r.shieldRechargeInGeoscape;
 		shieldBleedThrough -= r.shieldBleedThrough;
+		soldiers -= r.soldiers;
+		vehicles -= r.vehicles;
 		return *this;
 	}
 	/// Gets negative values of stats.
@@ -114,6 +119,8 @@ struct RuleCraftStats
 		shieldRecharge = node["shieldRecharge"].as<int>(shieldRecharge);
 		shieldRechargeInGeoscape = node["shieldRechargeInGeoscape"].as<int>(shieldRechargeInGeoscape);
 		shieldBleedThrough = node["shieldBleedThrough"].as<int>(shieldBleedThrough);
+		soldiers = node["soldiers"].as<int>(soldiers);
+		vehicles = node["vehicles"].as<int>(vehicles);
 	}
 
 	template<auto Stat, typename TBind>
@@ -134,6 +141,8 @@ struct RuleCraftStats
 		b.template addField<Stat, &RuleCraftStats::shieldRecharge>(prefix + "getShieldRecharge");
 		b.template addField<Stat, &RuleCraftStats::shieldRechargeInGeoscape>(prefix + "getShieldRechargeInGeoscape");
 		b.template addField<Stat, &RuleCraftStats::shieldBleedThrough>(prefix + "getShieldBleedThrough");
+		b.template addField<Stat, &RuleCraftStats::soldiers>(prefix + "getMaxUnits");
+		b.template addField<Stat, &RuleCraftStats::vehicles>(prefix + "getMaxVehiclesAndLargeSoldiers");
 	}
 };
 
@@ -168,9 +177,9 @@ private:
 	std::string _requiresBuyCountry;
 	int _sprite, _marker;
 	std::vector<int> _skinSprites;
-	int _weapons, _soldiers, _pilots, _vehicles;
+	int _weapons, _pilots;
 	int _maxSmallSoldiers, _maxLargeSoldiers, _maxSmallVehicles, _maxLargeVehicles;
-	int _maxSmallUnits, _maxLargeUnits, _maxSoldiers, _maxVehicles;
+	int _maxSmallUnits, _maxLargeUnits, _maxSoldiers, _maxVehicles, _maxUnitsLimit;
 	int _monthlyBuyLimit;
 	int _costBuy, _costRent, _costSell;
 	char _weaponTypes[WeaponMax][WeaponTypeMax];
@@ -205,6 +214,8 @@ public:
 	~RuleCraft();
 	/// Loads craft data from YAML.
 	void load(const YAML::Node& node, Mod *mod, const ModScript &parsers);
+	/// Cross link with other rules.
+	void afterLoad(const Mod* mod);
 	/// Gets the craft's type.
 	const std::string &getType() const;
 	/// Gets the craft's requirements.
@@ -250,6 +261,8 @@ public:
 	int getMaxSoldiers() const { return _maxSoldiers; }
 	/// Gets the craft's maximum supported number of vehicles (small + large).
 	int getMaxVehicles() const { return _maxVehicles; }
+	/// Gets the craft's unit capacity limit (soldiers and vehicles, small and large).
+	int getMaxUnitsLimit() const { return _maxUnitsLimit; }
 	/// Gets the craft's monthly buy limit.
 	int getMonthlyBuyLimit() const { return _monthlyBuyLimit; }
 	/// Gets the craft's cost.

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -1030,6 +1030,26 @@ int Craft::getFuelLimit(Base *base) const
 }
 
 /**
+ * Gets the maximum number of units (soldiers and vehicles, small and large) that
+ * the craft can carry.
+ * @return The maximum unit capacity.
+ */
+int Craft::getMaxUnits() const
+{
+	return _stats.soldiers;
+}
+
+/**
+ * Gets the maximum number of vehicles (and 2x2 soldiers) that
+ * the craft can carry.
+ * @return The maximum vehicle capacity (incl. 2x2 soldiers).
+ */
+int Craft::getMaxVehiclesAndLargeSoldiers() const
+{
+	return _stats.vehicles;
+}
+
+/**
  * Returns the maximum range the craft can travel
  * from its origin base on its current fuel.
  * @return Range in radians.
@@ -1425,7 +1445,7 @@ bool Craft::isDestroyed() const
  */
 int Craft::getSpaceAvailable() const
 {
-	return _rules->getMaxUnits() - getSpaceUsed();
+	return std::min(getMaxUnits(), _rules->getMaxUnitsLimit()) - getSpaceUsed();
 }
 
 /**
@@ -1869,10 +1889,10 @@ int Craft::getHunterKillerAttraction(int huntMode) const
 			// craft that can land (i.e. transports) are not attractive
 			attraction += 1000000;
 		}
-		if (_rules->getMaxUnits() > 0)
+		if (getMaxUnits() > 0)
 		{
 			// craft with more crew capacity (i.e. transports) are less attractive
-			attraction += 500000 + (_rules->getMaxUnits() * 1000);
+			attraction += 500000 + (getMaxUnits() * 1000);
 		}
 		// faster craft (i.e. interceptors) are more attractive
 		attraction += 100000 - _stats.speedMax;
@@ -1890,7 +1910,7 @@ int Craft::getHunterKillerAttraction(int huntMode) const
 			attraction += 1000000;
 		}
 		// craft with more crew capacity (i.e. transports) are more attractive
-		attraction += 500000 - (_rules->getMaxUnits() * 1000);
+		attraction += 500000 - (getMaxUnits() * 1000);
 		// faster craft (i.e. interceptors) are less attractive
 		attraction += 100000 + _stats.speedMax;
 	}
@@ -1957,7 +1977,7 @@ int Craft::getNumVehiclesAndLargeSoldiers() const
  */
 int Craft::getNumSmallSoldiers() const
 {
-	if (_rules->getMaxUnits() == 0)
+	if (getMaxUnits() == 0)
 		return 0;
 
 	int total = 0;
@@ -1977,7 +1997,7 @@ int Craft::getNumSmallSoldiers() const
  */
 int Craft::getNumLargeSoldiers() const
 {
-	if (_rules->getMaxUnits() == 0)
+	if (getMaxUnits() == 0)
 		return 0;
 
 	int total = 0;
@@ -1997,7 +2017,7 @@ int Craft::getNumLargeSoldiers() const
  */
 int Craft::getNumSmallVehicles() const
 {
-	if (_rules->getMaxUnits() == 0)
+	if (getMaxUnits() == 0)
 		return 0;
 
 	int total = 0;
@@ -2017,7 +2037,7 @@ int Craft::getNumSmallVehicles() const
  */
 int Craft::getNumLargeVehicles() const
 {
-	if (_rules->getMaxUnits() == 0)
+	if (getMaxUnits() == 0)
 		return 0;
 
 	int total = 0;
@@ -2105,7 +2125,7 @@ bool Craft::validateArmorChange(int sizeFrom, int sizeTo) const
 			{
 				return false;
 			}
-			if (_rules->getMaxVehiclesAndLargeSoldiers() > -1 && getNumVehiclesAndLargeSoldiers() >= _rules->getMaxVehiclesAndLargeSoldiers())
+			if (getMaxVehiclesAndLargeSoldiers() > -1 && getNumVehiclesAndLargeSoldiers() >= getMaxVehiclesAndLargeSoldiers())
 			{
 				return false;
 			}
@@ -2160,7 +2180,7 @@ bool Craft::validateAddingSoldier(int space, const Soldier* s) const
 	}
 	else // armorSize > 1
 	{
-		if (_rules->getMaxVehiclesAndLargeSoldiers() > -1 && getNumVehiclesAndLargeSoldiers() >= _rules->getMaxVehiclesAndLargeSoldiers())
+		if (getMaxVehiclesAndLargeSoldiers() > -1 && getNumVehiclesAndLargeSoldiers() >= getMaxVehiclesAndLargeSoldiers())
 		{
 			return false;
 		}
@@ -2184,9 +2204,9 @@ int Craft::validateAddingVehicles(int totalSize) const
 {
 	int maximumAllowed = getSpaceAvailable() / totalSize;
 
-	if (_rules->getMaxVehiclesAndLargeSoldiers() > -1)
+	if (getMaxVehiclesAndLargeSoldiers() > -1)
 	{
-		maximumAllowed = std::min(maximumAllowed, _rules->getMaxVehiclesAndLargeSoldiers() - getNumVehiclesAndLargeSoldiers());
+		maximumAllowed = std::min(maximumAllowed, getMaxVehiclesAndLargeSoldiers() - getNumVehiclesAndLargeSoldiers());
 	}
 	if (_rules->getMaxVehicles() > -1)
 	{

--- a/src/Savegame/Craft.h
+++ b/src/Savegame/Craft.h
@@ -214,7 +214,12 @@ public:
 	/// Gets the craft's minimum fuel limit.
 	int getFuelLimit() const;
 	/// Gets the craft's minimum fuel limit to go to a base.
-	int getFuelLimit(Base *base) const;
+	int getFuelLimit(Base* base) const;
+
+	/// Gets the craft's maximum unit capacity (soldiers and vehicles, small and large).
+	int getMaxUnits() const;
+	/// Gets the craft's maximum vehicle capacity (incl. 2x2 soldiers).
+	int getMaxVehiclesAndLargeSoldiers() const;
 
 	double getBaseRange() const;
 	/// Returns the craft to its base.

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -3200,6 +3200,7 @@ void StatsForNerdsState::initCraftList()
 	addInteger(ss, craftRule->getTransferTime(), "transferTime", 24);
 
 	addInteger(ss, craftRule->getMaxUnits(), "soldiers");
+	addInteger(ss, craftRule->getMaxUnitsLimit(), "maxUnitsLimit");
 	addInteger(ss, craftRule->getPilots(), "pilots");
 	addInteger(ss, craftRule->getMaxVehiclesAndLargeSoldiers(), "vehicles");
 
@@ -3724,6 +3725,8 @@ void StatsForNerdsState::initCraftWeaponList()
 		addInteger(ss, craftWeaponRule->getBonusStats().shieldRecharge, "shieldRecharge");
 		addInteger(ss, craftWeaponRule->getBonusStats().shieldRechargeInGeoscape, "shieldRechargeInGeoscape");
 		addInteger(ss, craftWeaponRule->getBonusStats().shieldBleedThrough, "shieldBleedThrough");
+		addInteger(ss, craftWeaponRule->getBonusStats().soldiers, "soldiers");
+		addInteger(ss, craftWeaponRule->getBonusStats().vehicles, "vehicles");
 		endHeading();
 	}
 


### PR DESCRIPTION
**Changes Information**
No `crafts` rule node/structure changes. Values `soldiers` and `vehicles` stay in their own places for `crafts`.

For `craftWeapons` it is now possible to add `soldiers` and `vehicles` under `stats` (such as subsystem that increases crew capacity of the craft).

Additional value `maxUnitsLimit` for `crafts` allows to set upper limit on how much craft's carry capacity can be expanded. If no mod or submod sets it, `maxUnitsLimit` will be set automatically to same amount as `soldiers`. Modder should take care to ensure that `maxUnitsLimit` doesn't exceed amount of spawn positions in their crafts.

**Localization Information**
There are additional localization entries that need to be added. Examples below:
`maxUnitsLimit: "Max cargo space"`
`STR_NO_CARGO_SPACE_FOR_REFIT: "CRAFT CAN'T CHANGE UNIT CAPACITY!{SMALLLINE}After refitting craft with selected weapon, system or utility, its unit capacity will change beyond currently available space. If your craft has crew assigned to it, please remove them to free occupied space."`