### PR TITLE
Bug in Engine/FileMap.cpp > SDL_LoadFile_RW()

### DIFF
--- a/src/Engine/FileMap.cpp
+++ b/src/Engine/FileMap.cpp
@@ -102,9 +102,11 @@ void *SDL_LoadFile_RW(SDL_RWops *src, size_t *datasize, int freesrc)
 		return NULL;
 	}
 
+	bool wholeFile = true;
 	size = SDL_RWsize(src);
 	if (size < 0) {
 		size = FILE_CHUNK_SIZE;
+		wholeFile = false;
 	}
 	data = SDL_malloc((size_t)(size + 1));
 
@@ -119,17 +121,19 @@ void *SDL_LoadFile_RW(SDL_RWops *src, size_t *datasize, int freesrc)
 				SDL_OutOfMemory();
 				goto done;
 			}
-		data = newdata;
-	}
-
-	size_read = SDL_RWread(src, (char *)data+size_total, 1, (size_t)(size-size_total));
-	if (size_read == 0) {
+			data = newdata;
+		}
+		size_read = SDL_RWread(src, (char*)data + size_total, 1, (size_t)(size - size_total));
+		if (size_read == 0) {
 			break;
 		}
-			if (size_read == -1) {
-				break;
-			}
+		if (size_read == -1) {
+			break;
+		}
 		size_total += size_read;
+		if (wholeFile) {
+			break;
+		}
 	}
 
 	if (datasize) {


### PR DESCRIPTION
There's a bug which makes loading files potentially 2x slower.

After reading the whole file into the buffer, the loop erroneously repeats, where the whole buffer is resized and reallocated.

![Screenshot 2024-11-23 222114](https://github.com/user-attachments/assets/bf2a2e38-a79f-470d-9aa8-25eaa11332eb)
