### PR TITLE
Fix: Missed Ufopaedia getSpriteEnabled() Added.

### DIFF
--- a/src/Ufopaedia/ArticleStateBaseFacility.cpp
+++ b/src/Ufopaedia/ArticleStateBaseFacility.cpp
@@ -92,7 +92,7 @@ namespace OpenXcom
 				frame = graphic->getFrame(facility->getSpriteShape() + num);
 				frame->blitNShade(_image, x_pos, y_pos);
 
-				if (facility->getSize()==1)
+				if (facility->getSpriteEnabled())
 				{
 					frame = graphic->getFrame(facility->getSpriteFacility() + num);
 					frame->blitNShade(_image, x_pos, y_pos);


### PR DESCRIPTION
Missed Ufopaedia page `getSpriteEnabled()` added.