### PR TITLE
Added the ability to filter sell item by autosold ones if the option is active

### DIFF
--- a/bin/common/Language/OXCE/en-GB.yml
+++ b/bin/common/Language/OXCE/en-GB.yml
@@ -118,6 +118,7 @@ en-GB:
   STR_FILTER_DEFAULT_NO_SUPPLIES: "Default (no supplies)"
   STR_FILTER_FACILITY_REQUIRED: "Facility Missing"
   STR_FILTER_HIDDEN: "Hidden"
+  STR_FILTER_AUTOSELL: "Autosold"
   STR_FILTER_EQUIPPED: "Equipped"
   STR_FILTER_MISSING: "Missing"
 #NewResearchListState.cpp

--- a/bin/common/Language/OXCE/en-US.yml
+++ b/bin/common/Language/OXCE/en-US.yml
@@ -118,6 +118,7 @@ en-US:
   STR_FILTER_DEFAULT_NO_SUPPLIES: "Default (no supplies)"
   STR_FILTER_FACILITY_REQUIRED: "Facility Missing"
   STR_FILTER_HIDDEN: "Hidden"
+  STR_FILTER_AUTOSELL: "Autosold"
   STR_FILTER_EQUIPPED: "Equipped"
   STR_FILTER_MISSING: "Missing"
 #NewResearchListState.cpp

--- a/src/Basescape/SellState.h
+++ b/src/Basescape/SellState.h
@@ -78,6 +78,7 @@ private:
 public:
 	/// Creates the Sell state.
 	SellState(Base *base, DebriefingState *debriefingState, OptionsOrigin origin = OPT_GEOSCAPE);
+	void initCategories();
 	void delayedInit();
 	/// Cleans up the Sell state.
 	~SellState();

--- a/src/Savegame/SavedGame.cpp
+++ b/src/Savegame/SavedGame.cpp
@@ -3056,6 +3056,14 @@ std::vector<Soldier*>::iterator SavedGame::killSoldier(bool resetArmor, Soldier 
 }
 
 /**
+*	rturns whether there are any autosell items added
+*/
+
+bool SavedGame::hasAutosellItems() const {
+	return !_autosales.empty();
+}
+
+/**
  * enables/disables autosell for an item type
  */
 void SavedGame::setAutosell(const RuleItem *itype, const bool enabled)

--- a/src/Savegame/SavedGame.h
+++ b/src/Savegame/SavedGame.h
@@ -491,6 +491,8 @@ public:
 	bool isUfoOnIgnoreList(int ufoId);
 	/// Handles a soldier's death.
 	std::vector<Soldier*>::iterator killSoldier(bool resetArmor, Soldier *soldier, BattleUnitKills *cause = 0);
+	/// has any item set to autosell?
+	bool hasAutosellItems() const;
 	/// enables/disables autosell for an item type
 	void setAutosell(const RuleItem *itype, const bool enabled);
 	/// get autosell state for an item type


### PR DESCRIPTION
I added the ability to filter the sell screen by 'junk' aka auto sold on mission debriefing items.
This is usefull to help discard unwanted items in mods with random production and/or random items from events. 

I made the choice to *not* auto-sell them in this screen as sometimes some items are usefull but you don't want more of them. ( for instance 5 guns can be usefull but you don't need more).
I think this could be added easily on the purchase screen too but I don't see the point.

On the technical side it seems that SellState::delayedInit() does for some mods some useless and redondant work  ( _cats is filled before being emptied and refilled). As I don't know the code base enough and performance isn't an issue here I didn't fix this but  just factorised common code in a helper function.

quickly tested on vanilla and x-piratez
