### PR TITLE
Speed up game saving

### DIFF
--- a/src/Savegame/BattleUnitStatistics.h
+++ b/src/Savegame/BattleUnitStatistics.h
@@ -94,13 +94,13 @@ struct BattleUnitKills
 		node["race"] = race;
 		node["weapon"] = weapon;
 		node["weaponAmmo"] = weaponAmmo;
-		node["status"] = (int)status;
-		node["faction"] = (int)faction;
-		node["mission"] = mission;
-		node["turn"] = turn;
-		node["side"] = (int)side;
-		node["bodypart"] = (int)bodypart;
-		node["id"] = id;
+		node["status"] = std::to_string((int)status);
+		node["faction"] = std::to_string((int)faction);
+		node["mission"] = std::to_string(mission);
+		node["turn"] = std::to_string(turn);
+		node["side"] = std::to_string((int)side);
+		node["bodypart"] = std::to_string((int)bodypart);
+		node["id"] = std::to_string(id);
 		return node;
 	}
 


### PR DESCRIPTION
For some reason, converting to string manually is quite a bit faster than letting YAML lib do it itself internally.

![perfbefore](https://github.com/user-attachments/assets/f4889521-7dbf-457d-ac3a-3f6f65eb86ef)
![perfafter](https://github.com/user-attachments/assets/f876461b-46de-4846-88dd-ba71b08d18b2)
