### PR TITLE
Feature: 'spriteEnabled' flag to allow bigger facilities behaviour of drawing sprite over shape.

### DIFF
--- a/src/Basescape/BaseView.cpp
+++ b/src/Basescape/BaseView.cpp
@@ -539,7 +539,7 @@ void BaseView::draw()
 		{
 			for (int x = fac->getX(); x < fac->getX() + fac->getRules()->getSize(); ++x)
 			{
-				if (fac->getRules()->getSize() == 1)
+				if (fac->getRules()->getSpriteEnabled())
 				{
 					Surface *frame = _texture->getFrame(fac->getRules()->getSpriteFacility() + num);
 					int fx = (x * GRID_SIZE);

--- a/src/Mod/RuleBaseFacility.cpp
+++ b/src/Mod/RuleBaseFacility.cpp
@@ -41,6 +41,7 @@ RuleBaseFacility::RuleBaseFacility(const std::string &type, int listOrder) :
 	_lift(false), _hyper(false), _mind(false), _grav(false), _mindPower(1),
 	_size(1), _buildCost(0), _refundValue(0), _buildTime(0), _monthlyCost(0),
 	_storage(0), _personnel(0), _aliens(0), _crafts(0), _labs(0), _workshops(0), _psiLabs(0),
+	_spriteEnabled(false),
 	_sightRange(0), _sightChance(0), _radarRange(0), _radarChance(0),
 	_defense(0), _hitRatio(0), _fireSound(0), _hitSound(0), _placeSound(-1), _ammoNeeded(1), _listOrder(listOrder),
 	_trainingRooms(0), _maxAllowedPerBase(0), _sickBayAbsoluteBonus(0.0f), _sickBayRelativeBonus(0.0f),
@@ -97,6 +98,9 @@ void RuleBaseFacility::load(const YAML::Node &node, Mod *mod)
 	_labs = node["labs"].as<int>(_labs);
 	_workshops = node["workshops"].as<int>(_workshops);
 	_psiLabs = node["psiLabs"].as<int>(_psiLabs);
+
+	_spriteEnabled = node["spriteEnabled"].as<bool>(_spriteEnabled);
+
 	_sightRange = node["sightRange"].as<int>(_sightRange);
 	_sightChance = node["sightChance"].as<int>(_sightChance);
 	_radarRange = node["radarRange"].as<int>(_radarRange);
@@ -293,6 +297,15 @@ int RuleBaseFacility::getSpriteFacility() const
 int RuleBaseFacility::getSize() const
 {
 	return _size;
+}
+
+/**
+ * Is sprite over shape behavior retained for bigger facility?
+ * @return True if retained.
+ */
+bool RuleBaseFacility::getSpriteEnabled() const
+{
+	return getSize() == 1 || _spriteEnabled;
 }
 
 /**

--- a/src/Mod/RuleBaseFacility.h
+++ b/src/Mod/RuleBaseFacility.h
@@ -57,6 +57,7 @@ private:
 	int _size, _buildCost, _refundValue, _buildTime, _monthlyCost;
 	std::map<std::string, std::pair<int, int> > _buildCostItems;
 	int _storage, _personnel, _aliens, _crafts, _labs, _workshops, _psiLabs;
+	bool _spriteEnabled;
 	int _sightRange, _sightChance;
 	int _radarRange, _radarChance, _defense, _hitRatio, _fireSound, _hitSound, _placeSound;
 	int _ammoNeeded;
@@ -106,6 +107,8 @@ public:
 	int getSpriteShape() const;
 	/// Gets the facility's content sprite.
 	int getSpriteFacility() const;
+	/// Retain sprite over shape behavior for bigger facility?
+	bool getSpriteEnabled() const;
 	/// Should there be connectors leading to this facility?
 	bool connectorsDisabled() const { return _connectorsDisabled; }
 	/// Gets the facility's size.


### PR DESCRIPTION
Added `spriteEnabled` flag (`false` by default) for `facilities:` entries. Allows to utilize both, sprite and shape for bigger facilities as it happens for 1x1 facilities by default.

Example:
```yaml
facilities:
  - type: STR_BIG_FACILITY
    spriteShape: 1011
    spriteFacility: 1819
    spriteEnabled: true # new code
```