### PR TITLE
Add unity build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -426,52 +426,74 @@ set ( c_src
 set_property ( SOURCE ${c_src} APPEND PROPERTY COMPILE_DEFINITIONS MINIZ_NO_STDIO )
 set_property ( SOURCE Engine/Scalers/xbrz.cpp APPEND_STRING PROPERTY COMPILE_FLAGS -Wno-unused\ )
 
+# These file groups do not work with UNITY_BUILD
+set ( skip_unity_src
+    ${mod_src}
+
+    ${sdl_src}
+
+    Engine/Adlib/adlplayer.cpp
+    Engine/Adlib/fmopl.cpp
+    Engine/AdlibMusic.cpp
+
+    Savegame/BattleItem.cpp
+    Savegame/BattleUnit.cpp
+
+    Savegame/SavedGame.cpp
+    Savegame/SavedBattleGame.cpp)
+set_property ( SOURCE ${skip_unity_src} PROPERTY SKIP_UNITY_BUILD_INCLUSION true)
+
 set ( data_install_dir bin )
 if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
   set_property ( SOURCE Engine/Options.cpp APPEND PROPERTY COMPILE_DEFINITIONS _DEBUG )
   set_property ( SOURCE OpenXcom.rc APPEND PROPERTY COMPILE_DEFINITIONS _DEBUG )
 endif ()
+
 if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
   # attempt to limit the executable size
-  set_property ( SOURCE ${cxx_src} APPEND_STRING PROPERTY COMPILE_FLAGS -femit-struct-debug-reduced\ )
+  add_compile_options( $<$<COMPILE_LANGUAGE:CXX>:-femit-struct-debug-reduced>)
 endif ()
+
 if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
   # C++ - only warnings
   # C and C++ warnings
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wall\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wextra\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Winit-self\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wmissing-include-dirs\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wunknown-pragmas\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wmissing-format-attribute\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wredundant-decls\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wformat-security\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wtype-limits\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wempty-body\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wuninitialized\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wignored-qualifiers\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wno-unused-parameter\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wno-inline\ )
+  add_compile_options ( -Wall )
+  add_compile_options ( -Wextra )
+  add_compile_options ( -Winit-self )
+  add_compile_options ( -Wmissing-include-dirs )
+  add_compile_options ( -Wunknown-pragmas )
+  add_compile_options ( -Wmissing-format-attribute )
+  add_compile_options ( -Wredundant-decls )
+  add_compile_options ( -Wformat-security )
+  add_compile_options ( -Wtype-limits )
+  add_compile_options ( -Wempty-body )
+  add_compile_options ( -Wuninitialized )
+  add_compile_options ( -Wignored-qualifiers )
+  add_compile_options ( -Wno-unused-parameter )
+  add_compile_options ( -Wno-inline )
+
   if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
+
     # apple clang 11.0 goes crazy with -Wshadow on the yaml-cpp source code
-    set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wshadow\ )
+    add_compile_options ( -Wshadow )
+
     # add warning flags recognized by g++ but not by clang
-    set_property ( SOURCE ${cxx_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wsuggest-override\ )
-    set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wclobbered\ )
-    set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Wlogical-op\ )
+    add_compile_options( $<$<COMPILE_LANGUAGE:CXX>:-Wsuggest-override> )
+    add_compile_options ( -Wclobbered )
+    add_compile_options ( -Wlogical-op )
   elseif ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     # add warning flags recognized by clang but not by g++
   endif ()
   if ( FATAL_WARNING )
-    set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Werror\ )
+    add_compile_options ( -Werror )
   endif ()
 endif ()
 
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -Qunused-arguments\ )
-  set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS -pipe\ )
+  add_compile_options ( -Qunused-arguments )
+  add_compile_options ( -pipe )
   if ( ENABLE_CLANG_ANALYSIS )
-    set_property ( SOURCE ${cxx_src} ${c_src} APPEND_STRING PROPERTY COMPILE_FLAGS --analyze\ )
+    add_compile_options ( --analyze )
   endif ()
 endif ()
 


### PR DESCRIPTION
### TLDR
Apply my changes and run this:

      mkdir build.d; cd build.d
      cmake .. -G Ninja -DCMAKE_UNITY_BUILD=true -DCMAKE_BUILD_TYPE=Release -DDEV_BUILD=ON -DBUILD_PACKAGE=OFF
      time /usr/bin/time -v ninja

and OpenXcom will compile 2 times faster!

## What is unity build

Usually C++ project consists of nice and small .cpp files that uses big and template heavy C++ standard library.
Compilling such project is inefficient because you need to reprocess lots of header files each time.
Unity build tries to reduce the time wasted on recompiling headers.

CMake prepares a unity_N.cxx files that looks like

    #include "/path/to/ArrowButton.cpp"
    #include "/path/to/Bar.cpp"
    #include "/path/to/BattlescapeButton.cpp"
    ...

And compiles these files instead.

The docs for cmake unity build are here https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html

