### PR TITLE
add: uniform shooting spread option

### DIFF
--- a/bin/common/Language/en-US.yml
+++ b/bin/common/Language/en-US.yml
@@ -107,6 +107,8 @@ en-US:
   STR_BATTLEINSTANTGRENADE_DESC: "Grenades primed to go off in 0 turns will explode immediately when thrown, instead of at the end of the turn."
   STR_BATTLEUFOEXTENDERACCURACY: "UFO Extender accuracy"
   STR_BATTLEUFOEXTENDERACCURACY_DESC: "Accuracy of shots drops off after a certain distance, according to shot type. Adjusted accuracy will be displayed on the cursor."
+  STR_UNIFORM_SHOOTING_SPREAD: "Uniform shooting spread"
+  STR_UNIFORM_SHOOTING_SPREAD_DESC: "Spread is uniform in all directions and more tight. Overall chances to hit are the same."
   STR_CANTRANSFERCRAFTSWHILEAIRBORNE: "Airborne transfers"
   STR_CANTRANSFERCRAFTSWHILEAIRBORNE_DESC: "Craft currently in-flight can be transferred."
   STR_CRAFTLAUNCHALWAYS: "Force craft launch"

--- a/src/Battlescape/Projectile.cpp
+++ b/src/Battlescape/Projectile.cpp
@@ -371,10 +371,22 @@ void Projectile::applyAccuracy(Position origin, Position *target, double accurac
 	int zDist = abs(origin.z - target->z);
 	int xyShift, zShift;
 
-	if (xDist / 2 <= yDist)				//yes, we need to add some x/y non-uniformity
-		xyShift = xDist / 4 + yDist;	//and don't ask why, please. it's The Commandment
+	if (Options::oxceUniformShootingSpread) // Uniform shooting spread
+	{
+		if (xDist <= yDist)
+			xyShift = xDist / 4 + yDist;
+		else
+			xyShift = xDist + yDist / 4;
+
+		xyShift *= 0.839; // Constant to match average xyShift to vanilla
+	}
 	else
-		xyShift = (xDist + yDist) / 2;	//that's uniform part of spreading
+	{
+		if (xDist / 2 <= yDist)				//yes, we need to add some x/y non-uniformity
+			xyShift = xDist / 4 + yDist;	//and don't ask why, please. it's The Commandment
+		else
+			xyShift = (xDist + yDist) / 2;	//that's uniform part of spreading
+	}
 
 	if (xyShift <= zDist)				//slight z deviation
 		zShift = xyShift / 2 + zDist;
@@ -417,8 +429,53 @@ void Projectile::applyAccuracy(Position origin, Position *target, double accurac
 
 	deviation = std::max(1, zShift * deviation / 200);	//range ratio
 
-	target->x += RNG::generate(0, deviation) - deviation / 2;
-	target->y += RNG::generate(0, deviation) - deviation / 2;
+	if (Options::oxceUniformShootingSpread)
+	{
+		// First, new target point is rolled as usual. Then, if it lies outside of outer circle (in square's corner)
+		// it's rerolled inside inner circle
+
+		const double OVERALL_SPREAD_COEFF = 1.0; // Overall spread diameter change compared to vanilla
+		const double INNER_SPREAD_COEFF = 0.85; // Inner spread circle diameter compared to outer
+
+		double targetDist2D = sqrt(xDist * xDist + yDist * yDist);
+		bool resultShifted = false;
+		int dX, dY;
+
+		for (int i = 0; i < 10; ++i) // Break from this cycle when proper target is found
+		{
+			dX = RNG::generate(0, deviation) - deviation / 2;
+			dY = RNG::generate(0, deviation) - deviation / 2;
+
+			double exprX = target->x + dX - origin.x;
+			double exprY = target->y + dY - origin.y;
+			double deviateDist2D = sqrt(exprX * exprX + exprY * exprY); // Distance from origin to deviation point
+
+			if (resultShifted &&                  // point is on inner ring and should be a "miss"
+				deviateDist2D > targetDist2D-2 &&
+				deviateDist2D < targetDist2D+2)
+				break;
+
+			if (!resultShifted) // This is the FIRST roll!
+			{
+				int radiusSq = dX*dX + dY*dY;
+				int deviateRadius = OVERALL_SPREAD_COEFF * deviation / 2;
+				int deviateRadiusSq = deviateRadius * deviateRadius;
+				if (radiusSq <= deviateRadiusSq) break;  // If we inside of outer circle - we're done!
+
+				resultShifted = true;
+				deviation *= INNER_SPREAD_COEFF; // Next attempts will be closer to target
+			}
+		}
+		target->x += dX;
+		target->y += dY;
+	}
+
+	else // Classic shooting spread
+	{
+		target->x += RNG::generate(0, deviation) - deviation / 2;
+		target->y += RNG::generate(0, deviation) - deviation / 2;
+	}
+
 	target->z += RNG::generate(0, deviation / 2) / 2 - deviation / 8;
 
 	if (extendLine)

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -478,6 +478,7 @@ void createAdvancedOptionsOXCE()
 	_info.push_back(OptionInfo(OPTION_OXCE, "oxceAutoSell", &oxceAutoSell, false, "STR_AUTO_SELL", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo(OPTION_OXCE, "oxceAutomaticPromotions", &oxceAutomaticPromotions, true, "STR_AUTOMATICPROMOTIONS", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo(OPTION_OXCE, "oxceEnableOffCentreShooting", &oxceEnableOffCentreShooting, false, "STR_OFF_CENTRE_SHOOTING", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo(OPTION_OXCE, "oxceUniformShootingSpread", &oxceUniformShootingSpread, false, "STR_UNIFORM_SHOOTING_SPREAD", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo(OPTION_OXCE, "oxceCrashedOrLanded", &oxceCrashedOrLanded, 0, "STR_CRASHED_OR_LANDED", "STR_BATTLESCAPE"));
 }
 

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -104,6 +104,7 @@ OPT int oxceShowAccuracyOnCrosshair;
 OPT bool oxceAutoSell;
 OPT bool oxceAutomaticPromotions;
 OPT bool oxceEnableOffCentreShooting;
+OPT bool oxceUniformShootingSpread;
 OPT int oxceCrashedOrLanded;
 
 // OXCE hidden, accessible only via options.cfg


### PR DESCRIPTION
In a nutshell:

1)
in OG / OXC(E) xyShift for shooting spread is calculated as follows:
~70%: dX / 4 + dY
~30%: (dX + dY) / 2

This leads to different spread along X and Y axes (could be seen on video)

In this PR, I always calculate xyShift like 70% variant from vanilla, but from dX or dY (whichever value is greater). Resulting xyShift is greater in average than vanilla, and I multiply it by number found from simulation, to get average xyShift exactly the same as vanilla one. As a result, vertical shots become more precise, horizontal ones - less precise, but overall chance to hit is simiar to vanilla.

2)
in OG / OXCE shooting spread cloud has square form, with sides always parallel to X/Y axes of a map. This leads to non-uniformity of spread angle. For 45-degree-shots linear width of dispersion at target point is equal to square's diagonal, for horizontal/vertical shots it's equal to square's side (but it's closer to shooter by 1/2 of its length)

In this PR I make spread cloud round, moving "square corners" of dispersion cloud closer to a target, to get more natural dispersion. It could increase chance to hit at point-blank range, but still not that hard as xyShift = (dX + dY)/2 in vanilla.

Video comparison is here:
https://www.youtube.com/watch?v=MeITe9SzlGY

Charts and simulations are here:
https://imgur.com/a/g9VLJXA

Video to demonstrate if all shooting dispersion was calculated as xyShift = (dX + dY) / 2
(For reference! This is not in this PR)
https://www.youtube.com/watch?v=8jtLOBpZY-4