There are independent implementations of this technique in CMake, [meson](https://mesonbuild.com/Unity-builds.html), [Visual Studio](https://devblogs.microsoft.com/cppblog/support-for-unity-jumbo-files-in-visual-studio-2017-15-8-experimental/) and other build systems. This PR is for CMake.

## The good parts
Not only it may reduce compile time. It allows to do more optimisations and may speed up linking.

On my system the compilation time reduced from 3 minutes to 1m30s.

I hope android developers will be happy if it gets ported...

## Drawbacks
The unity build can cause compillation errors and even runtime issues!

The source code should be "good enough" to allow unity builds.
The same names in different .cpp files (even in anonymous namespaces or static), abuse of #defines/#includes and other unusual practices are incompatible.

Many of 3rd party libraries are incompatible.

The unity build may interfere with ccache and precompiled headers. But building from scratch thould still be faster.

It also may limit the effect of using multiple CPU cores and increase memory requirements.
By default the unity build group files by 8 (and it works really well for OpenXcom, 16 is also good, other values are not so effective).

It works with cmake >=3.18 (older versions just ignore this settings).

So if you want to use it on Android... It is not trivial. ~~I do not understand gradle and I tried to compile for Android... There is a separate CMakeLists.txt. It builds with gradle 4.10 and cmake 3.6. I get errors when I try to replace cmake (meters of stack traces, something about parsing versions or just NullPointerException). Also upgrades require killing gradle server and removing .gradle directory. And gradle scripts need some changes when upgrading the gradle version. The execute() method is removed (https://docs.gradle.org/current/userguide/upgrading_version_4.html) and I do not know how to replace it. I guess it better to move the code for zips to cmake.~~
I see there is a pull request with updates but have not checked it https://github.com/MeridianOXC/openxcom-android/pull/3

~~I have not checked how it works with MSVC or Apple.~~
I checked mxe build on Ubuntu 22.04, it is ok, unity build works as expected.

On Windows everything seems to be ok if unity build is turned off.

<details><summary>I tried to build openxcom with fresh Visual Studio and it is... not trivial...</summary>

 - I can compile vs2010 solution (using this steps from https://openxcom.org/forum/index.php?topic=7048.0).
   I'm not sure how my changes in CMakeLists.txt are propagated to VS project.

 - My version of CMake does not generate vs2010 projects. I tried vs2022.
 - I got a project with no /MP option (same as -j in make). Need to turn it on manually.
 - Not all build tools for Windows 10 understand C++ that used in OpenXcom. I need to manually change build tool version in project properties.
 - I need to remove this line because MS C++ compiler do not understand this flag:

set_property ( SOURCE Engine/Scalers/xbrz.cpp APPEND_STRING PROPERTY COMPILE_FLAGS -Wno-unused\ )

 - The build failed with some linking errors.
 - Unity build seems to be working... partially... I get compilation errors that I do not understand
 - Visual Studio has its own "Unity (JUMBO) build". You can turn it on in project properties. It does not respect SKIP_UNITY_BUILD_INCLUSION so it fails when it sees conflicting symbols.
</details>

I asked for help on oxce forums (https://openxcom.org/forum/index.php?topic=11916.0)

## How to convert a project to unity build
Run cmake with `-DCMAKE_UNITY_BUILD=true`

Source files should have empty COMPILE_FLAGS property, see https://devdocs.io/cmake~3.26/prop_tgt/unity_build

Incompatible files may be excluded by setting SKIP_UNITY_BUILD_INCLUSION property to true.

To make source files compatible the conflicting symbols should be renamed or be placed in unique namespaces.

## My changes
I need to remove COMPILE_FLAGS property so I replaced `set_property` with `add_compile_options`.

I compared new and old ninja.build files. The difference are in whitespace and in compiler flag  -Wno-unused (flag order changed for xbrz.cpp).

So I go on and enabled the unity build. I excluded libraries and some game files.

I have not changed any .cpp files yet.

The CMake docs recommends to leave unity build off by default and allow the user to decide so it is off by default.

## I'm not sure about...
It is unclear why there is `set_property` instead of `add_compile_options`. It was introduced in https://github.com/MeridianOXC/OpenXcom/commit/a9b467056e090b108de29d4608ef3034155fbc6b#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R414 is it required on MacOS?

~~I have not compiled the code on Windows or on Apple.~~
Windows build unaffected but not will not benefits of unity build.

Apple build unchecked.

## Why am I doing this

To be honest I want to push the unity build to much bigger project. I do not know CMake well.
So I want to try first with something smaller and simpler.


<!--

Guidelines for pull requests:

* Use a separate branch (instead of "oxce-plus"). This will save you a lot of headaches: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
* Only one feature/fix per pull request (unless they're connected).
* Try to follow our coding conventions: https://www.ufopaedia.org/index.php/Coding_Style_(OpenXcom)
* Explain in detail what your pull request is changing and why we want it.

We're very conservative about adding new features to OpenXcom. The bigger the change, the more it's gonna cost us in complexity and maintenance. Gameplay-critical code is very sensitive to changes and prone to bugs. Once it's merged it's our responsibility. So it's not enough that "it works", it needs to justify its cost. Is it a highly-demanded must-have feature? Has it been thoroughly tested? Will we regret merging it? Etc.

GitHub isn't a good discussion board, only developers look at this, so it's better to post in the forums first to gauge interest before doing any major changes: https://openxcom.org/forum/

-->